### PR TITLE
fix incorrect header usage

### DIFF
--- a/src/core/datatypes/forte_lreal.cpp
+++ b/src/core/datatypes/forte_lreal.cpp
@@ -12,7 +12,7 @@
  *    Ingo Hegny, Martin Melik Merkumians, Monika Wenger
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
-#include <math.h>
+#include <cmath>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
`forte_lreal.cpp` uses a wrong header. `std::isfinite` does not work with `math.h`, because on some platforms, that defines `isfinite` as a macro. The correct solution is to use header `cmath`.