### PR TITLE
Remove gcc11 dependency

### DIFF
--- a/buildsupport/check_compiler_features.cmake
+++ b/buildsupport/check_compiler_features.cmake
@@ -24,13 +24,6 @@ function(TEST_NEEDED_FORTE_COMPILER_FEATURES)
     message(WARNING "`nullptr` not supported, replacing it with 0 via precprocessor")
     forte_add_definition("-Dnullptr=0")
   endif()
-
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
-          CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.3)
-    # gcc < 11.3 has a bug in the handling of std::variant and std::visit,
-    # incompatible with the current implementation of forte
-    message(FATAL_ERROR "At least GCC version 11.3 required!")
-  endif()
 endfunction()
 
 cmake_policy(POP)

--- a/src/core/datatypes/forte_any_bit_variant.cpp
+++ b/src/core/datatypes/forte_any_bit_variant.cpp
@@ -76,7 +76,7 @@ CIEC_ANY_BIT &CIEC_ANY_BIT_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(*this));;
+  }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_BIT &CIEC_ANY_BIT_VARIANT::unwrap() const {

--- a/src/core/datatypes/forte_any_bit_variant.cpp
+++ b/src/core/datatypes/forte_any_bit_variant.cpp
@@ -76,7 +76,7 @@ CIEC_ANY_BIT &CIEC_ANY_BIT_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(*this));;
 }
 
 const CIEC_ANY_BIT &CIEC_ANY_BIT_VARIANT::unwrap() const {
@@ -87,7 +87,7 @@ const CIEC_ANY_BIT &CIEC_ANY_BIT_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_BIT_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_BIT_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_char_variant.cpp
+++ b/src/core/datatypes/forte_any_char_variant.cpp
@@ -58,7 +58,7 @@ CIEC_ANY_CHAR &CIEC_ANY_CHAR_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<CIEC_ANY_CHAR_VARIANT::variant&>(*this));;
+  }, static_cast<CIEC_ANY_CHAR_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_CHAR &CIEC_ANY_CHAR_VARIANT::unwrap() const {
@@ -69,7 +69,7 @@ const CIEC_ANY_CHAR &CIEC_ANY_CHAR_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<const CIEC_ANY_CHAR_VARIANT::variant&>(*this));;
+  }, static_cast<const CIEC_ANY_CHAR_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_CHAR_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_char_variant.cpp
+++ b/src/core/datatypes/forte_any_char_variant.cpp
@@ -58,7 +58,7 @@ CIEC_ANY_CHAR &CIEC_ANY_CHAR_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_CHAR_VARIANT::variant&>(*this));;
 }
 
 const CIEC_ANY_CHAR &CIEC_ANY_CHAR_VARIANT::unwrap() const {
@@ -69,7 +69,7 @@ const CIEC_ANY_CHAR &CIEC_ANY_CHAR_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_CHAR_VARIANT::variant&>(*this));;
 }
 
 int CIEC_ANY_CHAR_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_chars_variant.cpp
+++ b/src/core/datatypes/forte_any_chars_variant.cpp
@@ -70,7 +70,7 @@ CIEC_ANY_CHARS &CIEC_ANY_CHARS_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_CHARS_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_CHARS &CIEC_ANY_CHARS_VARIANT::unwrap() const {
@@ -81,7 +81,7 @@ const CIEC_ANY_CHARS &CIEC_ANY_CHARS_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_CHARS_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_CHARS_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_date_variant.cpp
+++ b/src/core/datatypes/forte_any_date_variant.cpp
@@ -93,7 +93,7 @@ const CIEC_ANY_DATE &CIEC_ANY_DATE_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<const CIEC_ANY_DATE_VARIANT::variant&>(*this));;
+  }, static_cast<const CIEC_ANY_DATE_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_DATE_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_date_variant.cpp
+++ b/src/core/datatypes/forte_any_date_variant.cpp
@@ -82,7 +82,7 @@ CIEC_ANY_DATE &CIEC_ANY_DATE_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_DATE_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_DATE &CIEC_ANY_DATE_VARIANT::unwrap() const {
@@ -93,7 +93,7 @@ const CIEC_ANY_DATE &CIEC_ANY_DATE_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_DATE_VARIANT::variant&>(*this));;
 }
 
 int CIEC_ANY_DATE_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_duration_variant.cpp
+++ b/src/core/datatypes/forte_any_duration_variant.cpp
@@ -58,7 +58,7 @@ CIEC_ANY_DURATION &CIEC_ANY_DURATION_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_DURATION_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_DURATION &CIEC_ANY_DURATION_VARIANT::unwrap() const {
@@ -69,7 +69,7 @@ const CIEC_ANY_DURATION &CIEC_ANY_DURATION_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_DURATION_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_DURATION_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_elementary_variant.cpp
+++ b/src/core/datatypes/forte_any_elementary_variant.cpp
@@ -319,6 +319,6 @@ int CIEC_ANY_ELEMENTARY_VARIANT::compare(const CIEC_ANY_ELEMENTARY_VARIANT &paVa
         return -1;
       }
   }, static_cast<const CIEC_ANY_ELEMENTARY_VARIANT::variant&>(paValue), 
-      static_cast<const CIEC_ANY_ELEMENTARY_VARIANT::variant&>(paOther));
+     static_cast<const CIEC_ANY_ELEMENTARY_VARIANT::variant&>(paOther));
 }
 

--- a/src/core/datatypes/forte_any_elementary_variant.cpp
+++ b/src/core/datatypes/forte_any_elementary_variant.cpp
@@ -208,7 +208,7 @@ CIEC_ANY_ELEMENTARY &CIEC_ANY_ELEMENTARY_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_ELEMENTARY_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_ELEMENTARY &CIEC_ANY_ELEMENTARY_VARIANT::unwrap() const {
@@ -219,7 +219,7 @@ const CIEC_ANY_ELEMENTARY &CIEC_ANY_ELEMENTARY_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_ELEMENTARY_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_ELEMENTARY_VARIANT::fromString(const char *paValue) {
@@ -318,6 +318,7 @@ int CIEC_ANY_ELEMENTARY_VARIANT::compare(const CIEC_ANY_ELEMENTARY_VARIANT &paVa
                      CStringDictionary::getInstance().get(other.getTypeNameID()));
         return -1;
       }
-  }, paValue, paOther);;
+  }, static_cast<const CIEC_ANY_ELEMENTARY_VARIANT::variant&>(paValue), 
+      static_cast<const CIEC_ANY_ELEMENTARY_VARIANT::variant&>(paOther));
 }
 

--- a/src/core/datatypes/forte_any_int_variant.cpp
+++ b/src/core/datatypes/forte_any_int_variant.cpp
@@ -94,7 +94,7 @@ CIEC_ANY_INT &CIEC_ANY_INT_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_INT_VARIANT::variant&>(*this));;
 }
 
 const CIEC_ANY_INT &CIEC_ANY_INT_VARIANT::unwrap() const {
@@ -105,7 +105,7 @@ const CIEC_ANY_INT &CIEC_ANY_INT_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_INT_VARIANT::variant&>(*this));;
 }
 
 int CIEC_ANY_INT_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_int_variant.cpp
+++ b/src/core/datatypes/forte_any_int_variant.cpp
@@ -94,7 +94,7 @@ CIEC_ANY_INT &CIEC_ANY_INT_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<CIEC_ANY_INT_VARIANT::variant&>(*this));;
+  }, static_cast<CIEC_ANY_INT_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_INT &CIEC_ANY_INT_VARIANT::unwrap() const {
@@ -105,7 +105,7 @@ const CIEC_ANY_INT &CIEC_ANY_INT_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<const CIEC_ANY_INT_VARIANT::variant&>(*this));;
+  }, static_cast<const CIEC_ANY_INT_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_INT_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_magnitude_variant.cpp
+++ b/src/core/datatypes/forte_any_magnitude_variant.cpp
@@ -118,7 +118,7 @@ CIEC_ANY_MAGNITUDE &CIEC_ANY_MAGNITUDE_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_MAGNITUDE &CIEC_ANY_MAGNITUDE_VARIANT::unwrap() const {
@@ -129,7 +129,7 @@ const CIEC_ANY_MAGNITUDE &CIEC_ANY_MAGNITUDE_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_MAGNITUDE_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_MAGNITUDE_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_num_variant.cpp
+++ b/src/core/datatypes/forte_any_num_variant.cpp
@@ -106,7 +106,7 @@ CIEC_ANY_NUM &CIEC_ANY_NUM_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_NUM &CIEC_ANY_NUM_VARIANT::unwrap() const {
@@ -117,7 +117,7 @@ const CIEC_ANY_NUM &CIEC_ANY_NUM_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_NUM_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_NUM_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_real_variant.cpp
+++ b/src/core/datatypes/forte_any_real_variant.cpp
@@ -58,7 +58,7 @@ CIEC_ANY_REAL &CIEC_ANY_REAL_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(*this));;
 }
 
 const CIEC_ANY_REAL &CIEC_ANY_REAL_VARIANT::unwrap() const {
@@ -69,7 +69,7 @@ const CIEC_ANY_REAL &CIEC_ANY_REAL_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_REAL_VARIANT::variant&>(*this));;
 }
 
 int CIEC_ANY_REAL_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_real_variant.cpp
+++ b/src/core/datatypes/forte_any_real_variant.cpp
@@ -58,7 +58,7 @@ CIEC_ANY_REAL &CIEC_ANY_REAL_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(*this));;
+  }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_REAL &CIEC_ANY_REAL_VARIANT::unwrap() const {
@@ -69,7 +69,7 @@ const CIEC_ANY_REAL &CIEC_ANY_REAL_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<const CIEC_ANY_REAL_VARIANT::variant&>(*this));;
+  }, static_cast<const CIEC_ANY_REAL_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_REAL_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_signed_variant.cpp
+++ b/src/core/datatypes/forte_any_signed_variant.cpp
@@ -67,7 +67,7 @@ CIEC_ANY_SIGNED &CIEC_ANY_SIGNED_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_SIGNED_VARIANT::variant&>(*this));;
 }
 
 const CIEC_ANY_SIGNED &CIEC_ANY_SIGNED_VARIANT::unwrap() const {
@@ -78,7 +78,7 @@ const CIEC_ANY_SIGNED &CIEC_ANY_SIGNED_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_SIGNED_VARIANT::variant&>(*this));;
 }
 
 int CIEC_ANY_SIGNED_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_signed_variant.cpp
+++ b/src/core/datatypes/forte_any_signed_variant.cpp
@@ -67,7 +67,7 @@ CIEC_ANY_SIGNED &CIEC_ANY_SIGNED_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<CIEC_ANY_SIGNED_VARIANT::variant&>(*this));;
+  }, static_cast<CIEC_ANY_SIGNED_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_SIGNED &CIEC_ANY_SIGNED_VARIANT::unwrap() const {
@@ -78,7 +78,7 @@ const CIEC_ANY_SIGNED &CIEC_ANY_SIGNED_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<const CIEC_ANY_SIGNED_VARIANT::variant&>(*this));;
+  }, static_cast<const CIEC_ANY_SIGNED_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_SIGNED_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_string_variant.cpp
+++ b/src/core/datatypes/forte_any_string_variant.cpp
@@ -58,7 +58,7 @@ CIEC_ANY_STRING &CIEC_ANY_STRING_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_STRING &CIEC_ANY_STRING_VARIANT::unwrap() const {
@@ -69,7 +69,7 @@ const CIEC_ANY_STRING &CIEC_ANY_STRING_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_STRING_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_STRING_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_unsigned_variant.cpp
+++ b/src/core/datatypes/forte_any_unsigned_variant.cpp
@@ -67,7 +67,7 @@ CIEC_ANY_UNSIGNED &CIEC_ANY_UNSIGNED_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<CIEC_ANY_UNSIGNED_VARIANT::variant&>(*this));;
+  }, static_cast<CIEC_ANY_UNSIGNED_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY_UNSIGNED &CIEC_ANY_UNSIGNED_VARIANT::unwrap() const {
@@ -78,7 +78,7 @@ const CIEC_ANY_UNSIGNED &CIEC_ANY_UNSIGNED_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, static_cast<const CIEC_ANY_UNSIGNED_VARIANT::variant&>(*this));;
+  }, static_cast<const CIEC_ANY_UNSIGNED_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_UNSIGNED_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_unsigned_variant.cpp
+++ b/src/core/datatypes/forte_any_unsigned_variant.cpp
@@ -67,7 +67,7 @@ CIEC_ANY_UNSIGNED &CIEC_ANY_UNSIGNED_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_UNSIGNED_VARIANT::variant&>(*this));;
 }
 
 const CIEC_ANY_UNSIGNED &CIEC_ANY_UNSIGNED_VARIANT::unwrap() const {
@@ -78,7 +78,7 @@ const CIEC_ANY_UNSIGNED &CIEC_ANY_UNSIGNED_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_UNSIGNED_VARIANT::variant&>(*this));;
 }
 
 int CIEC_ANY_UNSIGNED_VARIANT::fromString(const char *paValue) {

--- a/src/core/datatypes/forte_any_variant.cpp
+++ b/src/core/datatypes/forte_any_variant.cpp
@@ -219,7 +219,7 @@ CIEC_ANY &CIEC_ANY_VARIANT::unwrap() {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<CIEC_ANY_VARIANT::variant&>(*this));
 }
 
 const CIEC_ANY &CIEC_ANY_VARIANT::unwrap() const {
@@ -234,7 +234,7 @@ const CIEC_ANY &CIEC_ANY_VARIANT::unwrap() const {
       } else {
         static_assert(always_false_v < T > , "non-exhaustive visitor");
       }
-  }, *this);;
+  }, static_cast<const CIEC_ANY_VARIANT::variant&>(*this));
 }
 
 int CIEC_ANY_VARIANT::fromString(const char *paValue) {

--- a/src/modules/IEC61131-3/Arithmetic/F_ADD.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_ADD.cpp
@@ -76,7 +76,8 @@ void FORTE_F_ADD::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_MAGNITUDE_VARIANT();
-      }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN1),
+         static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_ADD.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_ADD.cpp
@@ -76,7 +76,7 @@ void FORTE_F_ADD::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_MAGNITUDE_VARIANT();
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_DIV.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_DIV.cpp
@@ -76,7 +76,8 @@ void FORTE_F_DIV::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_NUM_VARIANT();
-      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN1), 
+         static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_DIV.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_DIV.cpp
@@ -76,7 +76,7 @@ void FORTE_F_DIV::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_NUM_VARIANT();
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_DIVTIME.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_DIVTIME.cpp
@@ -67,7 +67,7 @@ void FORTE_F_DIVTIME::executeEvent(TEventID paEIID, CEventChainExecutionThread *
     case scmEventREQID:
       var_OUT = std::visit([this](auto&&paIN2) -> CIEC_TIME {
         return func_DIV_TIME(var_IN1, paIN2);
-      }, var_IN2);
+      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_EXPT.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_EXPT.cpp
@@ -67,7 +67,8 @@ void FORTE_F_EXPT::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN1, auto&&paIN2) -> CIEC_ANY_REAL_VARIANT {
         return func_EXPT(paIN1, paIN2);
-      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN1), 
+         static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_EXPT.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_EXPT.cpp
@@ -67,7 +67,7 @@ void FORTE_F_EXPT::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN1, auto&&paIN2) -> CIEC_ANY_REAL_VARIANT {
         return func_EXPT(paIN1, paIN2);
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_MOD.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MOD.cpp
@@ -76,7 +76,8 @@ void FORTE_F_MOD::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_NUM_VARIANT();
-      }, static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_IN1), 
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_MOD.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MOD.cpp
@@ -76,7 +76,7 @@ void FORTE_F_MOD::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_NUM_VARIANT();
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_MUL.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MUL.cpp
@@ -76,7 +76,8 @@ void FORTE_F_MUL::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_NUM_VARIANT();
-      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN1), 
+         static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_MUL.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MUL.cpp
@@ -76,7 +76,7 @@ void FORTE_F_MUL::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_NUM_VARIANT();
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_MULTIME.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MULTIME.cpp
@@ -67,7 +67,7 @@ void FORTE_F_MULTIME::executeEvent(TEventID paEIID, CEventChainExecutionThread *
     case scmEventREQID:
       var_OUT = std::visit([this](auto&&paIN2) -> CIEC_TIME {
         return func_MUL_TIME(var_IN1, paIN2);
-      }, var_IN2);
+      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_SUB.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_SUB.cpp
@@ -76,7 +76,8 @@ void FORTE_F_SUB::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_MAGNITUDE_VARIANT();
-      }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN1),
+         static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_SUB.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_SUB.cpp
@@ -76,7 +76,7 @@ void FORTE_F_SUB::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         return CIEC_ANY_MAGNITUDE_VARIANT();
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_TRUNC.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_TRUNC.cpp
@@ -66,7 +66,7 @@ void FORTE_F_TRUNC::executeEvent(TEventID paEIID, CEventChainExecutionThread *co
       std::visit([](auto &&paIN, auto &&paOUT) -> void {
         using T = std::decay_t<decltype(paOUT)>;
         paOUT = func_TRUNC<T>(paIN);
-      }, var_IN, var_OUT);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/F_TRUNC.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_TRUNC.cpp
@@ -66,7 +66,8 @@ void FORTE_F_TRUNC::executeEvent(TEventID paEIID, CEventChainExecutionThread *co
       std::visit([](auto &&paIN, auto &&paOUT) -> void {
         using T = std::decay_t<decltype(paOUT)>;
         paOUT = func_TRUNC<T>(paIN);
-      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT));
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Arithmetic/GEN_ADD.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/GEN_ADD.cpp
@@ -54,7 +54,8 @@ void GEN_ADD::executeEvent(TEventID paEIID, CEventChainExecutionThread *const pa
                            CStringDictionary::getInstance().get(paOUT.getTypeNameID()),
                            CStringDictionary::getInstance().get(paIN.getTypeNameID()));
               return paOUT;
-          }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_OUT()), static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN(i)));
+          }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_OUT()), 
+             static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN(i)));
         }
       }
       sendOutputEvent(scmEventCNFID, paECET);

--- a/src/modules/IEC61131-3/Arithmetic/GEN_ADD.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/GEN_ADD.cpp
@@ -54,7 +54,7 @@ void GEN_ADD::executeEvent(TEventID paEIID, CEventChainExecutionThread *const pa
                            CStringDictionary::getInstance().get(paOUT.getTypeNameID()),
                            CStringDictionary::getInstance().get(paIN.getTypeNameID()));
               return paOUT;
-          }, var_OUT(), var_IN(i));
+          }, static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_OUT()), static_cast<CIEC_ANY_MAGNITUDE_VARIANT::variant&>(var_IN(i)));
         }
       }
       sendOutputEvent(scmEventCNFID, paECET);

--- a/src/modules/IEC61131-3/BitwiseOperators/F_AND.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_AND.cpp
@@ -67,7 +67,7 @@ void FORTE_F_AND::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN1, auto&&paIN2) -> CIEC_ANY_BIT_VARIANT {
         return func_AND(paIN1, paIN2);
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_AND.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_AND.cpp
@@ -67,7 +67,8 @@ void FORTE_F_AND::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN1, auto&&paIN2) -> CIEC_ANY_BIT_VARIANT {
         return func_AND(paIN1, paIN2);
-      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1), 
+         static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_NOT.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_NOT.cpp
@@ -65,7 +65,7 @@ void FORTE_F_NOT::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_BIT_VARIANT {
           return func_NOT(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_OR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_OR.cpp
@@ -67,7 +67,8 @@ void FORTE_F_OR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN1, auto&&paIN2) -> CIEC_ANY_BIT_VARIANT {
           return func_OR(paIN1, paIN2);
-      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1),
+         static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_OR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_OR.cpp
@@ -67,7 +67,7 @@ void FORTE_F_OR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN1, auto&&paIN2) -> CIEC_ANY_BIT_VARIANT {
           return func_OR(paIN1, paIN2);
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_ROL.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_ROL.cpp
@@ -74,7 +74,8 @@ void FORTE_F_ROL::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                        CStringDictionary::getInstance().get(paIN.getTypeNameID()),
                        CStringDictionary::getInstance().get(paN.getTypeNameID()));
           return CIEC_ANY_BIT_VARIANT();
-      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_ROL.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_ROL.cpp
@@ -74,7 +74,7 @@ void FORTE_F_ROL::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                        CStringDictionary::getInstance().get(paIN.getTypeNameID()),
                        CStringDictionary::getInstance().get(paN.getTypeNameID()));
           return CIEC_ANY_BIT_VARIANT();
-      }, var_IN, var_N);
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_ROR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_ROR.cpp
@@ -74,7 +74,7 @@ void FORTE_F_ROR::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                        CStringDictionary::getInstance().get(paIN.getTypeNameID()),
                        CStringDictionary::getInstance().get(paN.getTypeNameID()));
           return CIEC_ANY_BIT_VARIANT();
-      }, var_IN, var_N);
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_ROR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_ROR.cpp
@@ -74,7 +74,8 @@ void FORTE_F_ROR::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                        CStringDictionary::getInstance().get(paIN.getTypeNameID()),
                        CStringDictionary::getInstance().get(paN.getTypeNameID()));
           return CIEC_ANY_BIT_VARIANT();
-      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_SHL.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_SHL.cpp
@@ -74,7 +74,7 @@ void FORTE_F_SHL::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                        CStringDictionary::getInstance().get(paIN.getTypeNameID()),
                        CStringDictionary::getInstance().get(paN.getTypeNameID()));
           return CIEC_ANY_BIT_VARIANT();
-      }, var_IN, var_N);
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_SHL.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_SHL.cpp
@@ -74,7 +74,8 @@ void FORTE_F_SHL::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                        CStringDictionary::getInstance().get(paIN.getTypeNameID()),
                        CStringDictionary::getInstance().get(paN.getTypeNameID()));
           return CIEC_ANY_BIT_VARIANT();
-      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_SHR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_SHR.cpp
@@ -74,7 +74,8 @@ void FORTE_F_SHR::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                        CStringDictionary::getInstance().get(paIN.getTypeNameID()),
                        CStringDictionary::getInstance().get(paN.getTypeNameID()));
           return CIEC_ANY_BIT_VARIANT();
-      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_SHR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_SHR.cpp
@@ -74,7 +74,7 @@ void FORTE_F_SHR::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
                        CStringDictionary::getInstance().get(paIN.getTypeNameID()),
                        CStringDictionary::getInstance().get(paN.getTypeNameID()));
           return CIEC_ANY_BIT_VARIANT();
-      }, var_IN, var_N);
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_N));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_XOR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_XOR.cpp
@@ -67,7 +67,8 @@ void FORTE_F_XOR::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN1, auto&&paIN2) -> CIEC_ANY_BIT_VARIANT {
           return func_XOR(paIN1, paIN2);
-      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1),
+         static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_XOR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_XOR.cpp
@@ -67,7 +67,7 @@ void FORTE_F_XOR::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN1, auto&&paIN2) -> CIEC_ANY_BIT_VARIANT {
           return func_XOR(paIN1, paIN2);
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_AND.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_AND.cpp
@@ -37,7 +37,8 @@ void GEN_AND::executeEvent(TEventID paEIID, CEventChainExecutionThread *const pa
         for (size_t i = 1; i < getFBInterfaceSpec()->mNumDIs; ++i) {
           var_OUT() = std::visit([](auto &&paOUT, auto &&paIN) -> CIEC_ANY_BIT_VARIANT {
             return func_AND(paOUT, paIN);
-          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
+          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()),
+             static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
         }
       }
       sendOutputEvent(scmEventCNFID, paECET);

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_AND.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_AND.cpp
@@ -37,7 +37,7 @@ void GEN_AND::executeEvent(TEventID paEIID, CEventChainExecutionThread *const pa
         for (size_t i = 1; i < getFBInterfaceSpec()->mNumDIs; ++i) {
           var_OUT() = std::visit([](auto &&paOUT, auto &&paIN) -> CIEC_ANY_BIT_VARIANT {
             return func_AND(paOUT, paIN);
-          }, var_OUT(), var_IN(i));
+          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
         }
       }
       sendOutputEvent(scmEventCNFID, paECET);

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_OR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_OR.cpp
@@ -37,7 +37,7 @@ void GEN_OR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paE
         for (size_t i = 1; i < getFBInterfaceSpec()->mNumDIs; ++i) {
           var_OUT() = std::visit([](auto &&paOUT, auto &&paIN) -> CIEC_ANY_BIT_VARIANT {
               return func_OR(paOUT, paIN);
-          }, var_OUT(), var_IN(i));
+          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
         }
       }
       sendOutputEvent(scmEventCNFID, paECET);

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_OR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_OR.cpp
@@ -37,7 +37,8 @@ void GEN_OR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paE
         for (size_t i = 1; i < getFBInterfaceSpec()->mNumDIs; ++i) {
           var_OUT() = std::visit([](auto &&paOUT, auto &&paIN) -> CIEC_ANY_BIT_VARIANT {
               return func_OR(paOUT, paIN);
-          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
+          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()),
+             static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
         }
       }
       sendOutputEvent(scmEventCNFID, paECET);

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_XOR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_XOR.cpp
@@ -37,7 +37,7 @@ void GEN_XOR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const pa
         for (size_t i = 1; i < getFBInterfaceSpec()->mNumDIs; ++i) {
           var_OUT() = std::visit([](auto &&paOUT, auto &&paIN) -> CIEC_ANY_BIT_VARIANT {
               return func_XOR(paOUT, paIN);
-          }, var_OUT(), var_IN(i));
+          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
         }
       }
       sendOutputEvent(scmEventCNFID, paECET);

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_XOR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_XOR.cpp
@@ -37,7 +37,8 @@ void GEN_XOR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const pa
         for (size_t i = 1; i < getFBInterfaceSpec()->mNumDIs; ++i) {
           var_OUT() = std::visit([](auto &&paOUT, auto &&paIN) -> CIEC_ANY_BIT_VARIANT {
               return func_XOR(paOUT, paIN);
-          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()), static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
+          }, static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_OUT()),
+             static_cast<CIEC_ANY_BIT_VARIANT::variant&>(var_IN(i)));
         }
       }
       sendOutputEvent(scmEventCNFID, paECET);

--- a/src/modules/IEC61131-3/CharacterString/F_CONCAT.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_CONCAT.cpp
@@ -75,7 +75,8 @@ void FORTE_F_CONCAT::executeEvent(TEventID paEIID, CEventChainExecutionThread *c
                        CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                        CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
           return CIEC_ANY_STRING_VARIANT();
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1) ,static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2));
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1),
+         static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_CONCAT.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_CONCAT.cpp
@@ -75,7 +75,7 @@ void FORTE_F_CONCAT::executeEvent(TEventID paEIID, CEventChainExecutionThread *c
                        CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                        CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
           return CIEC_ANY_STRING_VARIANT();
-      }, var_IN1, var_IN2);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1) ,static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_DELETE.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_DELETE.cpp
@@ -69,7 +69,9 @@ void FORTE_F_DELETE::executeEvent(TEventID paEIID, CEventChainExecutionThread *c
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN, auto&&paL, auto&&paP) -> CIEC_ANY_STRING_VARIANT {
           return func_DELETE(paIN, paL, paP);
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_DELETE.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_DELETE.cpp
@@ -69,7 +69,7 @@ void FORTE_F_DELETE::executeEvent(TEventID paEIID, CEventChainExecutionThread *c
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN, auto&&paL, auto&&paP) -> CIEC_ANY_STRING_VARIANT {
           return func_DELETE(paIN, paL, paP);
-      }, var_IN, var_L, var_P);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_FIND.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_FIND.cpp
@@ -75,7 +75,9 @@ void FORTE_F_FIND::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         }
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT));
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1),
+         static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_FIND.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_FIND.cpp
@@ -75,7 +75,7 @@ void FORTE_F_FIND::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
                      CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                      CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
         }
-      }, var_IN1, var_IN2, var_OUT);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_INSERT.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_INSERT.cpp
@@ -77,7 +77,7 @@ void FORTE_F_INSERT::executeEvent(TEventID paEIID, CEventChainExecutionThread *c
                        CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                        CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
           return CIEC_ANY_STRING_VARIANT();
-      }, var_IN1, var_IN2, var_P);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_INSERT.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_INSERT.cpp
@@ -77,7 +77,9 @@ void FORTE_F_INSERT::executeEvent(TEventID paEIID, CEventChainExecutionThread *c
                        CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                        CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
           return CIEC_ANY_STRING_VARIANT();
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1),
+         static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_LEFT.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_LEFT.cpp
@@ -67,7 +67,7 @@ void FORTE_F_LEFT::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN, auto&&paL) -> CIEC_ANY_STRING_VARIANT {
           return func_LEFT(paIN, paL);
-      }, var_IN, var_L);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_LEFT.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_LEFT.cpp
@@ -67,7 +67,8 @@ void FORTE_F_LEFT::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN, auto&&paL) -> CIEC_ANY_STRING_VARIANT {
           return func_LEFT(paIN, paL);
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_LEN.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_LEN.cpp
@@ -65,7 +65,7 @@ void FORTE_F_LEN::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       std::visit([](auto &&paIN, auto&&paOUT) -> void {
           paOUT = func_LEN<std::remove_reference_t<decltype(paOUT)>>(paIN);
-      }, var_IN, var_OUT);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN) ,static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT) );
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_LEN.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_LEN.cpp
@@ -65,7 +65,8 @@ void FORTE_F_LEN::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       std::visit([](auto &&paIN, auto&&paOUT) -> void {
           paOUT = func_LEN<std::remove_reference_t<decltype(paOUT)>>(paIN);
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN) ,static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT) );
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_OUT) );
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_MID.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_MID.cpp
@@ -69,7 +69,9 @@ void FORTE_F_MID::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN, auto&&paL, auto&&paP) -> CIEC_ANY_STRING_VARIANT {
           return func_MID(paIN, paL, paP);
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_MID.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_MID.cpp
@@ -69,7 +69,7 @@ void FORTE_F_MID::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN, auto&&paL, auto&&paP) -> CIEC_ANY_STRING_VARIANT {
           return func_MID(paIN, paL, paP);
-      }, var_IN, var_L, var_P);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_REPLACE.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_REPLACE.cpp
@@ -79,7 +79,7 @@ void FORTE_F_REPLACE::executeEvent(TEventID paEIID, CEventChainExecutionThread *
                        CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                        CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
           return CIEC_ANY_STRING_VARIANT();
-      }, var_IN1, var_IN2, var_P, var_L);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_REPLACE.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_REPLACE.cpp
@@ -79,7 +79,10 @@ void FORTE_F_REPLACE::executeEvent(TEventID paEIID, CEventChainExecutionThread *
                        CStringDictionary::getInstance().get(paIN1.getTypeNameID()),
                        CStringDictionary::getInstance().get(paIN2.getTypeNameID()));
           return CIEC_ANY_STRING_VARIANT();
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1), static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P), static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN1),
+         static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN2),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_P),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_RIGHT.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_RIGHT.cpp
@@ -67,7 +67,7 @@ void FORTE_F_RIGHT::executeEvent(TEventID paEIID, CEventChainExecutionThread *co
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN, auto&&paL) -> CIEC_ANY_STRING_VARIANT {
           return func_RIGHT(paIN, paL);
-      }, var_IN, var_L);
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN) ,static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/CharacterString/F_RIGHT.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_RIGHT.cpp
@@ -67,7 +67,8 @@ void FORTE_F_RIGHT::executeEvent(TEventID paEIID, CEventChainExecutionThread *co
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN, auto&&paL) -> CIEC_ANY_STRING_VARIANT {
           return func_RIGHT(paIN, paL);
-      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN) ,static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
+      }, static_cast<CIEC_ANY_STRING_VARIANT::variant&>(var_IN),
+         static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_L));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_ABS.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_ABS.cpp
@@ -65,7 +65,7 @@ void FORTE_F_ABS::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_NUM_VARIANT {
         return func_ABS(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_NUM_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_ACOS.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_ACOS.cpp
@@ -65,7 +65,7 @@ void FORTE_F_ACOS::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_ACOS(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_ASIN.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_ASIN.cpp
@@ -65,7 +65,7 @@ void FORTE_F_ASIN::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_ASIN(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_ATAN.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_ATAN.cpp
@@ -65,7 +65,7 @@ void FORTE_F_ATAN::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_ATAN(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_COS.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_COS.cpp
@@ -65,7 +65,7 @@ void FORTE_F_COS::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_COS(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_EXP.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_EXP.cpp
@@ -65,7 +65,7 @@ void FORTE_F_EXP::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_EXP(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_LN.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_LN.cpp
@@ -65,7 +65,7 @@ void FORTE_F_LN::executeEvent(TEventID paEIID, CEventChainExecutionThread *const
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_LN(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_LOG.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_LOG.cpp
@@ -65,7 +65,7 @@ void FORTE_F_LOG::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_LOG(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_SIN.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_SIN.cpp
@@ -65,7 +65,7 @@ void FORTE_F_SIN::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_SIN(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_SQRT.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_SQRT.cpp
@@ -65,7 +65,7 @@ void FORTE_F_SQRT::executeEvent(TEventID paEIID, CEventChainExecutionThread *con
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_SQRT(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Numerical/F_TAN.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_TAN.cpp
@@ -65,7 +65,7 @@ void FORTE_F_TAN::executeEvent(TEventID paEIID, CEventChainExecutionThread *cons
     case scmEventREQID:
       var_OUT = std::visit([](auto &&paIN) -> CIEC_ANY_REAL_VARIANT {
           return func_TAN(paIN);
-      }, var_IN);
+      }, static_cast<CIEC_ANY_REAL_VARIANT::variant&>(var_IN));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }

--- a/src/modules/IEC61131-3/Selection/F_MUX_2.cpp
+++ b/src/modules/IEC61131-3/Selection/F_MUX_2.cpp
@@ -80,7 +80,7 @@ void FORTE_F_MUX_2::executeEvent(TEventID paEIID, CEventChainExecutionThread *co
         }
         DEVLOG_ERROR("value of input K is not between 0 and 1\n");
         return CIEC_ANY_VARIANT();
-      }, var_K);
+      }, static_cast<CIEC_ANY_INT_VARIANT::variant&>(var_K));
       sendOutputEvent(scmEventCNFID, paECET);
       break;
   }


### PR DESCRIPTION
As for https://stackoverflow.com/questions/63616709/incomplete-type-stdvariant-used-in-nested-name-specifier, the problem comes from a possible unclear specification. There is also shown a workaround of casting to the `parent::variant` class so the visit can work properly.

If this patch  doesn't create any problem and it only adds a `static_cast` I think it is worth having it to expand the compiler list which work with forte.  