### PR TITLE
Introduced onAliveChanged to CThreadBase

### DIFF
--- a/src/arch/threadbase.h
+++ b/src/arch/threadbase.h
@@ -90,7 +90,11 @@ namespace forte {
         /*! \brief set the alive flag for this flag
          */
         void setAlive(bool paVal) {
+          bool oldAlive = mAlive;
           mAlive = paVal;
+          if(oldAlive != mAlive){
+            onAliveChanged(mAlive);
+          }
         }
 
         /*! \brief Helper method to run the thread.
@@ -128,6 +132,15 @@ namespace forte {
          * @return handle to the newly created thread
          */
         virtual TThreadHandleType createThread(long paStackSize) = 0;
+
+
+        /*! \brief Call back allowing children to perform child specific actions on alive state changes
+         *
+         * @param paNewValue the new value of the alive flag
+         */
+        virtual void onAliveChanged(bool paNewValue) {
+          (void)paNewValue;  // inhibit compiler warning
+        }
 
         //! Semaphore for implementing a generic join functionality. For a stable functionality this mutex must be locked during thread creation.
         CSemaphore mJoinSem;

--- a/src/core/ecet.cpp
+++ b/src/core/ecet.cpp
@@ -34,6 +34,12 @@ void CEventChainExecutionThread::run(){
   }
 }
 
+void CEventChainExecutionThread::onAliveChanged(bool paNewValue) {
+  if(!paNewValue){
+    resumeSelfSuspend();
+  }
+}
+
 void CEventChainExecutionThread::mainRun(){
   if(externalEventOccured()){
     transferExternalEvents();
@@ -93,7 +99,6 @@ void CEventChainExecutionThread::changeExecutionState(EMGMCommandType paCommand)
       [[fallthrough]];
     case EMGMCommandType::Stop:
       setAlive(false); //end thread in both cases
-      resumeSelfSuspend();
       break;
     default:
       break;

--- a/src/core/ecet.h
+++ b/src/core/ecet.h
@@ -85,6 +85,8 @@ class CEventChainExecutionThread : public CThread{
      */
     void run() override;
 
+    void onAliveChanged(bool paNewValue) override;
+
     /*! \brief Clear the event chain.
      */
     void clear();


### PR DESCRIPTION
This method can be used by children of CThreadBase to perform any child specific actions when the alive state of this thread changes (e.g., release a mutex or semaphore).