### PR TITLE
win32: Use the standard C++ time functions

### DIFF
--- a/src/arch/ecos/nios2/CMakeLists.txt
+++ b/src/arch/ecos/nios2/CMakeLists.txt
@@ -32,7 +32,7 @@ if("${FORTE_ARCHITECTURE}" STREQUAL "Nios2")
   else(FORTE_FAKE_TIME)
     forte_add_sourcefile_hcpp(../ecostiha)
   endif(FORTE_FAKE_TIME)
-  forte_add_sourcefile_cpp(../../posix/forte_architecture_time.cpp)
+  forte_add_sourcefile_cpp(../../posix/forte_architecture_time.cpp ../../forte_standard_time.cpp)
 
   forte_add_sourcefile_cpp(../ecoscppinit.cpp ../../genforte_printer.cpp ../forte_architecture.cpp)
   forte_add_sourcefile_h(../../forte_architecture_time.h)

--- a/src/arch/ecos/phycoreat91/CMakeLists.txt
+++ b/src/arch/ecos/phycoreat91/CMakeLists.txt
@@ -25,7 +25,7 @@ if("${FORTE_ARCHITECTURE}" STREQUAL "Phycore AT91")
   else(FORTE_FAKE_TIME)
     forte_add_sourcefile_hcpp(../ecostiha)
   endif(FORTE_FAKE_TIME)
-  forte_add_sourcefile_cpp(../../posix/forte_architecture_time.cpp)
+  forte_add_sourcefile_cpp(../../posix/forte_architecture_time.cpp ../../forte_standard_time.cpp)
 
   forte_add_sourcefile_cpp(../../genforte_printer.cpp)
   forte_add_sourcefile_h(../../forte_architecture_time.h)

--- a/src/arch/forte_standard_time.cpp
+++ b/src/arch/forte_standard_time.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Samator Indo Gas
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Ketut Kumajaya - Create a common standard C++ time implementation
+ *******************************************************************************/
+
+#include <chrono>
+
+using namespace std::chrono;
+
+#include "forte_architecture_time.h"
+
+#ifndef FORTE_FAKE_TIME
+uint_fast64_t getNanoSecondsMonotonic() {
+  return static_cast<uint_fast64_t>(duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count());
+}
+
+uint_fast64_t getNanoSecondsRealtime() {
+  return static_cast<uint_fast64_t>(duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count());
+}
+#endif

--- a/src/arch/macos/CMakeLists.txt
+++ b/src/arch/macos/CMakeLists.txt
@@ -26,7 +26,7 @@ if("${FORTE_ARCHITECTURE}" STREQUAL "MacOs")
   else(FORTE_FAKE_TIME)
     forte_set_timer(../posix/pctimeha)
   endif(FORTE_FAKE_TIME)
-  forte_add_sourcefile_cpp(../posix/forte_architecture_time.cpp)
+  forte_add_sourcefile_cpp(../posix/forte_architecture_time.cpp ../forte_standard_time.cpp)
 
   forte_add_sourcefile_hcpp(../posix/forte_thread forte_sync forte_sem)
   forte_add_sourcefile_cpp(../genforte_printer.cpp)

--- a/src/arch/plcnext/CMakeLists.txt
+++ b/src/arch/plcnext/CMakeLists.txt
@@ -23,7 +23,7 @@ if("${FORTE_ARCHITECTURE}" STREQUAL "PLCnext")
   else(FORTE_FAKE_TIME)
     forte_set_timer(../posix/pctimeha)
   endif(FORTE_FAKE_TIME)
-  forte_add_sourcefile_cpp(../posix/forte_architecture_time.cpp)
+  forte_add_sourcefile_cpp(../posix/forte_architecture_time.cpp ../forte_standard_time.cpp)
 
   forte_add_sourcefile_hcpp(../posix/forte_thread ../posix/forte_sync ../posix/forte_sem)
   forte_add_sourcefile_cpp(../genforte_printer.cpp)

--- a/src/arch/posix/CMakeLists.txt
+++ b/src/arch/posix/CMakeLists.txt
@@ -24,7 +24,7 @@ if("${FORTE_ARCHITECTURE}" STREQUAL "Posix")
   else(FORTE_FAKE_TIME)
     forte_set_timer(pctimeha)
   endif(FORTE_FAKE_TIME)
-  forte_add_sourcefile_cpp(forte_architecture_time.cpp)
+  forte_add_sourcefile_cpp(forte_architecture_time.cpp ../forte_standard_time.cpp)
 
   forte_add_sourcefile_hcpp(forte_thread forte_sync forte_sem)
   forte_add_sourcefile_cpp(../genforte_printer.cpp)

--- a/src/arch/posix/forte_architecture_time.cpp
+++ b/src/arch/posix/forte_architecture_time.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2019 TU Wien/ACIN
  *               2023 Martin Erich Jobst
+ *               2024 Samator Indo Gas
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,28 +11,11 @@
  * Contributors:
  *  Martin Melik Merkumians - Adds getNanoSecondsMonotonic
  *  Martin Jobst - add high-resolution realtime clock
+ *  Ketut Kumajaya - Use the standard C++ time implementation
  *******************************************************************************/
-
-#include <time.h>
 
 #include "forte_architecture_time.h"
 #include "forte_constants.h"
-
-#ifndef FORTE_FAKE_TIME
-uint_fast64_t getNanoSecondsMonotonic() {
-  struct timespec now;
-  clock_gettime(CLOCK_MONOTONIC, &now);
-  return static_cast<uint_fast64_t>(now.tv_nsec) + static_cast<uint_fast64_t>(now.tv_sec) *
-   static_cast<uint_fast64_t>(forte::core::constants::cNanosecondsPerSecond);
-}
-
-uint_fast64_t getNanoSecondsRealtime() {
-  struct timespec now;
-  clock_gettime(CLOCK_REALTIME, &now);
-  return static_cast<uint_fast64_t>(now.tv_nsec) + static_cast<uint_fast64_t>(now.tv_sec) *
-   static_cast<uint_fast64_t>(forte::core::constants::cNanosecondsPerSecond);
-}
-#endif
 
 time_t forte_timegm(struct tm *pa_tm) {
   return timegm(pa_tm);

--- a/src/arch/win32/CMakeLists.txt
+++ b/src/arch/win32/CMakeLists.txt
@@ -28,7 +28,7 @@ if("${FORTE_ARCHITECTURE}" STREQUAL "Win32")
   else()
     forte_add_sourcefile_cpp(forte_sync.cpp)
   endif()
-  forte_add_sourcefile_cpp(forte_architecture.cpp winforte_printer.cpp forte_architecture_time.cpp)
+  forte_add_sourcefile_cpp(forte_architecture.cpp winforte_printer.cpp forte_architecture_time.cpp ../forte_standard_time.cpp)
   forte_add_sourcefile_cpp(../genforte_fileio.cpp)
   forte_add_sourcefile_cpp(../genforte_realFunctions.cpp)
   

--- a/src/arch/win32/forte_architecture_time.cpp
+++ b/src/arch/win32/forte_architecture_time.cpp
@@ -15,24 +15,12 @@
  *  Martin Jobst - add high-resolution realtime clock
  *  Ketut Kumajaya - Use the standard C++ time functions, fix pre Windows 8/
  *                   Server 2012 compatibility issue
+ *                 - Move the standard C++ time functions as a common time
+ *                   implementation
  *******************************************************************************/
-
-#include <chrono>
-
-using namespace std::chrono;
 
 #include "forte_architecture_time.h"
 #include "forte_constants.h"
-
-#ifndef FORTE_FAKE_TIME
-uint_fast64_t getNanoSecondsMonotonic() {
-  return static_cast<uint_fast64_t>(duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count());
-}
-
-uint_fast64_t getNanoSecondsRealtime() {
-  return static_cast<uint_fast64_t>(duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count());
-}
-#endif
 
 time_t forte_timegm(struct tm *pa_tm) {
   return _mkgmtime(pa_tm);

--- a/src/arch/win32/forte_architecture_time.cpp
+++ b/src/arch/win32/forte_architecture_time.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2019 TU Wien/ACIN
  *               2022 Primetals Technologies Austria GmbH
  *               2023 Martin Erich Jobst
+ *               2024 Samator Indo Gas
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -12,37 +13,24 @@
  *  Martin Melik Merkumians - Adds getNanoSecondsMonotonic
  *                          - Optimize order of operations for time result
  *  Martin Jobst - add high-resolution realtime clock
+ *  Ketut Kumajaya - Use the standard C++ time functions, fix pre Windows 8/
+ *                   Server 2012 compatibility issue
  *******************************************************************************/
 
-#include <windows.h>
+#include <chrono>
+
+using namespace std::chrono;
 
 #include "forte_architecture_time.h"
 #include "forte_constants.h"
 
 #ifndef FORTE_FAKE_TIME
 uint_fast64_t getNanoSecondsMonotonic() {
-  LARGE_INTEGER performance_counter;
-  LARGE_INTEGER performance_frequency;
-
-  QueryPerformanceCounter(&performance_counter);
-  QueryPerformanceFrequency(&performance_frequency);
-
-  // The clock frequency for Win10 on the Performance Timer is 10Mhz or less
-  // in previous versions accoording to
-  // https://stackoverflow.com/questions/63205226/better-than-100ns-resolution-timers-in-windows
-  // so it is safe to assume that forte::core::constants::cNanosecondsPerSecond >> performance_frequency.QuadPart
-  const uint_fast64_t timeFactor = static_cast<uint_fast64_t>(forte::core::constants::cNanosecondsPerSecond) / static_cast<uint_fast64_t>(performance_frequency.QuadPart);
-  return static_cast<uint_fast64_t>(performance_counter.QuadPart) * timeFactor;
+  return static_cast<uint_fast64_t>(duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count());
 }
 
 uint_fast64_t getNanoSecondsRealtime() {
-  FILETIME filetime;
-
-  GetSystemTimePreciseAsFileTime(&filetime);
-
-  // The FILETIME struct stores the number of 100-nanosecond intervals since January 1, 1601 (UTC).
-  uint_fast64_t time = static_cast<uint_fast64_t>(filetime.dwHighDateTime) << 32 | static_cast<uint_fast64_t>(filetime.dwLowDateTime);
-  return (time - 116444736000000000LL) * 100LL; // convert to Unix Epoch and nanoseconds
+  return static_cast<uint_fast64_t>(duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count());
 }
 #endif
 


### PR DESCRIPTION
This fix pre Windows 8/Server 2012 compatibility issue since the GetSystemTimePreciseAsFileTime function is not available in Windows 7