### PR TITLE
Cleanup of raw pointers in CNodePairInfo

### DIFF
--- a/src/com/opc_ua/opcua_action_info.h
+++ b/src/com/opc_ua/opcua_action_info.h
@@ -56,7 +56,7 @@ class CActionInfo {
           return mNodeId.get();
         }
 
-        void setNodeId(UA_NodeId * paNodeId){
+        void setNodeId(UA_NodeId *paNodeId){
           mNodeId.reset(paNodeId);
         }
 

--- a/src/com/opc_ua/opcua_client_information.cpp
+++ b/src/com/opc_ua/opcua_client_information.cpp
@@ -337,7 +337,7 @@ bool CUA_ClientInformation::initializeAction(CActionInfo& paActionInfo) {
             runnerHelper, paActionInfo.getLayer().getCommFB()->getInstanceName(), UA_StatusCode_name(retVal));
           somethingFailed = true;
         } else {
-          if(itNodePair->getNodeId()) {
+          if(itNodePair->getNodeId() != nullptr) {
             if(!UA_NodeId_equal(itNodePair->getNodeId(), nodeId)) { //if NodeId was provided, check if found is the same
               DEVLOG_ERROR("[OPC UA CLIENT]: The call from FB %s failed the found nodeId of the method doesn't match the provided one\n",
                 paActionInfo.getLayer().getCommFB()->getInstanceName());
@@ -374,7 +374,7 @@ bool CUA_ClientInformation::initializeCallMethod(CActionInfo& paActionInfo) {
       paActionInfo.getLayer().getCommFB()->getInstanceName(), UA_StatusCode_name(retVal));
     somethingFailed = true;
   } else {
-    if(itNodePair->getNodeId()) {
+    if(itNodePair->getNodeId() != nullptr) {
       if(!UA_NodeId_equal(itNodePair->getNodeId(), methodNode)) { //if NodeId of method was provided, check if found is the same
         DEVLOG_ERROR("[OPC UA CLIENT]: The method call from FB %s failed the found nodeId of the method doesn't match the provided one\n",
           paActionInfo.getLayer().getCommFB()->getInstanceName());

--- a/src/com/opc_ua/opcua_local_handler.cpp
+++ b/src/com/opc_ua/opcua_local_handler.cpp
@@ -908,9 +908,9 @@ UA_StatusCode COPC_UA_Local_Handler::initializeCreateNode(CActionInfo &paActionI
   //The main process is done in the execution
   UA_StatusCode retVal = UA_STATUSCODE_GOOD;
 
-  auto& instance = paActionInfo.getNodePairInfo().back();
+  auto& nodePair = paActionInfo.getNodePairInfo().back();
 
-  if(instance.getBrowsePath().empty()) { //the browsename of the instance is mandatory
+  if(nodePair.getBrowsePath().empty()) { //the browsename of the instance is mandatory
     retVal = UA_STATUSCODE_BADINTERNALERROR;
     DEVLOG_ERROR("[OPC UA LOCAL]: The BrowsePath of the instance is mandatory for creating a node at FB %s. Error: %s\n",
       paActionInfo.getLayer().getCommFB()->getInstanceName(), UA_StatusCode_name(retVal));
@@ -1076,22 +1076,22 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateVariable(CActionInfo &paAction
     //look for data value type
     if(isNodePresent(*itDataValueTypeNodePairInfo)) {
 
-      auto& instance = paActionInfo.getNodePairInfo().back();
+      auto& nodePair = paActionInfo.getNodePairInfo().back();
 
       CSinglyLinkedList<UA_NodeId*> referencedNodes;
       bool nodeExists = false;
-      //check if an instance is already present
-      retVal = getNode(instance, referencedNodes, &nodeExists);
+      //check if a nodePair is already present
+      retVal = getNode(nodePair, referencedNodes, &nodeExists);
 
       if(UA_STATUSCODE_GOOD == retVal) {
         if(!nodeExists) {
 
           std::string nodeName;
-          retVal = splitAndCreateFolders(instance.getBrowsePath(), nodeName, referencedNodes);
+          retVal = splitAndCreateFolders(nodePair.getBrowsePath(), nodeName, referencedNodes);
           if(UA_STATUSCODE_GOOD == retVal) {
             CCreateVariableInfo createInformation;
 
-            initializeCreateInfo(nodeName, instance, referencedNodes.isEmpty() ? nullptr : *(referencedNodes.back()), createInformation);
+            initializeCreateInfo(nodeName, nodePair, referencedNodes.isEmpty() ? nullptr : *(referencedNodes.back()), createInformation);
             createInformation.mVariableTypeNodeId = itVariableTypeNodePairInfo->getNodeId();
             const UA_NodeId *dataValueTypeNodeId = itDataValueTypeNodePairInfo->getNodeId();
 

--- a/src/com/opc_ua/opcua_local_handler.cpp
+++ b/src/com/opc_ua/opcua_local_handler.cpp
@@ -598,7 +598,7 @@ UA_StatusCode COPC_UA_Local_Handler::handleNonExistingVariable(CActionInfo &paAc
       if(!paWrite) {
         retVal = registerVariableCallBack(*variableInformation.mReturnedNodeId, paActionInfo, paIndexOfNodePair);
       }
-      if(UA_STATUSCODE_GOOD == retVal && !paNodePairInfo.getNodeId()) {
+      if(UA_STATUSCODE_GOOD == retVal && paNodePairInfo.getNodeId() == nullptr) {
         paNodePairInfo.setNodeId(UA_NodeId_new());
         UA_NodeId_copy(variableInformation.mReturnedNodeId, paNodePairInfo.getNodeId());
       }
@@ -759,7 +759,7 @@ UA_StatusCode COPC_UA_Local_Handler::initializeCreateMethod(CActionInfo &paActio
 
         createMethodArguments(paActionInfo, methodInformation);
 
-        UA_NodeId* result;
+        UA_NodeId* result = nullptr;
         retVal = createMethodNode(methodInformation, &result);
         if(UA_STATUSCODE_GOOD == retVal) {
           itMethodNodePairInfo->setNodeId(result);
@@ -1199,7 +1199,7 @@ UA_StatusCode COPC_UA_Local_Handler::getNode(CActionInfo::CNodePairInfo &paNodeP
     if(UA_STATUSCODE_GOOD == retVal) {
       if(firstNonExistingNode == pathCount) { //all nodes exist
         *paIsPresent = true;
-        if(paNodePairInfo.getNodeId()) { //nodeID was provided
+        if(paNodePairInfo.getNodeId() != nullptr) { //nodeID was provided
           if(!UA_NodeId_equal(paNodePairInfo.getNodeId(), *existingNodeIds.back())) {
             *paIsPresent = false; // the found Node has not the same NodeId.
           }


### PR DESCRIPTION
Just removing some raw pointers and using `unique_ptr` or objects directly.

It makes memory handling safer and keep destructors empty.

The major change is in `class CNodePairInfo`. The rest is refactoring the code to make it work