### PR TITLE
Add FB GetInstancePathAndName

### DIFF
--- a/src/modules/utils/CMakeLists.txt
+++ b/src/modules/utils/CMakeLists.txt
@@ -16,7 +16,7 @@ forte_add_module(UTILS OFF "FORTE UTILITY FBs")
 # FORTE UTILITY FBs
 #############################################################################
 
-forte_add_sourcefile_hcpp(E_STOPWATCH GetInstancePath_fbt)
+forte_add_sourcefile_hcpp(E_STOPWATCH GetInstancePath_fbt GetInstancePathAndName_fbt)
 forte_add_sourcefile_hcpp(OUT_ANY_CONSOLE GEN_F_MUX GEN_CSV_WRITER)
 forte_add_sourcefile_hcpp(GEN_ARRAY2VALUES GEN_VALUES2ARRAY GEN_ARRAY2ARRAY GET_AT_INDEX SET_AT_INDEX)
 forte_add_sourcefile_hcpp(FB_RANDOM GET_STRUCT_VALUE SET_STRUCT_VALUE)

--- a/src/modules/utils/GetInstancePathAndName_fbt.cpp
+++ b/src/modules/utils/GetInstancePathAndName_fbt.cpp
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Ernst Blecha - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+
+#include "GetInstancePathAndName_fbt.h"
+#ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
+#include "GetInstancePathAndName_fbt_gen.cpp"
+#endif
+
+#include "criticalregion.h"
+#include "resource.h"
+#include "forte_char.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
+
+DEFINE_FIRMWARE_FB(FORTE_GetInstancePathAndName, g_nStringIdGetInstancePathAndName)
+
+const CStringDictionary::TStringId FORTE_GetInstancePathAndName::scmDataInputNames[] = {g_nStringIdSep};
+const CStringDictionary::TStringId FORTE_GetInstancePathAndName::scmDataInputTypeIds[] = {g_nStringIdCHAR};
+const CStringDictionary::TStringId FORTE_GetInstancePathAndName::scmDataOutputNames[] = {g_nStringIdPath, g_nStringIdName};
+const CStringDictionary::TStringId FORTE_GetInstancePathAndName::scmDataOutputTypeIds[] = {g_nStringIdSTRING, g_nStringIdSTRING};
+const TDataIOID FORTE_GetInstancePathAndName::scmEIWith[] = {0, scmWithListDelimiter};
+const TForteInt16 FORTE_GetInstancePathAndName::scmEIWithIndexes[] = {0};
+const CStringDictionary::TStringId FORTE_GetInstancePathAndName::scmEventInputNames[] = {g_nStringIdREQ};
+const TDataIOID FORTE_GetInstancePathAndName::scmEOWith[] = {0, 1, scmWithListDelimiter};
+const TForteInt16 FORTE_GetInstancePathAndName::scmEOWithIndexes[] = {0};
+const CStringDictionary::TStringId FORTE_GetInstancePathAndName::scmEventOutputNames[] = {g_nStringIdCNF};
+const SFBInterfaceSpec FORTE_GetInstancePathAndName::scmFBInterfaceSpec = {
+  1, scmEventInputNames, scmEIWith, scmEIWithIndexes,
+  1, scmEventOutputNames, scmEOWith, scmEOWithIndexes,
+  1, scmDataInputNames, scmDataInputTypeIds,
+  2, scmDataOutputNames, scmDataOutputTypeIds,
+  0, nullptr,
+  0, nullptr
+};
+
+FORTE_GetInstancePathAndName::FORTE_GetInstancePathAndName(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+    CSimpleFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId, nullptr),
+    var_Sep(0x2f_CHAR),
+    var_conn_Path(var_Path),
+    var_conn_Name(var_Name),
+    conn_CNF(this, 0),
+    conn_Sep(nullptr),
+    conn_Path(this, 0, &var_conn_Path),
+    conn_Name(this, 1, &var_conn_Name) {
+}
+
+void FORTE_GetInstancePathAndName::setInitialValues() {
+  var_Sep = 0x2f_CHAR;
+  var_Path = ""_STRING;
+  var_Name = ""_STRING;
+}
+
+void FORTE_GetInstancePathAndName::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
+  switch(paEIID) {
+    case scmEventREQID:
+      alg_REQ();
+      break;
+    default:
+      break;
+  }
+  sendOutputEvent(scmEventCNFID, paECET);
+}
+
+void FORTE_GetInstancePathAndName::readInputData(const TEventID paEIID) {
+  switch(paEIID) {
+    case scmEventREQID: {
+      readData(0, var_Sep, conn_Sep);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void FORTE_GetInstancePathAndName::writeOutputData(const TEventID paEIID) {
+  switch(paEIID) {
+    case scmEventCNFID: {
+      writeData(0, var_Path, conn_Path);
+      writeData(1, var_Name, conn_Name);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+CIEC_ANY *FORTE_GetInstancePathAndName::getDI(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_Sep;
+  }
+  return nullptr;
+}
+
+CIEC_ANY *FORTE_GetInstancePathAndName::getDO(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_Path;
+    case 1: return &var_Name;
+  }
+  return nullptr;
+}
+
+CEventConnection *FORTE_GetInstancePathAndName::getEOConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_CNF;
+  }
+  return nullptr;
+}
+
+CDataConnection **FORTE_GetInstancePathAndName::getDIConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_Sep;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_GetInstancePathAndName::getDOConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_Path;
+    case 1: return &conn_Name;
+  }
+  return nullptr;
+}
+
+CIEC_ANY *FORTE_GetInstancePathAndName::getVarInternal(size_t) {
+  return nullptr;
+}
+
+void FORTE_GetInstancePathAndName::alg_REQ(void) {
+  var_Path = CIEC_STRING(getContainer().getFullQualifiedApplicationInstanceName(var_Sep.operator TForteChar()));
+  var_Name = CIEC_STRING(getInstanceName());
+}
+

--- a/src/modules/utils/GetInstancePathAndName_fbt.h
+++ b/src/modules/utils/GetInstancePathAndName_fbt.h
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Ernst Blecha - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#pragma once
+
+#include "simplefb.h"
+#include "forte_char.h"
+#include "forte_string.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
+
+
+class FORTE_GetInstancePathAndName final : public CSimpleFB {
+  DECLARE_FIRMWARE_FB(FORTE_GetInstancePathAndName)
+
+  private:
+    static const CStringDictionary::TStringId scmDataInputNames[];
+    static const CStringDictionary::TStringId scmDataInputTypeIds[];
+    static const CStringDictionary::TStringId scmDataOutputNames[];
+    static const CStringDictionary::TStringId scmDataOutputTypeIds[];
+    static const TEventID scmEventREQID = 0;
+    static const TDataIOID scmEIWith[];
+    static const TForteInt16 scmEIWithIndexes[];
+    static const CStringDictionary::TStringId scmEventInputNames[];
+    static const TEventID scmEventCNFID = 0;
+    static const TDataIOID scmEOWith[];
+    static const TForteInt16 scmEOWithIndexes[];
+    static const CStringDictionary::TStringId scmEventOutputNames[];
+
+    static const SFBInterfaceSpec scmFBInterfaceSpec;
+
+    CIEC_ANY *getVarInternal(size_t) override;
+
+    void alg_REQ(void);
+
+    void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+    void readInputData(TEventID paEIID) override;
+    void writeOutputData(TEventID paEIID) override;
+    void setInitialValues() override;
+
+  public:
+    FORTE_GetInstancePathAndName(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+
+    CIEC_CHAR var_Sep;
+
+    CIEC_STRING var_Path;
+    CIEC_STRING var_Name;
+
+    CIEC_STRING var_conn_Path;
+    CIEC_STRING var_conn_Name;
+
+    CEventConnection conn_CNF;
+
+    CDataConnection *conn_Sep;
+
+    CDataConnection conn_Path;
+    CDataConnection conn_Name;
+
+    CIEC_ANY *getDI(size_t) override;
+    CIEC_ANY *getDO(size_t) override;
+    CEventConnection *getEOConUnchecked(TPortId) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+    CDataConnection *getDOConUnchecked(TPortId) override;
+
+    void evt_REQ(const CIEC_CHAR &paSep, CIEC_STRING &paPath, CIEC_STRING &paName) {
+      var_Sep = paSep;
+      executeEvent(scmEventREQID, nullptr);
+      paPath = var_Path;
+      paName = var_Name;
+    }
+
+    void operator()(const CIEC_CHAR &paSep, CIEC_STRING &paPath, CIEC_STRING &paName) {
+      evt_REQ(paSep, paPath, paName);
+    }
+};
+
+


### PR DESCRIPTION
Adds cpp and h files for a new FB in Utils that offers the InstancePath and InstanceName of the respective instance

Respective IDE changes in https://github.com/eclipse-4diac/4diac-ide/pull/61