### PR TITLE
Bug 582881 - CIEC_STRING should not use ostream

### DIFF
--- a/src/core/datatypes/forte_string.h
+++ b/src/core/datatypes/forte_string.h
@@ -65,11 +65,6 @@ class CIEC_STRING : public CIEC_ANY_STRING {
     return paLeft.getStorage() <= paRight.getStorage();
   }
 
-  friend std::ostream &operator<<(std::ostream &out, const CIEC_STRING &variable) {
-    out << variable.getStorage();
-    return out;
-  }
-
   // CIEC_STRING to std::string and vice versa comparison operators
   friend bool operator==(const std::string &paLeft, const CIEC_STRING &paRight) {
     return paLeft == paRight.getStorage();

--- a/tests/forte_boost_output_support.h
+++ b/tests/forte_boost_output_support.h
@@ -21,6 +21,7 @@
 #include "forte_char.h"
 #include "forte_wchar.h"
 #include "forte_string.h"
+#include "forte_string_fixed.h"
 #include "forte_wstring.h"
 #include "forte_time.h"
 #include "forte_time_of_day.h"
@@ -115,6 +116,13 @@ std::ostream& boost_test_print_type(std::ostream &out, const CIEC_WCHAR &variabl
 
 inline
 std::ostream& boost_test_print_type(std::ostream &out, const CIEC_STRING &variable) {
+  out << variable.getStorage();
+  return out;
+}
+
+template<size_t maxLength>
+inline
+std::ostream& boost_test_print_type(std::ostream &out, const CIEC_STRING_FIXED<maxLength> &variable) {
   out << variable.getStorage();
   return out;
 }


### PR DESCRIPTION
Moved ostream to the tests where it should reside and where it is needed.

