### PR TITLE
OPC DA: Fix memory leaks

### DIFF
--- a/src/com/opc/opccomlayer.cpp
+++ b/src/com/opc/opccomlayer.cpp
@@ -38,9 +38,13 @@ COpcComLayer::~COpcComLayer(){
   for(auto &it :mFBInputVars){
     delete it;
   }
+  //clear vector and remove it from memory
+  TOpcProcessVarList().swap(mFBInputVars);
   for(auto &it :mFBOutputVars){
     delete it;
   }
+  //clear vector and remove it from memory
+  TOpcProcessVarList().swap(mFBOutputVars);
 }
 
 EComResponse COpcComLayer::sendData(void *paData, unsigned int paSize){

--- a/src/com/opc/opcconnectionhandler.cpp
+++ b/src/com/opc/opcconnectionhandler.cpp
@@ -31,6 +31,7 @@ COpcConnectionHandler::~COpcConnectionHandler(){
   for(TOpcConnectionList::Iterator it = mOpcConnectionList.begin(); it != itEnd; ++it){
     delete (*it);
   }
+  mOpcConnectionList.clearAll();
 }
 
 COpcConnection* COpcConnectionHandler::getOpcConnection(const std::string& paHost, const std::string& paServerName, CComLayer* paComCallback){

--- a/src/com/opc/opceventhandler.cpp
+++ b/src/com/opc/opceventhandler.cpp
@@ -44,11 +44,14 @@ void COpcEventHandler::clearCommandQueue(){
       delete nextCommand;
     }
   }
+  mCommandQueue.clearAll();
 
   for(TCallbackList::iterator itRunner = mComCallbacks.begin(); itRunner != mComCallbacks.end(); ++itRunner){
     DEVLOG_ERROR("erase from command callback\n");
     mComCallbacks.erase(itRunner);
   }
+  //clear vector and remove it from memory
+  TCallbackList().swap(mComCallbacks);
 }
 
 void COpcEventHandler::executeCommandQueue(){
@@ -60,6 +63,7 @@ void COpcEventHandler::executeCommandQueue(){
       nextCommand = nullptr;
     }
   }
+  mCommandQueue.clearAll();
 }
 
 void COpcEventHandler::sendCommand(ICmd *paCmd){
@@ -97,6 +101,10 @@ void COpcEventHandler::removeComCallback(COpcEventHandler::TCallbackDescriptor p
       mComCallbacks.erase(itRunner);
       break; 
     }
+  }
+  if(mComCallbacks.empty()){
+    //no content, remove vector from memory
+    TCallbackList().swap(mComCallbacks);
   }
 }
 


### PR DESCRIPTION
Not using an advance profiler but FORTE with OPC DA module only enabled for read 4 items Moxa OPC server, memory consumption on Task Manager slowly increase every time a new OPC data arrived. For about 16 hours, memory consumption increase from < 3MB to > 5MB. This issue only appears to occurs on Windows 7, no problem on Windows 11.