### PR TITLE
String NodeIds for OPC UA Struct Objects

### DIFF
--- a/src/com/opc_ua/opcua_local_handler.h
+++ b/src/com/opc_ua/opcua_local_handler.h
@@ -87,6 +87,11 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      */
     UA_StatusCode initializeActionForObjectStruct(std::shared_ptr<CActionInfo> &paActionInfo, CIEC_ANY &paMember);
 
+    /**
+     * Default value for the namespace of the browsename for all created nodes
+     */
+    static const UA_UInt16 scmDefaultBrowsenameNameSpace = 1;
+
   protected:
 
     /**
@@ -678,11 +683,6 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      * @return The method call. 0 if an external call for the action was not triggered
      */
     CLocalMethodCall* getLocalMethodCall(const CLocalMethodInfo &paActionInfo);
-
-    /**
-     * Default value for the namespace of the browsename for all created nodes
-     */
-    static const UA_UInt16 scmDefaultBrowsenameNameSpace = 1;
 
     /**
      * English locale used as default for all nodes

--- a/src/com/opc_ua/opcua_objectstruct_helper.cpp
+++ b/src/com/opc_ua/opcua_objectstruct_helper.cpp
@@ -30,7 +30,8 @@ const std::string COPC_UA_ObjectStruct_Helper::smMemberNamespaceIndex = "/%d:";
 char COPC_UA_ObjectStruct_Helper::smEmptyString[] = "";
 
 COPC_UA_ObjectStruct_Helper::COPC_UA_ObjectStruct_Helper(COPC_UA_Layer &paLayer, COPC_UA_HandlerAbstract *paHandler):
-  mLayer(paLayer), mHandler(paHandler), mOpcuaTypeNamespaceIndex(COPC_UA_Local_Handler::scmDefaultBrowsenameNameSpace) {
+  mLayer(paLayer), mHandler(paHandler), mOpcuaTypeNamespaceIndex(COPC_UA_Local_Handler::scmDefaultBrowsenameNameSpace),
+  mOpcuaObjectNamespaceIndex(COPC_UA_Local_Handler::scmDefaultBrowsenameNameSpace) {
 }
 
 COPC_UA_ObjectStruct_Helper::~COPC_UA_ObjectStruct_Helper() {
@@ -152,13 +153,6 @@ bool COPC_UA_ObjectStruct_Helper::addOPCUAStructTypeComponent(UA_Server *paServe
   mStructTypeMemberNodes.push_back(memberNodeId);
   if(status != UA_STATUSCODE_GOOD) {
     DEVLOG_ERROR("[OPC UA OBJECT STRUCT HELPER]: Failed to add Member to OPC UA Struct Type Node for Member %s, Status Code: %s\n", paStructMemberName.c_str(), UA_StatusCode_name(status));
-    return false;
-  }
-  status = UA_Server_addReference(paServer, memberNodeId,
-      UA_NODEID_NUMERIC(0, UA_NS0ID_HASMODELLINGRULE),
-      UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_MODELLINGRULE_MANDATORY), true);
-  if(status != UA_STATUSCODE_GOOD) {
-    DEVLOG_ERROR("[OPC UA OBJECT STRUCT HELPER]: Failed to add OPC UA reference to Struct Member %s, Status Code: %s\n", paStructMemberName.c_str(), UA_StatusCode_name(status));
     return false;
   }
   return true;
@@ -329,7 +323,7 @@ std::string COPC_UA_ObjectStruct_Helper::getStructBrowsePath(const std::string &
 std::string COPC_UA_ObjectStruct_Helper::getStructMemberBrowsePath(std::string &paBrowsePathPrefix, const CStringDictionary::TStringId structMemberNameId) {
   std::stringstream ss;
   char buf[100];
-  snprintf(buf, sizeof(buf), smMemberNamespaceIndex.c_str(), mOpcuaTypeNamespaceIndex);
+  snprintf(buf, sizeof(buf), smMemberNamespaceIndex.c_str(), mOpcuaObjectNamespaceIndex);
   ss << paBrowsePathPrefix << buf << CStringDictionary::getInstance().get(structMemberNameId);
   return ss.str();
 }

--- a/src/com/opc_ua/opcua_objectstruct_helper.cpp
+++ b/src/com/opc_ua/opcua_objectstruct_helper.cpp
@@ -30,7 +30,7 @@ const std::string COPC_UA_ObjectStruct_Helper::smMemberNamespaceIndex = "/%d:";
 char COPC_UA_ObjectStruct_Helper::smEmptyString[] = "";
 
 COPC_UA_ObjectStruct_Helper::COPC_UA_ObjectStruct_Helper(COPC_UA_Layer &paLayer, COPC_UA_HandlerAbstract *paHandler):
-  mLayer(paLayer), mHandler(paHandler), mOpcuaTypeNamespaceIndex(1) {
+  mLayer(paLayer), mHandler(paHandler), mOpcuaTypeNamespaceIndex(COPC_UA_Local_Handler::scmDefaultBrowsenameNameSpace) {
 }
 
 COPC_UA_ObjectStruct_Helper::~COPC_UA_ObjectStruct_Helper() {

--- a/src/com/opc_ua/opcua_objectstruct_helper.h
+++ b/src/com/opc_ua/opcua_objectstruct_helper.h
@@ -116,6 +116,12 @@ class COPC_UA_ObjectStruct_Helper {
     UA_UInt16 mOpcuaTypeNamespaceIndex;
 
     /**
+     * OPC UA Object Struct Instance Namespace Index.
+     * The default NamespaceIndex is 1.
+    */
+    UA_UInt16 mOpcuaObjectNamespaceIndex;
+
+    /**
      * BrowsePath to folder that contains Object Node Struct Types
      */
      static const std::string smStructTypesBrowsePath;
@@ -205,7 +211,7 @@ class COPC_UA_ObjectStruct_Helper {
 
     /**
      * Creates an OPC UA namespace with the given name and assigns the 
-     * namespace index to the mOpcuaNamespaceIndex member variable.
+     * namespace index to the mOpcuaTypeNamespaceIndex member variable.
      * @param nsName The name of the OPC UA Namespace
      * @return true if namespace was successfully created or if it already exists, false otherwise
     */

--- a/src/com/opc_ua/opcua_objectstruct_helper.h
+++ b/src/com/opc_ua/opcua_objectstruct_helper.h
@@ -220,4 +220,25 @@ class COPC_UA_ObjectStruct_Helper {
     bool defineOPCUAStructTypeNode(UA_Server *paServer, UA_NodeId &paNodeId, const std::string &paStructTypeName);
 
     bool addOPCUAStructTypeComponent(UA_Server *paServer, UA_NodeId &paParentNodeId, CIEC_ANY *paStructMember, const std::string &paStructMemberName);
+
+    /**
+     * Creates NodeId of type string from the given browsepath
+     * @param paBrowsePath The browsepath of the Object Struct
+     * @return The NodeId of type string 
+    */
+    static UA_NodeId *createStringNodeIdFromBrowsepath(const std::string& paBrowsePath);
+
+    /**
+     * Returns the namespace index of the Object Struct Instance from the given browsepath
+     * @param paBrowsePath The browsepath of the Object Struct
+     * @return The namespace index of the Object Struct
+    */
+    static UA_UInt16 getNamespaceIndexFromBrowsepath(const std::string& paBrowsePath);
+
+    /**
+     * Removes any present namespace indices from the browsepath.
+     * @param paBrowsePath The browsepath of the Object Struct
+     * @return The browsepath without any namespace indices
+    */
+    static std::string removeNamespaceIndicesFromBrowsePath(const std::string& paBrowsePath);
 };

--- a/src/com/opc_ua/opcua_objectstruct_helper.h
+++ b/src/com/opc_ua/opcua_objectstruct_helper.h
@@ -110,10 +110,10 @@ class COPC_UA_ObjectStruct_Helper {
     COPC_UA_HandlerAbstract *mHandler;
 
     /**
-     * OPC UA Object Struct Namespace Index.
+     * OPC UA Object Struct Type Namespace Index.
      * The default NamespaceIndex is 1.
     */
-    UA_UInt16 mOpcuaNamespaceIndex;
+    UA_UInt16 mOpcuaTypeNamespaceIndex;
 
     /**
      * BrowsePath to folder that contains Object Node Struct Types
@@ -133,6 +133,16 @@ class COPC_UA_ObjectStruct_Helper {
      * Pointer to ActionInfo for created OPC UA Struct Object Node
      */
     std::shared_ptr<CActionInfo> mCreateNodeActionInfo;
+
+    /**
+     * String NodeIds of OPCUA Struct Type Nodes 
+    */
+    std::vector<UA_NodeId> mStructTypeNodes;
+
+    /**
+     * String NodeIds of OPCUA Struct Type Member Nodes 
+    */
+    std::vector<UA_NodeId> mStructTypeMemberNodes;
 
     /**
      * ActionInfos of Struct members 


### PR DESCRIPTION
String NodeIds for Struct Types and Struct Object Instances.
Removed "Mandatory" Modelling rule for Struct Type members because otherwise the handler will create another set of members for the struct object instance when providing a string nodeId.