### PR TITLE
Clean-up Device Creation and Execution procedure

### DIFF
--- a/src/arch/ecos/forte_instance.cpp
+++ b/src/arch/ecos/forte_instance.cpp
@@ -98,7 +98,7 @@ void forteStopInstance(int paSig, TForteInstance paResultDevice){
   RMT_DEV *poDev = static_cast<RMT_DEV*>(paResultDevice);
   if(0 != poDev){
     poDev->changeFBExecutionState(EMGMCommandType::Kill);
-    poDev->MGR.joinResourceThread();
+    poDev->awaitShutdown();
     DEVLOG_INFO("FORTE finished\n");
     delete poDev;
   }

--- a/src/arch/freeRTOS/forte_Init.cpp
+++ b/src/arch/freeRTOS/forte_Init.cpp
@@ -92,7 +92,7 @@ int forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResu
 void forteJoinInstance(TForteInstance paInstance) {
   RMT_DEV *poDev = static_cast<RMT_DEV*>(paInstance);
   if(0 != poDev) {
-    poDev->MGR.joinResourceThread();
+    poDev->awaitShutdown();
   }
 }
 
@@ -104,7 +104,7 @@ void forteStopInstance(int paSig, TForteInstance paInstance) {
   RMT_DEV *poDev = static_cast<RMT_DEV*>(paInstance);
   if(0 != poDev) {
     poDev->changeFBExecutionState(EMGMCommandType::Kill);
-    poDev->MGR.joinResourceThread();
+    poDev->awaitShutdown();
     DEVLOG_INFO("FORTE finished\n");
     delete poDev;
   }

--- a/src/arch/freeRTOS/main.cpp
+++ b/src/arch/freeRTOS/main.cpp
@@ -28,7 +28,7 @@ void vForteTask(void* pvParameters) {
   poDev->setMGR_ID("localhost:61499");
   poDev->startDevice();
   DEVLOG_INFO("FORTE is up and running\n");
-  poDev->MGR.joinResourceThread();
+  poDev->awaitShutdown();
   DEVLOG_INFO("FORTE finished\n");
   delete poDev;
   vTaskDelete(nullptr);

--- a/src/arch/netos/root.cpp
+++ b/src/arch/netos/root.cpp
@@ -92,7 +92,7 @@ void applicationStart(void) {
   // Starting  Runtime
   RMT_DEV dev;
   dev.startDevice();
-  dev.MGR.joinResourceThread();
+  dev.awaitShutdown();
   tx_thread_suspend(tx_thread_identify());
 }
 

--- a/src/arch/pikeos_posix/main.cpp
+++ b/src/arch/pikeos_posix/main.cpp
@@ -74,7 +74,7 @@ void createDev(const char *paMGRID){
   poDev->setMGR_ID(paMGRID);
   poDev->startDevice();
   DEVLOG_INFO("FORTE is up and running\n");
-  poDev->MGR.joinResourceThread();
+  poDev->awaitShutdown();
   DEVLOG_INFO("FORTE finished\n");
   delete poDev;
 }

--- a/src/arch/rcX/forte_instance.cpp
+++ b/src/arch/rcX/forte_instance.cpp
@@ -98,7 +98,7 @@ void forteStopInstance(int paSig, TForteInstance pa_resultDevice){
   RMT_DEV *poDev = static_cast<RMT_DEV*>(pa_resultDevice);
   if(0 != poDev){
     poDev->changeFBExecutionState(EMGMCommandType::Kill);
-    poDev->MGR.joinResourceThread();
+    poDev->awaitShutdown();
     DEVLOG_INFO("FORTE finished\n");
     delete poDev;
   }

--- a/src/arch/vxworks/main.cpp
+++ b/src/arch/vxworks/main.cpp
@@ -62,7 +62,7 @@ void createDev(const char *paMGRID){
   poDev->setMGR_ID(paMGRID);
   poDev->startDevice();
   DEVLOG_INFO("FORTE is up and running\n");
-  poDev->MGR.joinResourceThread();
+  poDev->awaitShutdown();
   DEVLOG_INFO("FORTE finished\n");
   delete poDev;
 }

--- a/src/arch/win32/forte_instance.cpp
+++ b/src/arch/win32/forte_instance.cpp
@@ -30,7 +30,7 @@ extern "C"
 void shutdownFORTE(){
   if(0 != gDev){
     gDev->changeFBExecutionState(EMGMCommandType::Kill);
-    gDev->MGR.joinResourceThread();
+    gDev->awaitShutdown();
     delete gDev;
     gDev = 0;
   }

--- a/src/arch/win32/main.cpp
+++ b/src/arch/win32/main.cpp
@@ -19,6 +19,8 @@
 #include <stdio.h>
 #include <signal.h>
 
+void hookSignals();
+
 //this keeps away a lot of rtti and exception handling stuff
 #ifndef __cpp_exceptions
 extern "C" void __cxa_pure_virtual(void){
@@ -29,36 +31,24 @@ extern "C" void __cxa_pure_virtual(void){
 }
 #endif
 
-RMT_DEV *poDev = 0;
+CDevice *gRunningDev = nullptr;
 
 void endForte(int paSig){
   (void) paSig;
-  if(0 != poDev){
-    poDev->changeFBExecutionState(EMGMCommandType::Kill);
+  if(gRunningDev != nullptr){
+    gRunningDev->changeFBExecutionState(EMGMCommandType::Kill);
   }
 }
 
 /*!\brief Creates the Device-Object
  * \param paMGRID A string containing IP and Port like [IP]:[Port]
+ * \return the newly created and configured device object
  */
-void createDev(const char *paMGRID){
-
-  signal(SIGINT, endForte);
-  signal(SIGTERM, endForte);
-
-  poDev = new RMT_DEV;
-  poDev->initialize();
-
-#ifdef FORTE_FBTESTS
-  CFBTestsManager::getInstance().runAllTests();
-#endif
-
-  poDev->setMGR_ID(paMGRID);
-  poDev->startDevice();
-  DEVLOG_INFO("FORTE is up and running\n");
-  poDev->MGR.joinResourceThread();
-  DEVLOG_INFO("FORTE finished\n");
-  delete poDev;
+CDevice *createDev(const char *paMGRID){
+  RMT_DEV *dev = new RMT_DEV;
+  dev->initialize();
+  dev->setMGR_ID(paMGRID);
+  return dev;
 }
 
 int main(int argc, char *arg[]){
@@ -67,9 +57,19 @@ int main(int argc, char *arg[]){
 
     startupHook(argc, arg);
 
+    hookSignals();
+
     const char *pIpPort = parseCommandLineArguments(argc, arg);
     if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))){
-      createDev(pIpPort);
+      gRunningDev = createDev(pIpPort);
+      if(gRunningDev != nullptr){
+        gRunningDev->startDevice();
+        DEVLOG_INFO("FORTE is up and running\n");
+        gRunningDev->awaitShutdown();
+        DEVLOG_INFO("FORTE finished\n");
+        delete gRunningDev;
+        gRunningDev = nullptr;
+      }
     }
     else{ //! Lists the help for FORTE
       listHelp();
@@ -82,4 +82,9 @@ int main(int argc, char *arg[]){
     DEVLOG_ERROR("Architecture could not be initialized\n");
   }
   return 0;
+}
+
+void hookSignals() {
+  signal(SIGINT, endForte);
+  signal(SIGTERM, endForte);
 }

--- a/src/arch/zephyr/forte_Init.cpp
+++ b/src/arch/zephyr/forte_Init.cpp
@@ -92,7 +92,7 @@ int forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResu
 void forteJoinInstance(TForteInstance paInstance) {
   RMT_DEV *poDev = static_cast<RMT_DEV*>(paInstance);
   if(0 != poDev) {
-    poDev->MGR.joinResourceThread();
+    poDev->awaitShutdown();
   }
 }
 
@@ -104,7 +104,7 @@ void forteStopInstance(int paSig, TForteInstance paInstance) {
   RMT_DEV *poDev = static_cast<RMT_DEV*>(paInstance);
   if(0 != poDev) {
     poDev->changeFBExecutionState(EMGMCommandType::Kill);
-    poDev->MGR.joinResourceThread();
+    poDev->awaitShutdown();
     DEVLOG_INFO("FORTE finished\n");
     delete poDev;
   }

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -64,6 +64,13 @@ class CDevice : public CResource {
       return 1;
     }
 
+
+    /*!\brief wait till the execution of this device ends.
+     *
+     * The execution of devices can be stopped by sending it the kill command.
+     */
+    virtual void awaitShutdown() = 0;
+
     /*!\brief Execute the given management command
      *
      * Evaluates the mDestination parameter of the command if empty this class tries to execute the management command if not

--- a/src/stdfblib/ita/RMT_DEV.cpp
+++ b/src/stdfblib/ita/RMT_DEV.cpp
@@ -54,6 +54,10 @@ int RMT_DEV::startDevice(){
   return 0;
 }
 
+void RMT_DEV::awaitShutdown() {
+  MGR.joinResourceThread();
+}
+
 EMGMResponse RMT_DEV::changeFBExecutionState(EMGMCommandType paCommand){
   EMGMResponse eRetVal = CDevice::changeFBExecutionState(paCommand);
   if((EMGMResponse::Ready == eRetVal) && (EMGMCommandType::Kill == paCommand)){

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -23,8 +23,6 @@
 
 class RMT_DEV : public CDevice{
   public:
-    RMT_RES MGR;
-
     RMT_DEV();
     ~RMT_DEV() override;
 
@@ -35,6 +33,8 @@ class RMT_DEV : public CDevice{
   * This is that it waits till the thread of the MGR resource has anded
   */
     int startDevice() override;
+
+    void awaitShutdown() override;
 
     EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
 
@@ -51,6 +51,8 @@ class RMT_DEV : public CDevice{
     CIEC_WSTRING& MGR_ID() {
       return *static_cast<CIEC_WSTRING*>(getDI(0));
     }
+
+    RMT_RES MGR;
 };
 
 #endif /*RMT_DEV_H_*/

--- a/tests/core/fbtests/fbtesterglobalfixture.cpp
+++ b/tests/core/fbtests/fbtesterglobalfixture.cpp
@@ -28,9 +28,21 @@ const static SFBInterfaceSpec gscTestDevSpec = {
 CDevice *CFBTestDataGlobalFixture::smTestDev;
 CResource *CFBTestDataGlobalFixture::smTestRes;
 
+class CTesterDevice : public CDevice {
+  public:
+    CTesterDevice(const SFBInterfaceSpec *paInterfaceSpec, const CStringDictionary::TStringId paInstanceNameId) :
+        CDevice(paInterfaceSpec, paInstanceNameId){
+    }
+
+    void awaitShutdown() override {
+      // nothing to be done to join
+    }
+
+};
+
 CFBTestDataGlobalFixture::CFBTestDataGlobalFixture(){
   //setup is done in the setup so that boost_test can throw exceptions
-  smTestDev = new CDevice(&gscTestDevSpec, CStringDictionary::scmInvalidStringId);
+  smTestDev = new CTesterDevice(&gscTestDevSpec, CStringDictionary::scmInvalidStringId);
   //mimick the behavior provided by typelib
   smTestDev->changeFBExecutionState(EMGMCommandType::Reset);
 


### PR DESCRIPTION
In order to prepare the different architectures that the CDevice to be used on startup can be configured via CMake options in this commit some clean-ups and generalizations have been performed.

@dok-net, @franz-hoepfinger-4diac, @kumajaya  FYI