### PR TITLE
Create OPC UA namespace during runtime

### DIFF
--- a/src/com/opc_ua/opcua_layer.cpp
+++ b/src/com/opc_ua/opcua_layer.cpp
@@ -69,10 +69,8 @@ EComResponse COPC_UA_Layer::openConnection(char *paLayerParameter) {
       if(COPC_UA_ObjectStruct_Helper::isStructType(*this, isPublisher) && mStructObjectHelper->checkStructTypeConnection(isPublisher) && (CActionInfo::eWrite == action || CActionInfo::eRead == action) ) {
         mIsObjectNodeStruct = true;
         response = mStructObjectHelper->createObjectNode(*mActionInfo, isPublisher);
-        
-        CCriticalRegion criticalRegion(mRDBufferMutex);
-        response = e_InitOk;
-        if(!isPublisher) {
+        if(!isPublisher && (response == e_InitOk)) {
+          CCriticalRegion criticalRegion(mRDBufferMutex);
           mRDBuffer = mStructObjectHelper->initializeRDBuffer();
         }
       }

--- a/src/com/opc_ua/opcua_objectstruct_helper.h
+++ b/src/com/opc_ua/opcua_objectstruct_helper.h
@@ -110,9 +110,10 @@ class COPC_UA_ObjectStruct_Helper {
     COPC_UA_HandlerAbstract *mHandler;
 
     /**
-     * OPC UA Object Struct Namespace Index
+     * OPC UA Object Struct Namespace Index.
+     * The default NamespaceIndex is 1.
     */
-    static const UA_UInt16 smOpcuaNamespaceIndex;
+    UA_UInt16 mOpcuaNamespaceIndex;
 
     /**
      * BrowsePath to folder that contains Object Node Struct Types
@@ -124,7 +125,7 @@ class COPC_UA_ObjectStruct_Helper {
     */
      static const std::string smMemberNamespaceIndex;
 
-     static char smEmptyLocale[];
+     static char smEmptyString[];
 
      std::vector<char*> mStructTypeNames;
 
@@ -167,6 +168,13 @@ class COPC_UA_ObjectStruct_Helper {
     forte::com_infra::EComResponse initializeMemberAction(CActionInfo& paActionInfo, std::string &paBrowsePath, bool paIsPublisher);
     
     /**
+     * Check if OPC UA namespace is given by the Resource configuration. 
+     * If the configuration is set, change the namespace index. 
+     * Otherwise, leave it in default state.
+    */
+    void checkOPCUANamespace();
+
+    /**
      * Get the BrowsePath to the OPC UA Struct Object Type from the local Struct Type
      * @param paPathPrefix The BrowsePath directory with namespace (e.g. /Objects/1:)
      * @param paIsPublisher True if the FB is a Publisher, false othewise
@@ -183,10 +191,17 @@ class COPC_UA_ObjectStruct_Helper {
      * @param paBrowsePathPrefix BrowsePath to the Struct Object Node
      * @param structMemberNameId Name Id of Object Node Struct member
      */
-    static std::string getStructMemberBrowsePath(std::string &paBrowsePathPrefix, const CStringDictionary::TStringId structMemberNameId);
+    std::string getStructMemberBrowsePath(std::string &paBrowsePathPrefix, const CStringDictionary::TStringId structMemberNameId);
+
+    /**
+     * Creates an OPC UA namespace with the given name and assigns the 
+     * namespace index to the mOpcuaNamespaceIndex member variable.
+     * @param nsName The name of the OPC UA Namespace
+     * @return true if namespace was successfully created or if it already exists, false otherwise
+    */
+    bool createOPCUANamespace(char* nsName);
 
     bool defineOPCUAStructTypeNode(UA_Server *paServer, UA_NodeId &paNodeId, const std::string &paStructTypeName);
 
     bool addOPCUAStructTypeComponent(UA_Server *paServer, UA_NodeId &paParentNodeId, CIEC_ANY *paStructMember, const std::string &paStructMemberName);
-
 };

--- a/src/com/opc_ua/opcua_objectstruct_helper.h
+++ b/src/com/opc_ua/opcua_objectstruct_helper.h
@@ -16,7 +16,6 @@
 #include "opcua_layer.h"
 #include <memory>
 
-// class COPC_UA_Layer;
 class COPC_UA_HandlerAbstract;
 class CActionInfo;
 

--- a/src/stdfblib/ita/CMakeLists.txt
+++ b/src/stdfblib/ita/CMakeLists.txt
@@ -19,7 +19,7 @@ SET(SOURCE_GROUP ${SOURCE_GROUP}\\ita)
 forte_add_sourcefile_hcpp(DEV_MGR  EMB_RES  RMT_DEV  RMT_RES)
 
 if (FORTE_COM_OPC_UA)
-  forte_add_sourcefile_hcpp(OPCUA_DEV OPCUA_MGR)
+  forte_add_sourcefile_hcpp(OPCUA_DEV OPCUA_MGR Config_EMB_RES)
 endif (FORTE_COM_OPC_UA)
 
 forte_add_include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/stdfblib/ita/Config_EMB_RES.cpp
+++ b/src/stdfblib/ita/Config_EMB_RES.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Markus Meingast
+ *    - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+#include <stringdict.h>
+#include "Config_EMB_RES.h"
+#ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
+#include "Config_EMB_RES_gen.cpp"
+#endif
+
+DEFINE_FIRMWARE_FB(Config_EMB_RES, g_nStringIdConfig_EMB_RES);
+
+const CStringDictionary::TStringId Config_EMB_RES::scmVarInputNameIds[] = {g_nStringIdOPCUA_Namespace};
+const CStringDictionary::TStringId Config_EMB_RES::scmDIDataTypeIds[] = {g_nStringIdWSTRING};
+
+const SFBInterfaceSpec Config_EMB_RES::scmFBInterfaceSpec = {
+  0, nullptr, nullptr, nullptr,
+  0, nullptr, nullptr, nullptr,
+  1, scmVarInputNameIds, scmDIDataTypeIds,
+  0, nullptr, nullptr,
+  0, nullptr,
+  0, nullptr
+};
+
+Config_EMB_RES::Config_EMB_RES(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paDevice) :
+    EMB_RES(paInstanceNameId, paDevice) {
+      mInterfaceSpec = &scmFBInterfaceSpec;
+}
+
+Config_EMB_RES::~Config_EMB_RES() = default;

--- a/src/stdfblib/ita/Config_EMB_RES.h
+++ b/src/stdfblib/ita/Config_EMB_RES.h
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Markus Meingast
+ *    - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+#pragma once
+
+#include "EMB_RES.h"
+
+class Config_EMB_RES : public EMB_RES {
+  DECLARE_FIRMWARE_FB(Config_EMB_RES);
+
+  public:
+    Config_EMB_RES(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paDevice);
+    ~Config_EMB_RES() override;
+
+  private:
+    static const SFBInterfaceSpec scmFBInterfaceSpec;
+
+    static const CStringDictionary::TStringId scmVarInputNameIds[];
+    static const CStringDictionary::TStringId scmDIDataTypeIds[];
+};


### PR DESCRIPTION
- Refactored handling of default OPC UA namespace
- Added Config_EMB_RES class with an input parameter to specify the OPC UA namespace
- Create namespace according to this Resource input parameter and assign every created Struct Type to it, if it has a value