### PR TITLE
Add test to ctf tracer and helper classses 

### DIFF
--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -28,3 +28,7 @@ forte_test_add_subdirectory(datatypes)
 forte_test_add_subdirectory(cominfra)
 forte_test_add_subdirectory(fbtests)
 forte_test_add_subdirectory(utils)
+
+if(FORTE_TRACE_CTF)
+  forte_test_add_subdirectory(trace)
+endif(FORTE_TRACE_CTF)

--- a/tests/core/trace/CMakeLists.txt
+++ b/tests/core/trace/CMakeLists.txt
@@ -13,5 +13,7 @@ SET(SOURCE_GROUP ${SOURCE_GROUP}\\trace)
 
 forte_test_add_sourcefile_cpp(ctfTracerTest.cpp)
 forte_test_add_sourcefile_cpp(TraceReaderSink.cpp)
+forte_test_add_sourcefile_cpp(EventMessage.cpp)
+
 
 forte_add_link_library(babeltrace2)

--- a/tests/core/trace/CMakeLists.txt
+++ b/tests/core/trace/CMakeLists.txt
@@ -9,11 +9,25 @@
 # Contributors:
 #    Jose Cabral  - initial API and implementation and/or initial documentation
 # *******************************************************************************/
-SET(SOURCE_GROUP ${SOURCE_GROUP}\\trace)
-
-forte_test_add_sourcefile_cpp(ctfTracerTest.cpp)
-forte_test_add_sourcefile_cpp(TraceReaderSink.cpp)
-forte_test_add_sourcefile_cpp(EventMessage.cpp)
 
 
-forte_add_link_library(babeltrace2)
+# an extra CMake variable is added since test tracing requires extra libraries which
+# need to be compiled and might be too cumbersome
+SET(FORTE_TRACE_CTF_TEST OFF CACHE BOOL "Include CTF trace tests")
+mark_as_advanced(FORTE_TRACE_CTF_TEST)
+if(FORTE_TRACE_CTF_TEST)
+
+  SET(SOURCE_GROUP ${SOURCE_GROUP}\\trace)
+
+
+  forte_test_add_sourcefile_cpp(ctfTracerTest.cpp)
+  forte_test_add_sourcefile_cpp(TraceReaderSink.cpp)
+  forte_test_add_sourcefile_cpp(EventMessage.cpp)
+
+  forte_add_link_library(babeltrace2)
+
+  SET(CTF_OUTPUT_DIR ${CMAKE_BINARY_DIR}/ctfOutput)
+  SET(METADATA_FILE ${CMAKE_BINARY_DIR}/src/core/trace/metadata)
+
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_BINARY_DIR}/config.h)
+endif(FORTE_TRACE_CTF_TEST)

--- a/tests/core/trace/CMakeLists.txt
+++ b/tests/core/trace/CMakeLists.txt
@@ -1,0 +1,17 @@
+#*******************************************************************************
+# Copyright (c) 2024
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#    Jose Cabral  - initial API and implementation and/or initial documentation
+# *******************************************************************************/
+SET(SOURCE_GROUP ${SOURCE_GROUP}\\trace)
+
+forte_test_add_sourcefile_cpp(ctfTracerTest.cpp)
+forte_test_add_sourcefile_cpp(TraceReaderSink.cpp)
+
+forte_add_link_library(babeltrace2)

--- a/tests/core/trace/EventMessage.cpp
+++ b/tests/core/trace/EventMessage.cpp
@@ -1,0 +1,193 @@
+#include "EventMessage.h"
+#include <array>
+#include <iomanip>
+
+// ******************** //
+// EventMessage methods //
+// ******************** //
+
+EventMessage::EventMessage(const bt_message* message)  {
+    
+  // Borrow the event message's event and its class
+  const bt_event *event =
+    bt_message_event_borrow_event_const(message);
+  const bt_event_class *event_class = bt_event_borrow_class_const(event);
+
+  const bt_field *payload_field =
+      bt_event_borrow_payload_field_const(event);
+
+  mEventType = bt_event_class_get_name(event_class);
+  mPayload = PayloadFactory::createPayload(mEventType, payload_field);
+
+  if(mPayload == nullptr){
+    std::abort();
+  }
+
+  if(BT_CLOCK_SNAPSHOT_GET_NS_FROM_ORIGIN_STATUS_OK != 
+      bt_clock_snapshot_get_ns_from_origin(
+        bt_message_event_borrow_default_clock_snapshot_const(message), 
+        &mTimestamp)){
+    std::abort();
+  }	
+}
+
+std::string EventMessage::getPayloadString() const {
+  return mEventType + (mPayload != nullptr ? ": " + mPayload->getString() : "");
+}
+
+std::string EventMessage::getTimestampString() const {
+  auto nanoseconds = mTimestamp;
+  auto milliseconds = mTimestamp / 1000000;
+  
+  auto seconds = milliseconds / 1000;
+  auto minutes = seconds / 60;
+  auto hours = minutes / 60;
+
+  nanoseconds %= 1000000000;
+  seconds %= 60;
+  minutes %= 60;
+
+  std::stringstream ss;
+  ss << "[" << 
+      std::setw(2) << std::setfill('0') << hours + 1 << ":" <<
+      std::setw(2) << std::setfill('0') << minutes << ":" <<
+      std::setw(2) << std::setfill('0') << seconds << "." <<
+      std::setw(6) << std::setfill('0') << nanoseconds <<  "]";
+
+  return ss.str();
+}
+
+bool EventMessage::operator==(const EventMessage& other) const {
+  return mEventType == other.mEventType  
+    && (mPayload == nullptr) == (other.mPayload == nullptr)
+    && (mPayload != nullptr ? *mPayload == *other.mPayload : true);
+}
+
+// *********************** //
+// AbstractPayload Methods //
+// *********************** //
+
+AbstractPayload::AbstractPayload(const bt_field* field) {
+  auto const typeNameField = bt_field_structure_borrow_member_field_by_name_const(field, "typeName");
+  auto const instanceNameField = bt_field_structure_borrow_member_field_by_name_const(field, "instanceName");
+  
+  mTypeName = bt_field_string_get_value(typeNameField);
+  instanceName = bt_field_string_get_value(instanceNameField);
+}
+
+std::string AbstractPayload::getString() const {
+  return "{ typeName = \"" + mTypeName + "\", instanceName = \"" + instanceName + "\"" + specificPayloadString() + " }";
+}
+
+
+bool AbstractPayload::operator==(const AbstractPayload& other) const {
+  return mTypeName == other.mTypeName && instanceName == other.instanceName && specificPayloadEqual(other);
+}
+
+// ************** //
+// FBEventPayload //
+// ************** //
+
+FBEventPayload::FBEventPayload(const bt_field* field) : AbstractPayload(field){
+  eventId = bt_field_integer_unsigned_get_value(
+      bt_field_structure_borrow_member_field_by_name_const(field, "eventId"));
+}
+
+std::string FBEventPayload::specificPayloadString() const {
+  return ", eventId = " + std::to_string(eventId);
+}
+
+bool FBEventPayload::specificPayloadEqual(const AbstractPayload& other) const {
+  const auto& childInstance = dynamic_cast<const FBEventPayload&>(other); 
+  return eventId == childInstance.eventId;
+}
+
+// ************* //
+// FBDataPayload //
+// ************* //
+
+FBDataPayload::FBDataPayload(const bt_field* field) : AbstractPayload(field){
+  dataId = bt_field_integer_unsigned_get_value(
+      bt_field_structure_borrow_member_field_by_name_const(field, "dataId"));
+
+  value = bt_field_string_get_value(
+      bt_field_structure_borrow_member_field_by_name_const(field, "value"));
+}
+
+std::string FBDataPayload::specificPayloadString() const {
+  auto convertedString = value;
+
+  // add backslash to quoutes and double quotes
+  for(auto toReplace : {"\"", "\'"}){
+    for(auto pos = convertedString.find(toReplace); pos != std::string::npos; pos = convertedString.find(toReplace, pos + 2)){
+      convertedString.insert(pos, "\\");
+    }
+  }
+  return ", dataId = " + std::to_string(dataId) + ", value = \"" + convertedString + "\"";
+}
+
+bool FBDataPayload::specificPayloadEqual(const AbstractPayload& other) const {
+  const auto& childInstance = dynamic_cast<const FBDataPayload&>(other); 
+  return dataId == childInstance.dataId && value == childInstance.value;
+}
+
+// ********************* //
+// FBInstanceDataPayload //
+// ********************* //
+
+FBInstanceDataPayload::FBInstanceDataPayload(const bt_field* field) : AbstractPayload(field){
+
+  std::array<const char*, 4> fieldNames{"inputs", "outputs", "internal", "internalFB"};
+  std::array<std::vector<std::string>*, 4> storage = {&inputs, &outputs, &internal, &internalFB};
+
+  for(size_t fieldRunner = 0; fieldRunner < fieldNames.size(); fieldRunner++){
+    auto arrayField = bt_field_structure_borrow_member_field_by_name_const(field, fieldNames[fieldRunner]);
+    auto arrayLength = bt_field_array_get_length(arrayField);
+    for(decltype(arrayLength) dynamicArrayRunner = 0; dynamicArrayRunner < arrayLength; dynamicArrayRunner++) {
+      storage[fieldRunner]->emplace_back(bt_field_string_get_value(
+          bt_field_array_borrow_element_field_by_index_const(arrayField, dynamicArrayRunner)
+      ));
+    } 
+  }
+}
+  
+std::string FBInstanceDataPayload::specificPayloadString() const {
+
+  auto createStringFromVector = [](const std::vector<std::string>& vec) -> std::string {
+    std::string result = "[";
+    for(size_t i = 0; i < vec.size(); i++) {
+      if(i != 0) {
+        result += ",";
+      }
+      result += " [" + std::to_string(i) + "] = \"" + vec[i] + "\""; 
+    }
+    result += " ]";
+    return result;
+  };
+
+  return ", _inputs_len = " + std::to_string(inputs.size()) + ", inputs = " + createStringFromVector(inputs) +
+    ", _outputs_len = " + std::to_string(outputs.size()) + ", outputs = " + createStringFromVector(outputs) +
+    ", _internal_len = " + std::to_string(internal.size()) + ", internal = " + createStringFromVector(internal) +
+    ", _internalFB_len = " + std::to_string(internalFB.size()) + ", internalFB = " + createStringFromVector(internalFB);
+}
+
+bool FBInstanceDataPayload::specificPayloadEqual(const AbstractPayload& other) const {
+  const auto& childInstance = dynamic_cast<const FBInstanceDataPayload&>(other); 
+  return inputs == childInstance.inputs && outputs == childInstance.outputs && internal == childInstance.internal && internalFB == childInstance.internalFB;
+}
+
+// ************** //
+// PayloadFactory //
+// ************** //
+
+std::unique_ptr<AbstractPayload> PayloadFactory::createPayload(const std::string& eventType, const bt_field* field){
+  std::unique_ptr<AbstractPayload> result = nullptr;
+  if(eventType == "receiveInputEvent" || eventType == "sendOutputEvent") {
+    result.reset(new FBEventPayload(field));
+  } else if(eventType == "inputData" || eventType == "outputData") {
+    result.reset(new FBDataPayload(field));
+  } else if(eventType == "instanceData") {
+    result.reset(new FBInstanceDataPayload(field));
+  }
+  return result;
+}

--- a/tests/core/trace/EventMessage.h
+++ b/tests/core/trace/EventMessage.h
@@ -1,0 +1,220 @@
+
+#include <string>
+#include <memory>
+#include <array>
+
+#include <ostream>
+#include <iostream>
+#include <iomanip>
+
+#include <babeltrace2/babeltrace.h>
+
+class AbstractPayload {
+public:
+  AbstractPayload(const bt_field* field) {
+    auto const typeNameField = bt_field_structure_borrow_member_field_by_name_const(field, "typeName");
+    auto const instanceNameField = bt_field_structure_borrow_member_field_by_name_const(field, "instanceName");
+    
+    mTypeName = bt_field_string_get_value(typeNameField);
+    instanceName = bt_field_string_get_value(instanceNameField);
+  }
+  
+  virtual std::string getString() const {
+    return "{ typeName = \"" + mTypeName + "\", instanceName = \"" + instanceName + "\"" + specificPayloadString() + " }";
+  }
+
+
+  virtual bool operator==(const AbstractPayload& other) const {
+    return mTypeName == other.mTypeName && instanceName == other.instanceName && specificPayloadEqual(other);
+  }
+
+protected:
+  virtual bool specificPayloadEqual(const AbstractPayload& other) const = 0;
+
+  virtual std::string specificPayloadString() const = 0;
+
+  std::string mTypeName;
+  std::string instanceName;
+};
+
+class FBEventPayload : public AbstractPayload {
+public:
+  FBEventPayload(const bt_field* field) : AbstractPayload(field){
+    eventId = bt_field_integer_unsigned_get_value(
+        bt_field_structure_borrow_member_field_by_name_const(field, "eventId"));
+  }
+
+private:
+
+  std::string specificPayloadString() const {
+    return ", eventId = " + std::to_string(eventId);
+  }
+
+  bool specificPayloadEqual(const AbstractPayload& other) const {
+    const auto& childInstance = dynamic_cast<const FBEventPayload&>(other); 
+    return eventId == childInstance.eventId;
+  }
+ 
+  uint64_t eventId;
+};
+
+class FBDataPayload : public AbstractPayload {
+public:
+  FBDataPayload(const bt_field* field) : AbstractPayload(field){
+    dataId = bt_field_integer_unsigned_get_value(
+        bt_field_structure_borrow_member_field_by_name_const(field, "dataId"));
+
+    value = bt_field_string_get_value(
+        bt_field_structure_borrow_member_field_by_name_const(field, "value"));
+  }
+  
+private:
+  std::string specificPayloadString() const {
+    auto convertedString = value;
+
+    for(auto toReplace : {"\"", "\'"}){
+      for(auto pos = convertedString.find(toReplace); pos != std::string::npos; pos = convertedString.find(toReplace, pos + 2)){
+        convertedString.insert(pos, "\\");
+      }
+    }
+    return ", dataId = " + std::to_string(dataId) + ", value = \"" + convertedString + "\"";
+  }
+
+  bool specificPayloadEqual(const AbstractPayload& other) const {
+    const auto& childInstance = dynamic_cast<const FBDataPayload&>(other); 
+    return dataId == childInstance.dataId && value == childInstance.value;
+  }
+
+  uint64_t dataId;
+  std::string value;
+};
+
+class FBInstanceDataPayload : public AbstractPayload {
+public:
+  FBInstanceDataPayload(const bt_field* field) : AbstractPayload(field){
+
+    std::array<const char*, 4> fieldNames{"inputs", "outputs", "internal", "internalFB"};
+    std::array<std::vector<std::string>*, 4> storage = {&inputs, &outputs, &internal, &internalFB};
+
+    for(size_t fieldRunner = 0; fieldRunner < fieldNames.size(); fieldRunner++){
+      auto arrayField = bt_field_structure_borrow_member_field_by_name_const(field, fieldNames[fieldRunner]);
+      auto arrayLength = bt_field_array_get_length(arrayField);
+      for(decltype(arrayLength) dynamicArrayRunner = 0; dynamicArrayRunner < arrayLength; dynamicArrayRunner++) {
+        storage[fieldRunner]->emplace_back(bt_field_string_get_value(
+            bt_field_array_borrow_element_field_by_index_const(arrayField, dynamicArrayRunner)
+        ));
+      } 
+    }
+  }
+  
+private:
+  std::string specificPayloadString() const {
+
+    auto createStringFromVector = [](const std::vector<std::string>& vec) -> std::string {
+      std::string result = "[";
+      for(size_t i = 0; i < vec.size(); i++) {
+        if(i != 0) {
+          result += ",";
+        }
+        result += " [" + std::to_string(i) + "] = \"" + vec[i] + "\""; 
+      }
+      result += " ]";
+      return result;
+    };
+
+    return ", _inputs_len = " + std::to_string(inputs.size()) + ", inputs = " + createStringFromVector(inputs) +
+      ", _outputs_len = " + std::to_string(outputs.size()) + ", outputs = " + createStringFromVector(outputs) +
+      ", _internal_len = " + std::to_string(internal.size()) + ", internal = " + createStringFromVector(internal) +
+      ", _internalFB_len = " + std::to_string(internalFB.size()) + ", internalFB = " + createStringFromVector(internalFB);
+  }
+
+  bool specificPayloadEqual(const AbstractPayload& other) const {
+    const auto& childInstance = dynamic_cast<const FBInstanceDataPayload&>(other); 
+    return inputs == childInstance.inputs && outputs == childInstance.outputs && internal == childInstance.internal && internalFB == childInstance.internalFB;
+  }
+
+  std::vector<std::string> inputs;
+  std::vector<std::string> outputs;
+  std::vector<std::string> internal;
+  std::vector<std::string> internalFB;
+
+};
+
+class PayloadFactory {
+public:
+  static std::unique_ptr<AbstractPayload> createPayload(const std::string& eventType, const bt_field* field){
+    std::unique_ptr<AbstractPayload> result = nullptr;
+    if(eventType == "receiveInputEvent" || eventType == "sendOutputEvent") {
+      result.reset(new FBEventPayload(field));
+    } else if(eventType == "inputData" || eventType == "outputData") {
+      result.reset(new FBDataPayload(field));
+    } else if(eventType == "instanceData") {
+      result.reset(new FBInstanceDataPayload(field));
+    }
+    return result;
+  }
+};
+
+class EventMessage {
+public:
+  EventMessage(const bt_message* message)  {
+    
+    // Borrow the event message's event and its class
+    const bt_event *event =
+      bt_message_event_borrow_event_const(message);
+    const bt_event_class *event_class = bt_event_borrow_class_const(event);
+
+    const bt_field *payload_field =
+        bt_event_borrow_payload_field_const(event);
+
+    mEventType = bt_event_class_get_name(event_class);
+    mPayload = PayloadFactory::createPayload(mEventType, payload_field);
+ 
+    auto clockClass = bt_clock_snapshot_borrow_clock_class_const	(	bt_message_event_borrow_default_clock_snapshot_const(message));
+
+    if(BT_CLOCK_SNAPSHOT_GET_NS_FROM_ORIGIN_STATUS_OK != 
+        bt_clock_snapshot_get_ns_from_origin(
+          bt_message_event_borrow_default_clock_snapshot_const(message), 
+          &mTimestamp)){
+      mTimestamp = 0;
+    }	
+  }
+
+  std::string getString() const {
+    auto nanoseconds = mTimestamp;
+    auto milliseconds = mTimestamp / 1000000;
+    
+    auto seconds = milliseconds / 1000;
+    auto minutes = seconds / 60;
+    auto hours = minutes / 60;
+
+    nanoseconds %= 1000000000;
+    seconds %= 60;
+    minutes %= 60;
+
+    std::stringstream ss;
+    ss << "[" << 
+        std::setw(2) << std::setfill('0') << hours + 1 << ":" <<
+        std::setw(2) << std::setfill('0') << minutes << ":" <<
+        std::setw(2) << std::setfill('0') << seconds << "." <<
+        std::setw(6) << std::setfill('0') << nanoseconds <<  "] " << 
+        mEventType << (mPayload != nullptr ? ": " + mPayload->getString() : "");
+
+    return ss.str();
+  }
+
+  bool operator==(const EventMessage& other) const {
+    return mEventType == other.mEventType  
+      && (mPayload == nullptr) == (other.mPayload == nullptr)
+      && (mPayload != nullptr ? *mPayload == *other.mPayload : true);
+  }
+
+  bool isValidRecord() const {
+    return mPayload != nullptr;
+  }
+
+private:
+  std::string mEventType;
+  std::unique_ptr<AbstractPayload> mPayload;
+  int64_t mTimestamp;
+};

--- a/tests/core/trace/EventMessage.h
+++ b/tests/core/trace/EventMessage.h
@@ -11,6 +11,8 @@ class AbstractPayload;
 
 class EventMessage {
 public:
+  EventMessage(const std::string& paEventType, std::unique_ptr<AbstractPayload> paPayload, int64_t paTimestamp);
+
   EventMessage(const bt_message* message);
   
   std::string getPayloadString() const;
@@ -29,6 +31,8 @@ private:
 
 class AbstractPayload {
 public:
+  AbstractPayload(const std::string& paTypeName, const std::string& paInstanceName);
+
   AbstractPayload(const bt_field* field);
   
   virtual std::string getString() const;
@@ -41,13 +45,13 @@ protected:
   virtual std::string specificPayloadString() const = 0;
 
   std::string mTypeName;
-  std::string instanceName;
+  std::string mInstanceName;
 };
-
-
 
 class FBEventPayload : public AbstractPayload {
 public:
+  FBEventPayload(const std::string& paTypeName, const std::string& paInstanceName, const uint64_t eventId);
+
   FBEventPayload(const bt_field* field);
 
 private:
@@ -55,11 +59,13 @@ private:
 
   bool specificPayloadEqual(const AbstractPayload& other) const;
  
-  uint64_t eventId;
+  uint64_t mEventId;
 };
 
 class FBDataPayload : public AbstractPayload {
 public:
+  FBDataPayload(const std::string& paTypeName, const std::string& paInstanceName, uint64_t paDataId, const std::string& paValue);
+
   FBDataPayload(const bt_field* field);
 
 private:
@@ -67,12 +73,18 @@ private:
 
   bool specificPayloadEqual(const AbstractPayload& other) const;
 
-  uint64_t dataId;
-  std::string value;
+  uint64_t mDataId;
+  std::string mValue;
 };
 
 class FBInstanceDataPayload : public AbstractPayload {
 public:
+  FBInstanceDataPayload(const std::string& paTypeName, const std::string& paInstanceName, 
+        const std::vector<std::string>& paInputs,
+        const std::vector<std::string>& paOutputs,
+        const std::vector<std::string>& paInternal,
+        const std::vector<std::string>& paInternalFB);
+
   FBInstanceDataPayload(const bt_field* field);
   
 private:
@@ -80,17 +92,15 @@ private:
 
   bool specificPayloadEqual(const AbstractPayload& other) const;
 
-  std::vector<std::string> inputs;
-  std::vector<std::string> outputs;
-  std::vector<std::string> internal;
-  std::vector<std::string> internalFB;
+  std::vector<std::string> mInputs;
+  std::vector<std::string> mOutputs;
+  std::vector<std::string> mInternal;
+  std::vector<std::string> mInternalFB;
 };
 
 class PayloadFactory {
 public:
-  static std::unique_ptr<AbstractPayload> createPayload(const std::string& eventType, const bt_field* field);
+  static std::unique_ptr<AbstractPayload> createPayload(const std::string& paEventType, const bt_field* paField);
 };
-
-
 
 #endif //  _FORTE_TESTS_CORE_TRACE_EVENT_MESSAGE_H_

--- a/tests/core/trace/EventMessage.h
+++ b/tests/core/trace/EventMessage.h
@@ -1,32 +1,39 @@
+#ifndef _FORTE_TESTS_CORE_TRACE_EVENT_MESSAGE_H_
+#define _FORTE_TESTS_CORE_TRACE_EVENT_MESSAGE_H_
 
-#include <string>
 #include <memory>
-#include <array>
-
-#include <ostream>
-#include <iostream>
-#include <iomanip>
+#include <string>
+#include <vector>
 
 #include <babeltrace2/babeltrace.h>
 
+class AbstractPayload;
+
+class EventMessage {
+public:
+  EventMessage(const bt_message* message);
+  
+  std::string getPayloadString() const;
+
+  std::string getTimestampString() const;
+
+  int64_t getTimestamp () const { return mTimestamp;}
+
+  bool operator==(const EventMessage& other) const;
+
+private:
+  std::string mEventType;
+  std::unique_ptr<AbstractPayload> mPayload;
+  int64_t mTimestamp;
+};
+
 class AbstractPayload {
 public:
-  AbstractPayload(const bt_field* field) {
-    auto const typeNameField = bt_field_structure_borrow_member_field_by_name_const(field, "typeName");
-    auto const instanceNameField = bt_field_structure_borrow_member_field_by_name_const(field, "instanceName");
-    
-    mTypeName = bt_field_string_get_value(typeNameField);
-    instanceName = bt_field_string_get_value(instanceNameField);
-  }
+  AbstractPayload(const bt_field* field);
   
-  virtual std::string getString() const {
-    return "{ typeName = \"" + mTypeName + "\", instanceName = \"" + instanceName + "\"" + specificPayloadString() + " }";
-  }
+  virtual std::string getString() const;
 
-
-  virtual bool operator==(const AbstractPayload& other) const {
-    return mTypeName == other.mTypeName && instanceName == other.instanceName && specificPayloadEqual(other);
-  }
+  virtual bool operator==(const AbstractPayload& other) const;
 
 protected:
   virtual bool specificPayloadEqual(const AbstractPayload& other) const = 0;
@@ -37,53 +44,28 @@ protected:
   std::string instanceName;
 };
 
+
+
 class FBEventPayload : public AbstractPayload {
 public:
-  FBEventPayload(const bt_field* field) : AbstractPayload(field){
-    eventId = bt_field_integer_unsigned_get_value(
-        bt_field_structure_borrow_member_field_by_name_const(field, "eventId"));
-  }
+  FBEventPayload(const bt_field* field);
 
 private:
+  std::string specificPayloadString() const;
 
-  std::string specificPayloadString() const {
-    return ", eventId = " + std::to_string(eventId);
-  }
-
-  bool specificPayloadEqual(const AbstractPayload& other) const {
-    const auto& childInstance = dynamic_cast<const FBEventPayload&>(other); 
-    return eventId == childInstance.eventId;
-  }
+  bool specificPayloadEqual(const AbstractPayload& other) const;
  
   uint64_t eventId;
 };
 
 class FBDataPayload : public AbstractPayload {
 public:
-  FBDataPayload(const bt_field* field) : AbstractPayload(field){
-    dataId = bt_field_integer_unsigned_get_value(
-        bt_field_structure_borrow_member_field_by_name_const(field, "dataId"));
+  FBDataPayload(const bt_field* field);
 
-    value = bt_field_string_get_value(
-        bt_field_structure_borrow_member_field_by_name_const(field, "value"));
-  }
-  
 private:
-  std::string specificPayloadString() const {
-    auto convertedString = value;
+  std::string specificPayloadString() const;
 
-    for(auto toReplace : {"\"", "\'"}){
-      for(auto pos = convertedString.find(toReplace); pos != std::string::npos; pos = convertedString.find(toReplace, pos + 2)){
-        convertedString.insert(pos, "\\");
-      }
-    }
-    return ", dataId = " + std::to_string(dataId) + ", value = \"" + convertedString + "\"";
-  }
-
-  bool specificPayloadEqual(const AbstractPayload& other) const {
-    const auto& childInstance = dynamic_cast<const FBDataPayload&>(other); 
-    return dataId == childInstance.dataId && value == childInstance.value;
-  }
+  bool specificPayloadEqual(const AbstractPayload& other) const;
 
   uint64_t dataId;
   std::string value;
@@ -91,130 +73,24 @@ private:
 
 class FBInstanceDataPayload : public AbstractPayload {
 public:
-  FBInstanceDataPayload(const bt_field* field) : AbstractPayload(field){
-
-    std::array<const char*, 4> fieldNames{"inputs", "outputs", "internal", "internalFB"};
-    std::array<std::vector<std::string>*, 4> storage = {&inputs, &outputs, &internal, &internalFB};
-
-    for(size_t fieldRunner = 0; fieldRunner < fieldNames.size(); fieldRunner++){
-      auto arrayField = bt_field_structure_borrow_member_field_by_name_const(field, fieldNames[fieldRunner]);
-      auto arrayLength = bt_field_array_get_length(arrayField);
-      for(decltype(arrayLength) dynamicArrayRunner = 0; dynamicArrayRunner < arrayLength; dynamicArrayRunner++) {
-        storage[fieldRunner]->emplace_back(bt_field_string_get_value(
-            bt_field_array_borrow_element_field_by_index_const(arrayField, dynamicArrayRunner)
-        ));
-      } 
-    }
-  }
+  FBInstanceDataPayload(const bt_field* field);
   
 private:
-  std::string specificPayloadString() const {
+  std::string specificPayloadString() const;
 
-    auto createStringFromVector = [](const std::vector<std::string>& vec) -> std::string {
-      std::string result = "[";
-      for(size_t i = 0; i < vec.size(); i++) {
-        if(i != 0) {
-          result += ",";
-        }
-        result += " [" + std::to_string(i) + "] = \"" + vec[i] + "\""; 
-      }
-      result += " ]";
-      return result;
-    };
-
-    return ", _inputs_len = " + std::to_string(inputs.size()) + ", inputs = " + createStringFromVector(inputs) +
-      ", _outputs_len = " + std::to_string(outputs.size()) + ", outputs = " + createStringFromVector(outputs) +
-      ", _internal_len = " + std::to_string(internal.size()) + ", internal = " + createStringFromVector(internal) +
-      ", _internalFB_len = " + std::to_string(internalFB.size()) + ", internalFB = " + createStringFromVector(internalFB);
-  }
-
-  bool specificPayloadEqual(const AbstractPayload& other) const {
-    const auto& childInstance = dynamic_cast<const FBInstanceDataPayload&>(other); 
-    return inputs == childInstance.inputs && outputs == childInstance.outputs && internal == childInstance.internal && internalFB == childInstance.internalFB;
-  }
+  bool specificPayloadEqual(const AbstractPayload& other) const;
 
   std::vector<std::string> inputs;
   std::vector<std::string> outputs;
   std::vector<std::string> internal;
   std::vector<std::string> internalFB;
-
 };
 
 class PayloadFactory {
 public:
-  static std::unique_ptr<AbstractPayload> createPayload(const std::string& eventType, const bt_field* field){
-    std::unique_ptr<AbstractPayload> result = nullptr;
-    if(eventType == "receiveInputEvent" || eventType == "sendOutputEvent") {
-      result.reset(new FBEventPayload(field));
-    } else if(eventType == "inputData" || eventType == "outputData") {
-      result.reset(new FBDataPayload(field));
-    } else if(eventType == "instanceData") {
-      result.reset(new FBInstanceDataPayload(field));
-    }
-    return result;
-  }
+  static std::unique_ptr<AbstractPayload> createPayload(const std::string& eventType, const bt_field* field);
 };
 
-class EventMessage {
-public:
-  EventMessage(const bt_message* message)  {
-    
-    // Borrow the event message's event and its class
-    const bt_event *event =
-      bt_message_event_borrow_event_const(message);
-    const bt_event_class *event_class = bt_event_borrow_class_const(event);
 
-    const bt_field *payload_field =
-        bt_event_borrow_payload_field_const(event);
 
-    mEventType = bt_event_class_get_name(event_class);
-    mPayload = PayloadFactory::createPayload(mEventType, payload_field);
- 
-    auto clockClass = bt_clock_snapshot_borrow_clock_class_const	(	bt_message_event_borrow_default_clock_snapshot_const(message));
-
-    if(BT_CLOCK_SNAPSHOT_GET_NS_FROM_ORIGIN_STATUS_OK != 
-        bt_clock_snapshot_get_ns_from_origin(
-          bt_message_event_borrow_default_clock_snapshot_const(message), 
-          &mTimestamp)){
-      mTimestamp = 0;
-    }	
-  }
-
-  std::string getString() const {
-    auto nanoseconds = mTimestamp;
-    auto milliseconds = mTimestamp / 1000000;
-    
-    auto seconds = milliseconds / 1000;
-    auto minutes = seconds / 60;
-    auto hours = minutes / 60;
-
-    nanoseconds %= 1000000000;
-    seconds %= 60;
-    minutes %= 60;
-
-    std::stringstream ss;
-    ss << "[" << 
-        std::setw(2) << std::setfill('0') << hours + 1 << ":" <<
-        std::setw(2) << std::setfill('0') << minutes << ":" <<
-        std::setw(2) << std::setfill('0') << seconds << "." <<
-        std::setw(6) << std::setfill('0') << nanoseconds <<  "] " << 
-        mEventType << (mPayload != nullptr ? ": " + mPayload->getString() : "");
-
-    return ss.str();
-  }
-
-  bool operator==(const EventMessage& other) const {
-    return mEventType == other.mEventType  
-      && (mPayload == nullptr) == (other.mPayload == nullptr)
-      && (mPayload != nullptr ? *mPayload == *other.mPayload : true);
-  }
-
-  bool isValidRecord() const {
-    return mPayload != nullptr;
-  }
-
-private:
-  std::string mEventType;
-  std::unique_ptr<AbstractPayload> mPayload;
-  int64_t mTimestamp;
-};
+#endif //  _FORTE_TESTS_CORE_TRACE_EVENT_MESSAGE_H_

--- a/tests/core/trace/EventMessage.h
+++ b/tests/core/trace/EventMessage.h
@@ -11,9 +11,9 @@ class AbstractPayload;
 
 class EventMessage {
 public:
-  EventMessage(const std::string& paEventType, std::unique_ptr<AbstractPayload> paPayload, int64_t paTimestamp);
+  EventMessage(std::string paEventType, std::unique_ptr<AbstractPayload> paPayload, int64_t paTimestamp);
 
-  EventMessage(const bt_message* message);
+  EventMessage(const bt_message* paMessage);
   
   std::string getPayloadString() const;
 
@@ -21,7 +21,7 @@ public:
 
   int64_t getTimestamp () const { return mTimestamp;}
 
-  bool operator==(const EventMessage& other) const;
+  bool operator==(const EventMessage& paOther) const;
 
 private:
   std::string mEventType;
@@ -31,16 +31,18 @@ private:
 
 class AbstractPayload {
 public:
-  AbstractPayload(const std::string& paTypeName, const std::string& paInstanceName);
+  AbstractPayload(std::string paTypeName, std::string paInstanceName);
 
-  AbstractPayload(const bt_field* field);
+  AbstractPayload(const bt_field* paField);
   
-  virtual std::string getString() const;
+  std::string getString() const;
 
-  virtual bool operator==(const AbstractPayload& other) const;
+  bool operator==(const AbstractPayload& paOther) const;
+
+  virtual ~AbstractPayload() = default;
 
 protected:
-  virtual bool specificPayloadEqual(const AbstractPayload& other) const = 0;
+  virtual bool specificPayloadEqual(const AbstractPayload& paOther) const = 0;
 
   virtual std::string specificPayloadString() const = 0;
 
@@ -50,28 +52,28 @@ protected:
 
 class FBEventPayload : public AbstractPayload {
 public:
-  FBEventPayload(const std::string& paTypeName, const std::string& paInstanceName, const uint64_t eventId);
+  FBEventPayload(std::string paTypeName, std::string paInstanceName, const uint64_t paEventId);
 
-  FBEventPayload(const bt_field* field);
+  FBEventPayload(const bt_field* paField);
 
 private:
-  std::string specificPayloadString() const;
+  std::string specificPayloadString() const override;
 
-  bool specificPayloadEqual(const AbstractPayload& other) const;
+  bool specificPayloadEqual(const AbstractPayload& paOther) const override;
  
   uint64_t mEventId;
 };
 
 class FBDataPayload : public AbstractPayload {
 public:
-  FBDataPayload(const std::string& paTypeName, const std::string& paInstanceName, uint64_t paDataId, const std::string& paValue);
+  FBDataPayload(std::string paTypeName, std::string paInstanceName, uint64_t paDataId, std::string paValue);
 
-  FBDataPayload(const bt_field* field);
+  FBDataPayload(const bt_field* paField);
 
 private:
-  std::string specificPayloadString() const;
+  std::string specificPayloadString() const override;
 
-  bool specificPayloadEqual(const AbstractPayload& other) const;
+  bool specificPayloadEqual(const AbstractPayload& paOther) const override;
 
   uint64_t mDataId;
   std::string mValue;
@@ -79,18 +81,20 @@ private:
 
 class FBInstanceDataPayload : public AbstractPayload {
 public:
-  FBInstanceDataPayload(const std::string& paTypeName, const std::string& paInstanceName, 
+  FBInstanceDataPayload(std::string paTypeName, std::string paInstanceName, 
         const std::vector<std::string>& paInputs,
         const std::vector<std::string>& paOutputs,
         const std::vector<std::string>& paInternal,
         const std::vector<std::string>& paInternalFB);
 
-  FBInstanceDataPayload(const bt_field* field);
+  FBInstanceDataPayload(const bt_field* paField);
   
 private:
-  std::string specificPayloadString() const;
+  std::string specificPayloadString() const override;
 
-  bool specificPayloadEqual(const AbstractPayload& other) const;
+  bool specificPayloadEqual(const AbstractPayload& paOther) const override;
+
+  void readDynamicArrayField(const bt_field* paField, const char* paFieldName, std::vector<std::string>& paStorage);
 
   std::vector<std::string> mInputs;
   std::vector<std::string> mOutputs;

--- a/tests/core/trace/TraceReaderSink.cpp
+++ b/tests/core/trace/TraceReaderSink.cpp
@@ -70,30 +70,18 @@ bt_component_class_sink_consume_method_status EventsReader::consume()
     // Current message 
     const bt_message *message = messages[i];
 
-    /* Print line for current message if it's an event message */
-    print_message(message);
+    // Discard if it's not an event message
+    if (bt_message_get_type(message) != BT_MESSAGE_TYPE_EVENT) {
+        continue;
+    }
+
+    mOutput.emplace_back(message);  
 
     // Put this message's reference
     bt_message_put_ref(message);
   }
 
   return BT_COMPONENT_CLASS_SINK_CONSUME_METHOD_STATUS_OK;
-}
-
-void EventsReader::print_message(const bt_message *message)
-{
-  // Discard if it's not an event message
-  if (bt_message_get_type(message) != BT_MESSAGE_TYPE_EVENT) {
-      return;
-  }
-
-  if(auto forteEventRecord = EventMessage(message); forteEventRecord.isValidRecord()){
-    mOutput.push_back(forteEventRecord.getString());  
-  } else {
-    std::abort();
-  }
-
-  return;
 }
 
 }

--- a/tests/core/trace/TraceReaderSink.cpp
+++ b/tests/core/trace/TraceReaderSink.cpp
@@ -23,7 +23,7 @@ EventsReader::EventsReader(bt_self_component_sink *self_component_sink,
     this);
 
   bt_self_component_sink_add_input_port(mSelfComponentSink,
-      "in", NULL, NULL);
+      "in", nullptr, nullptr);
 }
 
 bt_component_class_sink_graph_is_configured_method_status EventsReader::graphIsConfigured()
@@ -92,7 +92,7 @@ bt_component_class_sink_consume_method_status EventsReader::consume()
 // to create the components   //
 // ************************** //
 
-bt_component_class_initialize_method_status forte_events_reader_initialize(
+static bt_component_class_initialize_method_status forte_events_reader_initialize(
       bt_self_component_sink *self_component_sink,
       bt_self_component_sink_configuration *configuration,
       const bt_value *params, void *initialize_method_data){
@@ -114,7 +114,7 @@ bt_component_class_initialize_method_status forte_events_reader_initialize(
 }
 
 // finalze
-void forte_events_reader_finalize(bt_self_component_sink *self_component_sink)
+static void forte_events_reader_finalize(bt_self_component_sink *self_component_sink)
 {
   forte::EventsReader* instance = static_cast<forte::EventsReader*>(bt_self_component_get_data(
       bt_self_component_sink_as_self_component(self_component_sink)));
@@ -122,7 +122,7 @@ void forte_events_reader_finalize(bt_self_component_sink *self_component_sink)
   delete instance;
 }
 
-bt_component_class_sink_graph_is_configured_method_status
+static bt_component_class_sink_graph_is_configured_method_status
 forte_events_reader_graph_is_configured(bt_self_component_sink *self_component_sink)
 {
   auto instance = static_cast<forte::EventsReader *>(bt_self_component_get_data(
@@ -131,7 +131,7 @@ forte_events_reader_graph_is_configured(bt_self_component_sink *self_component_s
   return instance->graphIsConfigured();
 }
 
-bt_component_class_sink_consume_method_status forte_events_reader_consume(
+static bt_component_class_sink_consume_method_status forte_events_reader_consume(
         bt_self_component_sink *self_component_sink)
 {
   auto instance = static_cast<forte::EventsReader *>(bt_self_component_get_data(

--- a/tests/core/trace/TraceReaderSink.cpp
+++ b/tests/core/trace/TraceReaderSink.cpp
@@ -91,6 +91,7 @@ bt_component_class_sink_consume_method_status EventsReader::consume()
 // by the babeltrace2 library //
 // to create the components   //
 // ************************** //
+extern "C" {
 
 static bt_component_class_initialize_method_status forte_events_reader_initialize(
       bt_self_component_sink *self_component_sink,
@@ -155,3 +156,5 @@ BT_PLUGIN_SINK_COMPONENT_CLASS_INITIALIZE_METHOD(event_reader,
 BT_PLUGIN_SINK_COMPONENT_CLASS_FINALIZE_METHOD(event_reader, forte_events_reader_finalize);
 BT_PLUGIN_SINK_COMPONENT_CLASS_GRAPH_IS_CONFIGURED_METHOD(event_reader,
     forte_events_reader_graph_is_configured);
+
+} // extern "C"

--- a/tests/core/trace/TraceReaderSink.cpp
+++ b/tests/core/trace/TraceReaderSink.cpp
@@ -1,0 +1,163 @@
+#include "TraceReaderSink.h"
+#include "EventMessage.h"
+
+#include <inttypes.h> // for printing 
+#include <sstream>
+#include <iostream>
+#include <cstring>
+
+namespace forte{
+  
+// initialize the sink instance
+EventsReader::EventsReader(bt_self_component_sink *self_component_sink,
+        const bt_value *params, 
+        MessageStorage& initialize_method_data) 
+          : mSelfComponentSink{self_component_sink}, 
+            mOutput{initialize_method_data}
+{
+  // params not used for now
+  (void) params;
+
+  bt_self_component_set_data(
+    bt_self_component_sink_as_self_component(mSelfComponentSink),
+    this);
+
+  bt_self_component_sink_add_input_port(mSelfComponentSink,
+      "in", NULL, NULL);
+}
+
+bt_component_class_sink_graph_is_configured_method_status EventsReader::graphIsConfigured()
+{
+  // get the input port
+  bt_self_component_port_input *in_port =
+      bt_self_component_sink_borrow_input_port_by_index(
+          mSelfComponentSink, 0);
+
+  // Create the uptream message iterator
+  bt_message_iterator_create_from_sink_component(mSelfComponentSink,
+      in_port, &mMessageIterator);
+    
+  return BT_COMPONENT_CLASS_SINK_GRAPH_IS_CONFIGURED_METHOD_STATUS_OK;
+}
+
+bt_component_class_sink_consume_method_status EventsReader::consume()
+{
+  // Consume a batch of messages from the upstream message iterator
+  bt_message_array_const messages;
+  uint64_t message_count;
+  bt_message_iterator_next_status next_status =
+      bt_message_iterator_next(mMessageIterator, &messages,
+          &message_count);
+
+  switch (next_status) {
+  case BT_MESSAGE_ITERATOR_NEXT_STATUS_END:
+      /* End of iteration: put the message iterator's reference */
+      bt_message_iterator_put_ref(mMessageIterator);
+      return BT_COMPONENT_CLASS_SINK_CONSUME_METHOD_STATUS_END;
+  case BT_MESSAGE_ITERATOR_NEXT_STATUS_AGAIN:
+      return BT_COMPONENT_CLASS_SINK_CONSUME_METHOD_STATUS_AGAIN;
+  case BT_MESSAGE_ITERATOR_NEXT_STATUS_MEMORY_ERROR:
+      return BT_COMPONENT_CLASS_SINK_CONSUME_METHOD_STATUS_MEMORY_ERROR;
+  case BT_MESSAGE_ITERATOR_NEXT_STATUS_ERROR:
+      return BT_COMPONENT_CLASS_SINK_CONSUME_METHOD_STATUS_ERROR;
+  default:
+      break;
+  }
+
+  // For each consumed message
+  for (uint64_t i = 0; i < message_count; i++) {
+      
+    // Current message 
+    const bt_message *message = messages[i];
+
+    /* Print line for current message if it's an event message */
+    print_message(message);
+
+    // Put this message's reference
+    bt_message_put_ref(message);
+  }
+
+  return BT_COMPONENT_CLASS_SINK_CONSUME_METHOD_STATUS_OK;
+}
+
+void EventsReader::print_message(const bt_message *message)
+{
+  // Discard if it's not an event message
+  if (bt_message_get_type(message) != BT_MESSAGE_TYPE_EVENT) {
+      return;
+  }
+
+  if(auto forteEventRecord = EventMessage(message); forteEventRecord.isValidRecord()){
+    mOutput.push_back(forteEventRecord.getString());  
+  } else {
+    std::abort();
+  }
+
+  return;
+}
+
+}
+
+bt_component_class_initialize_method_status forte_events_reader_initialize(
+      bt_self_component_sink *self_component_sink,
+      bt_self_component_sink_configuration *configuration,
+      const bt_value *params, void *initialize_method_data){
+    
+  (void) configuration; // not used according to the documentation
+  
+  if(initialize_method_data == nullptr){
+    std::cout << "You need to pass a valid pointer initialize_method_data when creating a event_reader sink instance" << std::endl;
+    std::abort();
+  }
+
+  // the allocated pointer is stored inside the class when "this" is passed to the
+  // the user data of self_component_sink, which is deleted later in "finalize" 
+  new forte::EventsReader(
+      self_component_sink, 
+      params, 
+      *static_cast<forte::EventsReader::MessageStorage*>(initialize_method_data));
+  return BT_COMPONENT_CLASS_INITIALIZE_METHOD_STATUS_OK;
+}
+
+// finalze
+void forte_events_reader_finalize(bt_self_component_sink *self_component_sink)
+{
+  forte::EventsReader* instance = static_cast<forte::EventsReader*>(bt_self_component_get_data(
+      bt_self_component_sink_as_self_component(self_component_sink)));
+
+  delete instance;
+}
+
+bt_component_class_sink_graph_is_configured_method_status
+forte_events_reader_graph_is_configured(bt_self_component_sink *self_component_sink)
+{
+  auto instance = static_cast<forte::EventsReader *>(bt_self_component_get_data(
+    bt_self_component_sink_as_self_component(self_component_sink)));
+ 
+  return instance->graphIsConfigured();
+}
+
+bt_component_class_sink_consume_method_status forte_events_reader_consume(
+        bt_self_component_sink *self_component_sink)
+{
+  auto instance = static_cast<forte::EventsReader *>(bt_self_component_get_data(
+      bt_self_component_sink_as_self_component(self_component_sink)));
+
+  return instance->consume();
+}
+
+/* Mandatory */
+BT_PLUGIN_MODULE();
+ 
+/* Define the `forte` plugin */
+BT_PLUGIN(forte);
+ 
+/* Define the `event_reader` sink component class */
+BT_PLUGIN_SINK_COMPONENT_CLASS(event_reader, forte_events_reader_consume);
+ 
+/* Set some of the `event_reader` sink component class's optional methods */
+BT_PLUGIN_SINK_COMPONENT_CLASS_INITIALIZE_METHOD(event_reader,
+    forte_events_reader_initialize);
+BT_PLUGIN_SINK_COMPONENT_CLASS_FINALIZE_METHOD(event_reader, forte_events_reader_finalize);
+BT_PLUGIN_SINK_COMPONENT_CLASS_GRAPH_IS_CONFIGURED_METHOD(event_reader,
+    forte_events_reader_graph_is_configured);

--- a/tests/core/trace/TraceReaderSink.cpp
+++ b/tests/core/trace/TraceReaderSink.cpp
@@ -86,6 +86,12 @@ bt_component_class_sink_consume_method_status EventsReader::consume()
 
 }
 
+// ************************** //
+// C-Style functions needed   // 
+// by the babeltrace2 library //
+// to create the components   //
+// ************************** //
+
 bt_component_class_initialize_method_status forte_events_reader_initialize(
       bt_self_component_sink *self_component_sink,
       bt_self_component_sink_configuration *configuration,

--- a/tests/core/trace/TraceReaderSink.h
+++ b/tests/core/trace/TraceReaderSink.h
@@ -1,0 +1,30 @@
+
+#include <babeltrace2/babeltrace.h>
+
+#include <vector>
+#include <string>
+
+namespace forte {
+  class EventsReader {
+    public:
+
+    typedef std::vector<std::string> MessageStorage;
+
+    EventsReader(bt_self_component_sink *self_component_sink,
+        const bt_value *params, 
+        MessageStorage& initialize_method_data);
+
+    bt_component_class_sink_graph_is_configured_method_status graphIsConfigured();
+
+    bt_component_class_sink_consume_method_status consume();
+
+    private:
+    void print_message(const bt_message *message);
+
+    bt_self_component_sink *mSelfComponentSink;
+
+    std::vector<std::string>& mOutput;
+
+    bt_message_iterator *mMessageIterator{nullptr};
+  };  
+}

--- a/tests/core/trace/TraceReaderSink.h
+++ b/tests/core/trace/TraceReaderSink.h
@@ -1,14 +1,19 @@
+#ifndef _FORTE_TESTS_CORE_TRACE_TRACE_READER_SINK_H_
+#define _FORTE_TESTS_CORE_TRACE_TRACE_READER_SINK_H_
 
-#include <babeltrace2/babeltrace.h>
 
 #include <vector>
 #include <string>
+
+#include <babeltrace2/babeltrace.h>
+
+#include "EventMessage.h"
 
 namespace forte {
   class EventsReader {
     public:
 
-    typedef std::vector<std::string> MessageStorage;
+    typedef std::vector<EventMessage> MessageStorage;
 
     EventsReader(bt_self_component_sink *self_component_sink,
         const bt_value *params, 
@@ -19,12 +24,12 @@ namespace forte {
     bt_component_class_sink_consume_method_status consume();
 
     private:
-    void print_message(const bt_message *message);
-
     bt_self_component_sink *mSelfComponentSink;
 
-    std::vector<std::string>& mOutput;
+    MessageStorage& mOutput;
 
     bt_message_iterator *mMessageIterator{nullptr};
   };  
 }
+
+#endif // _FORTE_TESTS_CORE_TRACE_TRACE_READER_SINK_H_

--- a/tests/core/trace/TraceReaderSink.h
+++ b/tests/core/trace/TraceReaderSink.h
@@ -1,17 +1,20 @@
 #ifndef _FORTE_TESTS_CORE_TRACE_TRACE_READER_SINK_H_
 #define _FORTE_TESTS_CORE_TRACE_TRACE_READER_SINK_H_
 
-
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <babeltrace2/babeltrace.h>
 
 #include "EventMessage.h"
 
 namespace forte {
+  /**
+   * Used with the babeltrace2 library to read event messages from it and transform them 
+   * into EventMessage objects
+  */
   class EventsReader {
-    public:
+  public:
 
     typedef std::vector<EventMessage> MessageStorage;
 
@@ -23,7 +26,7 @@ namespace forte {
 
     bt_component_class_sink_consume_method_status consume();
 
-    private:
+  private:
     bt_self_component_sink *mSelfComponentSink;
 
     MessageStorage& mOutput;

--- a/tests/core/trace/config.h.in
+++ b/tests/core/trace/config.h.in
@@ -1,0 +1,3 @@
+
+const char* CTF_OUTPUT_DIR =  "${CTF_OUTPUT_DIR}";
+const char* METADATA_FILE = "${METADATA_FILE}";

--- a/tests/core/trace/ctfTracerTest.cpp
+++ b/tests/core/trace/ctfTracerTest.cpp
@@ -19,69 +19,105 @@
 #include <optional>
 #include <iomanip>
 
-BOOST_AUTO_TEST_SUITE (ctfTracer_test)
+#include <thread>
 
-BOOST_AUTO_TEST_CASE(library_test) {
+#include "trace/barectf_platform_forte.h"
+#include "../stdfblib/ita/EMB_RES.h"
+#include "ecet.h"
+#include "ctfTracerTest_gen.cpp"
+#include "device.h"
+#include "resource.h"
 
-  // load ctf plugin
-  const bt_plugin* ctfPlugin;
-  BOOST_TEST(BT_PLUGIN_FIND_STATUS_OK == bt_plugin_find("ctf", BT_FALSE, BT_FALSE, BT_TRUE, BT_FALSE, BT_TRUE, &ctfPlugin));
-  auto fileSourceClass = bt_plugin_borrow_source_component_class_by_name_const(ctfPlugin, "fs"); 
 
-  // load utils plugin
-  const bt_plugin* utilsPlugin;
-  BOOST_TEST(BT_PLUGIN_FIND_STATUS_OK == bt_plugin_find("utils", BT_FALSE, BT_FALSE, BT_TRUE, BT_FALSE, BT_TRUE, &utilsPlugin));
 
-  auto muxerFilterClass = bt_plugin_borrow_filter_component_class_by_name_const(utilsPlugin, "muxer"); 
 
-  // look on static plugins only
-  const bt_plugin* fortePlugin;
-  BOOST_TEST(BT_PLUGIN_FIND_STATUS_OK == bt_plugin_find("forte", BT_FALSE, BT_FALSE, BT_FALSE, BT_TRUE, BT_TRUE, &fortePlugin));
-  auto forteReaderClass = bt_plugin_borrow_sink_component_class_by_name_const(fortePlugin, "event_reader"); 
+BOOST_AUTO_TEST_SUITE (tracer_test)
 
-  // create graph
-  auto graph = bt_graph_create(0);
-  
-  // Source component
-  // create parameters to file source component
-  const bt_component_source*  tracesComponent;
-  auto parameters = bt_value_map_create();
-  bt_value *dirsArray;
+std::vector<EventMessage> getEventMessages(const std::string& path);
 
-  BOOST_TEST(BT_VALUE_MAP_INSERT_ENTRY_STATUS_OK == bt_value_map_insert_empty_array_entry(parameters, "inputs", &dirsArray));
 
-  BOOST_TEST(BT_VALUE_ARRAY_APPEND_ELEMENT_STATUS_OK ==
-     	bt_value_array_append_string_element(dirsArray, "/home/cochicde/ctf"));
+BOOST_AUTO_TEST_CASE(sequential_events_test) {
 
-  // create Source component
-  BOOST_TEST(BT_GRAPH_ADD_COMPONENT_STATUS_OK == 
-    bt_graph_add_source_component(graph, fileSourceClass, "traces", parameters, BT_LOGGING_LEVEL_TRACE, &tracesComponent));
-  
-  // create muxer component
-  const bt_component_filter*  muxerComponent;
-  BOOST_TEST(BT_GRAPH_ADD_COMPONENT_STATUS_OK == 
-    bt_graph_add_filter_component(graph, muxerFilterClass, "muxer", nullptr, BT_LOGGING_LEVEL_TRACE, &muxerComponent));
+  const std::string traceOutputPath = "/home/cochicde/ctf";
 
-  // create pretty component
-  std::vector<EventMessage> messages;
-  const bt_component_sink*  forteReaderComponent;
-  BOOST_TEST(BT_GRAPH_ADD_COMPONENT_STATUS_OK == 
-   bt_graph_add_sink_component_with_initialize_method_data(graph, forteReaderClass, "forteReader", nullptr, &messages, BT_LOGGING_LEVEL_TRACE, &forteReaderComponent));
+  BarectfPlatformFORTE::setup(traceOutputPath);
 
-  // Connections
-  for(uint64_t i = 0; i < bt_component_source_get_output_port_count(tracesComponent); i++){
-    BOOST_TEST(BT_GRAPH_CONNECT_PORTS_STATUS_OK ==  bt_graph_connect_ports(graph, 
-        bt_component_source_borrow_output_port_by_index_const(tracesComponent, i), 
-        bt_component_filter_borrow_input_port_by_index_const(muxerComponent, i), 
-        nullptr));
-  }    
+const  SFBInterfaceSpec scTestDevSpec = {
+  0, nullptr, nullptr, nullptr,
+  0, nullptr, nullptr, nullptr,
+  0, nullptr, nullptr,
+  0, nullptr, nullptr,
+  0, nullptr,
+  0, nullptr
+};
+  CDevice device(&scTestDevSpec, g_nStringIdMyDevice);
+  auto resource = new EMB_RES(g_nStringIdMyResource, device);
 
-  BOOST_TEST(BT_GRAPH_CONNECT_PORTS_STATUS_OK ==  bt_graph_connect_ports(graph, 
-    bt_component_filter_borrow_output_port_by_index_const(muxerComponent, 0), 
-    bt_component_sink_borrow_input_port_by_index_const(forteReaderComponent, 0), 
-    nullptr));
+  resource->initialize();
 
-  BOOST_TEST(BT_GRAPH_RUN_STATUS_OK == bt_graph_run(graph));	
+  auto startInstanceName = g_nStringIdSTART;
+  auto counterInstanceName = g_nStringIdCounter;
+  auto switchInstanceName = g_nStringIdSwitch;
+
+  resource->addFB(CTypeLib::createFB(counterInstanceName, g_nStringIdE_CTU, *resource));
+  resource->addFB(CTypeLib::createFB(switchInstanceName, g_nStringIdE_SWITCH, *resource));
+
+  forte::core::SManagementCMD command;
+  command.mCMD = EMGMCommandType::CreateConnection;
+  command.mDestination = CStringDictionary::scmInvalidStringId;
+
+  BOOST_TEST_INFO("Event connection: Start.COLD -> Counter.CU");
+  command.mFirstParam.pushBack(startInstanceName);
+  command.mFirstParam.pushBack(g_nStringIdCOLD);
+  command.mSecondParam.pushBack(counterInstanceName);
+  command.mSecondParam.pushBack(g_nStringIdCU);
+
+  BOOST_CHECK(EMGMResponse::Ready == resource->executeMGMCommand(command));
+
+  BOOST_TEST_INFO("Event connection: Counter.CUO -> Switch.EI");
+  command.mFirstParam.clear();
+  command.mFirstParam.pushBack(counterInstanceName);
+  command.mFirstParam.pushBack(g_nStringIdCUO);
+  command.mSecondParam.clear();
+  command.mSecondParam.pushBack(switchInstanceName);
+  command.mSecondParam.pushBack(g_nStringIdEI);
+  BOOST_CHECK(EMGMResponse::Ready == resource->executeMGMCommand(command));
+
+  BOOST_TEST_INFO("Data connection: Counter.Q -> Switch.G ");
+  command.mFirstParam.clear();
+  command.mFirstParam.pushBack(counterInstanceName);
+  command.mFirstParam.pushBack(g_nStringIdQ);
+  command.mSecondParam.clear();
+  command.mSecondParam.pushBack(switchInstanceName);
+  command.mSecondParam.pushBack(g_nStringIdG);
+  BOOST_CHECK(EMGMResponse::Ready == resource->executeMGMCommand(command));
+
+  BOOST_TEST_INFO(" Data constant value: Counter.PV = 1");
+  command.mFirstParam.clear();
+  command.mFirstParam.pushBack(counterInstanceName);
+  command.mFirstParam.pushBack(g_nStringIdPV);
+  BOOST_CHECK(EMGMResponse::Ready == resource->writeValue(command.mFirstParam, CIEC_STRING(std::string("1")), false));
+
+  BOOST_TEST_INFO("Event connection: Switch.EO1 -> Counter.R ");
+  command.mFirstParam.clear();
+  command.mFirstParam.pushBack(switchInstanceName);
+  command.mFirstParam.pushBack(g_nStringIdEO1);
+  command.mSecondParam.clear();
+  command.mSecondParam.pushBack(counterInstanceName);
+  command.mSecondParam.pushBack(g_nStringIdR);
+  BOOST_CHECK(EMGMResponse::Ready == resource->executeMGMCommand(command));
+
+  device.addFB(resource);
+
+
+  device.startDevice();
+  while(resource->getResourceEventExecution()->isProcessingEvents()){
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  device.changeFBExecutionState(EMGMCommandType::Stop);
+  resource->getResourceEventExecution()->joinEventChainExecutionThread();
+
+  auto messages = getEventMessages(traceOutputPath);
 
   auto getTimestampDifference = [](int64_t current, std::optional<int64_t> prev) -> std::string {
     if(prev == std::nullopt){
@@ -110,6 +146,73 @@ BOOST_AUTO_TEST_CASE(library_test) {
       << message.getPayloadString() << std::endl;
     lastTimestamp = message.getTimestamp();
   }
+
+  // disable logging 
+  //BarectfPlatformFORTE::setup("");
+}
+
+std::vector<EventMessage> getEventMessages(const std::string& path){
+  
+  BOOST_TEST_INFO("Load ctf plugin");
+  const bt_plugin* ctfPlugin;
+  BOOST_CHECK_EQUAL(BT_PLUGIN_FIND_STATUS_OK, bt_plugin_find("ctf", BT_FALSE, BT_FALSE, BT_TRUE, BT_FALSE, BT_TRUE, &ctfPlugin));
+  auto fileSourceClass = bt_plugin_borrow_source_component_class_by_name_const(ctfPlugin, "fs"); 
+
+  BOOST_TEST_INFO("Load utils plugin");
+  const bt_plugin* utilsPlugin;
+  BOOST_CHECK_EQUAL(BT_PLUGIN_FIND_STATUS_OK, bt_plugin_find("utils", BT_FALSE, BT_FALSE, BT_TRUE, BT_FALSE, BT_TRUE, &utilsPlugin));
+  auto muxerFilterClass = bt_plugin_borrow_filter_component_class_by_name_const(utilsPlugin, "muxer"); 
+
+  BOOST_TEST_INFO("Load forte plugin");
+  const bt_plugin* fortePlugin;
+  BOOST_CHECK_EQUAL(BT_PLUGIN_FIND_STATUS_OK, bt_plugin_find("forte", BT_FALSE, BT_FALSE, BT_FALSE, BT_TRUE, BT_TRUE, &fortePlugin));
+  auto forteReaderClass = bt_plugin_borrow_sink_component_class_by_name_const(fortePlugin, "event_reader"); 
+
+  // create graph
+  auto graph = bt_graph_create(0);
+  
+  // Source component
+  // create parameters to file source component
+  const bt_component_source*  tracesComponent;
+  auto parameters = bt_value_map_create();
+  bt_value *dirsArray;
+
+  BOOST_TEST_INFO("Add empty array to map parameter for ctf.source.fs component");
+  BOOST_CHECK_EQUAL(BT_VALUE_MAP_INSERT_ENTRY_STATUS_OK, bt_value_map_insert_empty_array_entry(parameters, "inputs", &dirsArray));
+
+  BOOST_TEST_INFO("Add input folder to ctf.source.fs component's input parameter");
+  BOOST_CHECK_EQUAL(BT_VALUE_ARRAY_APPEND_ELEMENT_STATUS_OK, bt_value_array_append_string_element(dirsArray, path.c_str()));
+
+  BOOST_TEST_INFO("Create Source component");
+  BOOST_CHECK_EQUAL(BT_GRAPH_ADD_COMPONENT_STATUS_OK, bt_graph_add_source_component(graph, fileSourceClass, "traces", parameters, BT_LOGGING_LEVEL_TRACE, &tracesComponent));
+  
+  const bt_component_filter*  muxerComponent;
+  BOOST_CHECK_EQUAL(BT_GRAPH_ADD_COMPONENT_STATUS_OK, bt_graph_add_filter_component(graph, muxerFilterClass, "muxer", nullptr, BT_LOGGING_LEVEL_TRACE, &muxerComponent));
+
+  BOOST_TEST_INFO("Create forte event reader component");
+  std::vector<EventMessage> messages;
+  const bt_component_sink*  forteReaderComponent;
+  BOOST_CHECK_EQUAL(BT_GRAPH_ADD_COMPONENT_STATUS_OK, 
+   bt_graph_add_sink_component_with_initialize_method_data(graph, forteReaderClass, "forteReader", nullptr, &messages, BT_LOGGING_LEVEL_TRACE, &forteReaderComponent));
+
+  for(uint64_t i = 0; i < bt_component_source_get_output_port_count(tracesComponent); i++){
+    BOOST_TEST_INFO("Add connection " << i << " from source to muxer");
+    BOOST_CHECK_EQUAL(BT_GRAPH_CONNECT_PORTS_STATUS_OK,  bt_graph_connect_ports(graph, 
+        bt_component_source_borrow_output_port_by_index_const(tracesComponent, i), 
+        bt_component_filter_borrow_input_port_by_index_const(muxerComponent, i), 
+        nullptr));
+  }    
+
+  BOOST_TEST_INFO("Add connection from muxer to forte reader");
+  BOOST_CHECK_EQUAL(BT_GRAPH_CONNECT_PORTS_STATUS_OK,  bt_graph_connect_ports(graph, 
+    bt_component_filter_borrow_output_port_by_index_const(muxerComponent, 0), 
+    bt_component_sink_borrow_input_port_by_index_const(forteReaderComponent, 0), 
+    nullptr));
+
+  BOOST_TEST_INFO("Run graph");
+  BOOST_CHECK_EQUAL(BT_GRAPH_RUN_STATUS_OK, bt_graph_run(graph));
+
+  return messages;	
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/core/trace/ctfTracerTest.cpp
+++ b/tests/core/trace/ctfTracerTest.cpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2019 fotiss GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Jose Cabral- initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include <boost/test/unit_test.hpp>
+
+#include <babeltrace2/babeltrace.h>
+
+
+BOOST_AUTO_TEST_SUITE (ctfTracer_test)
+
+BOOST_AUTO_TEST_CASE(library_test) {
+
+  // load ctf plugin
+  const bt_plugin* ctfPlugin;
+  BOOST_TEST(BT_PLUGIN_FIND_STATUS_OK == bt_plugin_find("ctf", BT_FALSE, BT_FALSE, BT_TRUE, BT_FALSE, BT_TRUE, &ctfPlugin));
+  auto fileSourceClass = bt_plugin_borrow_source_component_class_by_name_const(ctfPlugin, "fs"); 
+
+  // load utils plugin
+  const bt_plugin* utilsPlugin;
+  BOOST_TEST(BT_PLUGIN_FIND_STATUS_OK == bt_plugin_find("utils", BT_FALSE, BT_FALSE, BT_TRUE, BT_FALSE, BT_TRUE, &utilsPlugin));
+
+  auto muxerFilterClass = bt_plugin_borrow_filter_component_class_by_name_const(utilsPlugin, "muxer"); 
+
+  const bt_plugin* textPlugin;
+  BOOST_TEST(BT_PLUGIN_FIND_STATUS_OK == bt_plugin_find("text", BT_FALSE, BT_FALSE, BT_TRUE, BT_FALSE, BT_TRUE, &textPlugin));
+  auto prettySinkClass = bt_plugin_borrow_sink_component_class_by_name_const(textPlugin, "pretty"); 
+
+  // look on static plugins only
+  const bt_plugin* fortePlugin;
+  BOOST_TEST(BT_PLUGIN_FIND_STATUS_OK == bt_plugin_find("forte", BT_FALSE, BT_FALSE, BT_FALSE, BT_TRUE, BT_TRUE, &fortePlugin));
+  auto forteReaderClass = bt_plugin_borrow_sink_component_class_by_name_const(fortePlugin, "event_reader"); 
+
+  // create graph
+  auto graph = bt_graph_create(0);
+  
+  // Source component
+  // create parameters to file source component
+  const bt_component_source*  tracesComponent;
+  auto parameters = bt_value_map_create();
+  bt_value *dirsArray;
+
+  BOOST_TEST(BT_VALUE_MAP_INSERT_ENTRY_STATUS_OK == bt_value_map_insert_empty_array_entry(parameters, "inputs", &dirsArray));
+
+  BOOST_TEST(BT_VALUE_ARRAY_APPEND_ELEMENT_STATUS_OK ==
+     	bt_value_array_append_string_element(dirsArray, "/home/cochicde/ctf"));
+
+  // create Source component
+  BOOST_TEST(BT_GRAPH_ADD_COMPONENT_STATUS_OK == 
+    bt_graph_add_source_component(graph, fileSourceClass, "traces", parameters, BT_LOGGING_LEVEL_TRACE, &tracesComponent));
+  
+  // create muxer component
+  const bt_component_filter*  muxerComponent;
+  BOOST_TEST(BT_GRAPH_ADD_COMPONENT_STATUS_OK == 
+    bt_graph_add_filter_component(graph, muxerFilterClass, "muxer", nullptr, BT_LOGGING_LEVEL_TRACE, &muxerComponent));
+
+  // create pretty component
+  std::vector<std::string> messages;
+  const bt_component_sink*  prettyComponent;
+  BOOST_TEST(BT_GRAPH_ADD_COMPONENT_STATUS_OK == 
+ //  bt_graph_add_sink_component(graph, prettySinkClass, "pretty", nullptr, BT_LOGGING_LEVEL_TRACE, &prettyComponent));
+   bt_graph_add_sink_component_with_initialize_method_data(graph, forteReaderClass, "pretty", nullptr, &messages, BT_LOGGING_LEVEL_TRACE, &prettyComponent));
+
+  // Connections
+  for(uint64_t i = 0; i < bt_component_source_get_output_port_count(tracesComponent); i++){
+    BOOST_TEST(BT_GRAPH_CONNECT_PORTS_STATUS_OK ==  bt_graph_connect_ports(graph, 
+        bt_component_source_borrow_output_port_by_index_const(tracesComponent, i), 
+        bt_component_filter_borrow_input_port_by_index_const(muxerComponent, i), 
+        nullptr));
+  }    
+
+  BOOST_TEST(BT_GRAPH_CONNECT_PORTS_STATUS_OK ==  bt_graph_connect_ports(graph, 
+    bt_component_filter_borrow_output_port_by_index_const(muxerComponent, 0), 
+    bt_component_sink_borrow_input_port_by_index_const(prettyComponent, 0), 
+    nullptr));
+
+  BOOST_TEST(BT_GRAPH_RUN_STATUS_OK == bt_graph_run(graph));	
+
+  for(auto message : messages) {
+    std::cout << message << std::endl;
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR is to have a base for testing the ctf traces. It has classes representing all possible events being traced, a way of reading the trace files, and a minimal example of comparison of a small FB network.

The test is very simple, but the rest is what's needed for further improvement of the trace module and for more complex analysis of traces. 