### PR TITLE
Moved device creation to CDevice

### DIFF
--- a/buildsupport/forte.cmake
+++ b/buildsupport/forte.cmake
@@ -207,6 +207,12 @@ FUNCTION(forte_add_architecture)
   ENDFOREACH(ARG)
 ENDFUNCTION(forte_add_architecture)
 
+FUNCTION(forte_add_device)
+  FOREACH(ARG ${ARGV})
+    set_property(GLOBAL APPEND PROPERTY FORTE_DEVICES ${ARG})
+  ENDFOREACH(ARG)
+ENDFUNCTION(forte_add_device)
+
 MACRO(forte_add_network_layer NAME ONOFF CONFIGNAME CLASSNAME FILENAME DESCRIPTION)
 # TODO: parse filename from filename
   set(FORTE_COM_${NAME} ${ONOFF} CACHE BOOL "${DESCRIPTION}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -253,17 +253,26 @@ ENDFOREACH(FILE)
 FILE(WRITE ${CMAKE_BINARY_DIR}/file_list.txt "${WRITE_FILE}")
 
 ######################################################################################
-# Architecutre to build forte on
+# Architecutre to build 4diac FORTE on
 ######################################################################################
 set(FORTE_ARCHITECTURE "None" CACHE STRING "Architecture to build FORTE on")
 GET_PROPERTY(architectures GLOBAL PROPERTY FORTE_ARCHITECTURES)
 list(SORT architectures)
 set_property(CACHE FORTE_ARCHITECTURE PROPERTY STRINGS None ${architectures})
 
+######################################################################################
+# Device to be used in this 4diac FORTE instance
+######################################################################################
+set(FORTE_DEVICE "RMT_DEV" CACHE STRING "Device to be used in this 4diac FORTE instance")
+GET_PROPERTY(devices GLOBAL PROPERTY FORTE_DEVICES)
+list(SORT devices)
+set_property(CACHE FORTE_DEVICE PROPERTY STRINGS None ${devices})
+
+
 #######################################################################################
 # Link Libraries to the Executable
 #######################################################################################
-# get Linker-Direcotries from Modules
+# get Linker-Directories from Modules
 get_property(LINK_LIBRARY GLOBAL PROPERTY FORTE_LINK_LIBRARY)
 
 #######################################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,6 +268,7 @@ GET_PROPERTY(devices GLOBAL PROPERTY FORTE_DEVICES)
 list(SORT devices)
 set_property(CACHE FORTE_DEVICE PROPERTY STRINGS None ${devices})
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/forte_device_config.h.in ${CMAKE_BINARY_DIR}/forte_device_config.h)
 
 #######################################################################################
 # Link Libraries to the Executable

--- a/src/arch/ecos/forte_instance.cpp
+++ b/src/arch/ecos/forte_instance.cpp
@@ -109,10 +109,7 @@ void forteStopInstance(int paSig, TForteInstance paResultDevice){
  * \param The result
  */
 void createDev(const char *paMGRID, TForteInstance* paResultDevice){
-  RMT_DEV *poDev = new RMT_DEV;
-  poDev->initialize();
-
-  poDev->setMGR_ID(paMGRID);
+  CDevice *dev = CDevice::createDev(paMGRID);
   poDev->startDevice();
   *paResultDevice = poDev;
   DEVLOG_INFO("FORTE is up and running\n");

--- a/src/arch/ecos/forte_instance.h
+++ b/src/arch/ecos/forte_instance.h
@@ -37,9 +37,8 @@ extern "C" {
     FORTE_WRONG_ENDIANESS,
     FORTE_WRONG_PARAMETERS,
     FORTE_ARCHITECTURE_NOT_READY,
+    FORTE_COULD_NOT_CREATE_DEVICE,
   };
-
-  typedef void* TForteInstance;
 
   /**
    * \brief Start forte instance
@@ -47,7 +46,7 @@ extern "C" {
    * @param pa_resultDevice Address of an instance of forte
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int pa_port, TForteInstance* pa_resultDevice);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int pa_port);
 
   /**
    * \brief Start forte instance with posibilities of more arguments
@@ -56,14 +55,14 @@ extern "C" {
    * @param pa_resultDevice Address of an instance of forte
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int argc, char *arg[], TForteInstance* pa_resultDevice);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int argc, char *arg[]);
 
   /**
    * \brief Terminates a Forte instance
    * @param signal  Signal value to terminate instance
    * @param pa_resultDevice Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int signal, TForteInstance pa_resultDevice);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int signal);
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started

--- a/src/arch/ecos/forte_instance.h
+++ b/src/arch/ecos/forte_instance.h
@@ -40,13 +40,15 @@ extern "C" {
     FORTE_COULD_NOT_CREATE_DEVICE,
   };
 
+  typedef void* TForteInstance;
+
   /**
    * \brief Start forte instance
    * @param pa_port The port on which to forte will listen. Use 0 for default (normally 61499)
    * @param pa_resultDevice Address of an instance of forte
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int pa_port);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int pa_port, TForteInstance* paResultInstance);
 
   /**
    * \brief Start forte instance with posibilities of more arguments
@@ -55,14 +57,14 @@ extern "C" {
    * @param pa_resultDevice Address of an instance of forte
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int argc, char *arg[]);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int argc, char *arg[], TForteInstance* paResultInstance);
 
   /**
    * \brief Terminates a Forte instance
    * @param signal  Signal value to terminate instance
    * @param pa_resultDevice Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int signal);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int signal, TForteInstance paInstance);
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started

--- a/src/arch/ecos/phycoreat91/phycoreAT91main.cpp
+++ b/src/arch/ecos/phycoreat91/phycoreAT91main.cpp
@@ -10,7 +10,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *******************************************************************************/
 #include <fortenew.h>
-#include <device.h>
+#include "device.h"
 #include <cyg/kernel/kapi.h>
 #include <network.h>
 #include <cyg/hal/hal_io.h>             // IO macros
@@ -19,8 +19,7 @@ externC void
 cyg_user_start( void );
 
 void cyg_user_start(){
-  CDevice *dev = CDevice::createDev("");
-  dev->startDevice();
+  CDevice::startupNewDevice("");
 }
 
 //get the stuff that fixes some ecos cpp problems which have to be near the main

--- a/src/arch/ecos/phycoreat91/phycoreAT91main.cpp
+++ b/src/arch/ecos/phycoreat91/phycoreAT91main.cpp
@@ -10,7 +10,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *******************************************************************************/
 #include <fortenew.h>
-#include "../../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 #include <cyg/kernel/kapi.h>
 #include <network.h>
 #include <cyg/hal/hal_io.h>             // IO macros
@@ -19,7 +19,7 @@ externC void
 cyg_user_start( void );
 
 void cyg_user_start(){
-  RMT_DEV *dev = new RMT_DEV;  //otherwise we would loose the var if it is only on the stack
+  CDevice *dev = CDevice::createDev("");
   dev->startDevice();
 }
 

--- a/src/arch/ecos/phycoreat91/phycoreAT91main.cpp
+++ b/src/arch/ecos/phycoreat91/phycoreAT91main.cpp
@@ -10,7 +10,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *******************************************************************************/
 #include <fortenew.h>
-#include "device.h"
+#include "forteinstance.h"
 #include <cyg/kernel/kapi.h>
 #include <network.h>
 #include <cyg/hal/hal_io.h>             // IO macros
@@ -18,8 +18,10 @@
 externC void
 cyg_user_start( void );
 
+C4diacFORTEInstance g4diacForteInstance;
+
 void cyg_user_start(){
-  CDevice::startupNewDevice("");
+  g4diacForteInstance.startupNewDevice("");
 }
 
 //get the stuff that fixes some ecos cpp problems which have to be near the main

--- a/src/arch/freeRTOS/forte_Init.cpp
+++ b/src/arch/freeRTOS/forte_Init.cpp
@@ -18,7 +18,7 @@
 #include "forte_printer.h"
 #include <stdio.h>
 #include <string>
-#include "../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 
 #include "../utils/mainparam_utils.h"
 
@@ -90,7 +90,7 @@ int forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResu
 }
 
 void forteJoinInstance(TForteInstance paInstance) {
-  RMT_DEV *poDev = static_cast<RMT_DEV*>(paInstance);
+  CDevice *poDev = static_cast<CDevice*>(paInstance);
   if(0 != poDev) {
     poDev->awaitShutdown();
   }
@@ -101,7 +101,7 @@ void forteStopInstance(int paSig, TForteInstance paInstance) {
     return;
   }
   (void) paSig;
-  RMT_DEV *poDev = static_cast<RMT_DEV*>(paInstance);
+  CDevice *poDev = static_cast<CDevice*>(paInstance);
   if(0 != poDev) {
     poDev->changeFBExecutionState(EMGMCommandType::Kill);
     poDev->awaitShutdown();
@@ -115,10 +115,7 @@ void forteStopInstance(int paSig, TForteInstance paInstance) {
  * \param The result
  */
 void createDev(const char *paMGRID, TForteInstance* paInstance) {
-  RMT_DEV *device = new RMT_DEV;
-  device->initialize();
-
-  device->setMGR_ID(paMGRID);
+  CDevice *device = CDevice::createDev(paMGRID);
   device->startDevice();
   *paInstance = device;
   DEVLOG_INFO("FORTE is up and running\n");

--- a/src/arch/freeRTOS/forte_Init.cpp
+++ b/src/arch/freeRTOS/forte_Init.cpp
@@ -18,7 +18,7 @@
 #include "forte_printer.h"
 #include <stdio.h>
 #include <string>
-#include "device.h"
+#include "forteinstance.h"
 
 #include "../utils/mainparam_utils.h"
 
@@ -39,7 +39,7 @@ void forteGlobalDeinitialize() {
   CForteArchitecture::deinitialize();
 }
 
-int forteStartInstance(unsigned int paPort) {
+int forteStartInstance(unsigned int paPort, TForteInstance* paResultInstance) {
 
   if(65535 < paPort) {
     return FORTE_WRONG_PARAMETERS;
@@ -57,10 +57,10 @@ int forteStartInstance(unsigned int paPort) {
   strcat(address, port);
 
   char* arguments[] = { progName, flag, address };
-  return forteStartInstanceGeneric(3, arguments);
+  return forteStartInstanceGeneric(3, arguments, paResultInstance);
 }
 
-int forteStartInstanceGeneric(int paArgc, char *paArgv[]) {
+int forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResultInstance) {
 
   if(!CForteArchitecture::isInitialized()) {
     return FORTE_ARCHITECTURE_NOT_READY;
@@ -80,9 +80,12 @@ int forteStartInstanceGeneric(int paArgc, char *paArgv[]) {
 
   const char *pIpPort = parseCommandLineArguments(paArgc, paArgv);
   if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))) {
-    if(!CDevice::startupNewDevice(ipPort)) {
+    C4diacFORTEInstance *instance = new C4diacFORTEInstance();
+    if(!instance->startupNewDevice(ipPort)) {
+      delete instance;
       return FORTE_COULD_NOT_CREATE_DEVICE;
     }
+    *paResultInstance = instance;
     DEVLOG_INFO("FORTE is up and running\n");
   } else { //! If needed call listHelp() to list the help for FORTE
     return FORTE_WRONG_PARAMETERS;
@@ -91,16 +94,21 @@ int forteStartInstanceGeneric(int paArgc, char *paArgv[]) {
   return FORTE_OK;
 }
 
-void forteJoinInstance() {
-  CDevice::awaitDeviceShutdown();
+void forteJoinInstance(TForteInstance paInstance) {
+  C4diacFORTEInstance *instance = static_cast<C4diacFORTEInstance *>(paInstance);
+  if(instance != nullptr){
+    instance->awaitDeviceShutdown();
+  }
 }
 
-void forteStopInstance(int ) {
-  if(!CForteArchitecture::isInitialized()) {
+void forteStopInstance(int, TForteInstance paInstance) {
+  if(!CForteArchitecture::isInitialized() || paInstance != nullptr) {
     return;
   }
-  CDevice::triggerDeviceShutdown();
-  CDevice::awaitDeviceShutdown();
+  C4diacFORTEInstance *instance = static_cast<C4diacFORTEInstance *>(paInstance);
+  instance->triggerDeviceShutdown();
+  instance->awaitDeviceShutdown();
+  delete instance;
   DEVLOG_INFO("FORTE finished\n");
 }
 

--- a/src/arch/freeRTOS/forte_Init.h
+++ b/src/arch/freeRTOS/forte_Init.h
@@ -36,9 +36,8 @@ extern "C" {
     FORTE_WRONG_ENDIANESS,
     FORTE_WRONG_PARAMETERS,
     FORTE_ARCHITECTURE_NOT_READY,
+    FORTE_COULD_NOT_CREATE_DEVICE
   };
-
-  typedef void* TForteInstance;
 
   /**
    * \brief Start forte instance
@@ -46,7 +45,7 @@ extern "C" {
    * @param paResultInstance Address of an instance of forte where the new instance is stored
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int paPort, TForteInstance* paResultInstance);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int paPort);
 
   /**
    * \brief Start forte instance with possibilities of more arguments
@@ -55,20 +54,20 @@ extern "C" {
    * @param paResultInstance Address of an instance of forte where the new instance is stored
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResultInstance);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int paArgc, char *paArgv[]);
 
   /**
    * \brief Terminates a Forte instance
    * @param paSignal  Signal value to terminate instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal, TForteInstance paInstance);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal);
 
   /**
    * \brief Terminates a Forte instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance(TForteInstance paInstance);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance();
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started

--- a/src/arch/freeRTOS/forte_Init.h
+++ b/src/arch/freeRTOS/forte_Init.h
@@ -39,13 +39,14 @@ extern "C" {
     FORTE_COULD_NOT_CREATE_DEVICE
   };
 
+  typedef void* TForteInstance;
   /**
    * \brief Start forte instance
    * @param paPort The port on which to forte will listen. Use 0 for default (normally 61499)
    * @param paResultInstance Address of an instance of forte where the new instance is stored
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int paPort);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int paPort, TForteInstance* paResultInstance);
 
   /**
    * \brief Start forte instance with possibilities of more arguments
@@ -54,20 +55,20 @@ extern "C" {
    * @param paResultInstance Address of an instance of forte where the new instance is stored
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int paArgc, char *paArgv[]);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance pInstance);
 
   /**
    * \brief Terminates a Forte instance
    * @param paSignal  Signal value to terminate instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal, TForteInstance paInstance);
 
   /**
    * \brief Terminates a Forte instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance();
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance(TForteInstance paInstance);
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started

--- a/src/arch/freeRTOS/main.cpp
+++ b/src/arch/freeRTOS/main.cpp
@@ -15,19 +15,18 @@
 
 #include "../forte_architecture.h"
 #include "../devlog.h"
-#include <device.h>
+#include "device.h"
 
 const static unsigned mainFORTE_TASK_PRIORITY = tskIDLE_PRIORITY + 1;
 
 void vForteTask(void* pvParameters) {
   (void) pvParameters;
 
-  CDevice *dev = CDevice::createDev("localhost:61499");
-  dev->startDevice();
-  DEVLOG_INFO("FORTE is up and running\n");
-  dev->awaitShutdown();
-  DEVLOG_INFO("FORTE finished\n");
-  delete dev;
+  if(CDevice::startupNewDevice (pIpPort)) {
+    DEVLOG_INFO("FORTE is up and running\n");
+    CDevice::awaitDeviceShutdown();
+    DEVLOG_INFO("FORTE finished\n");
+  }
   vTaskDelete(nullptr);
 }
 

--- a/src/arch/freeRTOS/main.cpp
+++ b/src/arch/freeRTOS/main.cpp
@@ -15,22 +15,19 @@
 
 #include "../forte_architecture.h"
 #include "../devlog.h"
-#include "../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 
 const static unsigned mainFORTE_TASK_PRIORITY = tskIDLE_PRIORITY + 1;
 
 void vForteTask(void* pvParameters) {
   (void) pvParameters;
 
-  RMT_DEV *poDev = new RMT_DEV;
-  poDev->initialize();
-
-  poDev->setMGR_ID("localhost:61499");
-  poDev->startDevice();
+  CDevice *dev = CDevice::createDev("localhost:61499");
+  dev->startDevice();
   DEVLOG_INFO("FORTE is up and running\n");
-  poDev->awaitShutdown();
+  dev->awaitShutdown();
   DEVLOG_INFO("FORTE finished\n");
-  delete poDev;
+  delete dev;
   vTaskDelete(nullptr);
 }
 

--- a/src/arch/freeRTOS/main.cpp
+++ b/src/arch/freeRTOS/main.cpp
@@ -15,16 +15,16 @@
 
 #include "../forte_architecture.h"
 #include "../devlog.h"
-#include "device.h"
+#include "forteinstance.h"
 
 const static unsigned mainFORTE_TASK_PRIORITY = tskIDLE_PRIORITY + 1;
 
-void vForteTask(void* pvParameters) {
-  (void) pvParameters;
+void vForteTask(void* ) {
+  C4diacFORTEInstance instance;
 
-  if(CDevice::startupNewDevice (pIpPort)) {
+  if(instance.startupNewDevice (pIpPort)) {
     DEVLOG_INFO("FORTE is up and running\n");
-    CDevice::awaitDeviceShutdown();
+    instance.awaitDeviceShutdown();
     DEVLOG_INFO("FORTE finished\n");
   }
   vTaskDelete(nullptr);

--- a/src/arch/pikeos_posix/main.cpp
+++ b/src/arch/pikeos_posix/main.cpp
@@ -14,7 +14,7 @@
 #include <fortenew.h>
 #include <stdio.h>
 #include <signal.h>
-#include <device.h>
+#include "device.h"
 
 #include "../utils/mainparam_utils.h"
 
@@ -42,13 +42,8 @@ extern "C" void __cxa_pure_virtual(void){
 }
 #endif
 
-CDevice *poDev = nullptr;
-
-void endForte(int paSig){
-  (void) paSig;
-  if(0 != poDev){
-    poDev->changeFBExecutionState(EMGMCommandType::Kill);
-  }
+void endForte(int ){
+  CDevice::triggerDeviceShutdown();
 }
 
 /*!\brief Creates the Device-Object
@@ -60,12 +55,11 @@ void createDev(const char *paMGRID){
   signal(SIGTERM, endForte);
   signal(SIGHUP, endForte);
 
-  poDev = CDevice::createDev(paMGRID);
-  poDev->startDevice();
-  DEVLOG_INFO("FORTE is up and running\n");
-  poDev->awaitShutdown();
-  DEVLOG_INFO("FORTE finished\n");
-  delete poDev;
+  if(CDevice::startupNewDevice (pIpPort)) {
+    DEVLOG_INFO("FORTE is up and running\n");
+    CDevice::awaitDeviceShutdown();
+    DEVLOG_INFO("FORTE finished\n");
+  }
 }
 
 int main(int argc, char *arg[]){

--- a/src/arch/pikeos_posix/main.cpp
+++ b/src/arch/pikeos_posix/main.cpp
@@ -14,14 +14,10 @@
 #include <fortenew.h>
 #include <stdio.h>
 #include <signal.h>
-#include "../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 
 #include "../utils/mainparam_utils.h"
 
-
-#ifdef CONFIG_POWERLINK_USERSTACK
-#include <EplWrapper.h>
-#endif
 
 /* CG: testing */
 #include <sys/debug.h>
@@ -46,7 +42,7 @@ extern "C" void __cxa_pure_virtual(void){
 }
 #endif
 
-RMT_DEV *poDev = 0;
+CDevice *poDev = nullptr;
 
 void endForte(int paSig){
   (void) paSig;
@@ -64,14 +60,7 @@ void createDev(const char *paMGRID){
   signal(SIGTERM, endForte);
   signal(SIGHUP, endForte);
 
-#ifdef CONFIG_POWERLINK_USERSTACK
-  CEplStackWrapper::eplMainInit();
-#endif
-
-  poDev = new RMT_DEV;
-  poDev->initialize();
-
-  poDev->setMGR_ID(paMGRID);
+  poDev = CDevice::createDev(paMGRID);
   poDev->startDevice();
   DEVLOG_INFO("FORTE is up and running\n");
   poDev->awaitShutdown();

--- a/src/arch/pikeos_posix/main.cpp
+++ b/src/arch/pikeos_posix/main.cpp
@@ -14,7 +14,7 @@
 #include <fortenew.h>
 #include <stdio.h>
 #include <signal.h>
-#include "device.h"
+#include "forteinstance.h"
 
 #include "../utils/mainparam_utils.h"
 
@@ -32,6 +32,8 @@
  */
 void checkEndianess();
 
+C4diacFORTEInstance g4diacForteInstance;
+
 //this keeps away a lot of rtti and exception handling stuff
 #ifndef __cpp_exceptions
 extern "C" void __cxa_pure_virtual(void){
@@ -43,23 +45,7 @@ extern "C" void __cxa_pure_virtual(void){
 #endif
 
 void endForte(int ){
-  CDevice::triggerDeviceShutdown();
-}
-
-/*!\brief Creates the Device-Object
- * \param paMGRID A string containing IP and Port like [IP]:[Port]
- */
-void createDev(const char *paMGRID){
-
-  signal(SIGINT, endForte);
-  signal(SIGTERM, endForte);
-  signal(SIGHUP, endForte);
-
-  if(CDevice::startupNewDevice (pIpPort)) {
-    DEVLOG_INFO("FORTE is up and running\n");
-    CDevice::awaitDeviceShutdown();
-    DEVLOG_INFO("FORTE finished\n");
-  }
+  g4diacForteInstance.triggerDeviceShutdown();
 }
 
 int main(int argc, char *arg[]){
@@ -75,11 +61,17 @@ int main(int argc, char *arg[]){
   }
 #endif
 
-  //gdb_breakpoint();
+  signal(SIGINT, endForte);
+  signal(SIGTERM, endForte);
+  signal(SIGHUP, endForte);
 
   const char *pIpPort = parseCommandLineArguments(argc, arg);
   if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))){
-    createDev(pIpPort);
+    if(g4diacForteInstance.startupNewDevice(pIpPort)) {
+      DEVLOG_INFO("FORTE is up and running\n");
+      g4diacForteInstance.awaitDeviceShutdown();
+      DEVLOG_INFO("FORTE finished\n");
+    }
   }
   else{ //! Lists the help for FORTE
     listHelp();

--- a/src/arch/plcnext/ForteComponent.cpp
+++ b/src/arch/plcnext/ForteComponent.cpp
@@ -15,7 +15,7 @@
 namespace ForteLibrary {
 
   void ForteComponent::Initialize(){
-    mDev = new RMT_DEV;
+    mDev = CDevice::createDev("");
   }
 
   void ForteComponent::LoadSettings(const String& /*paSettingsPath*/){
@@ -31,7 +31,6 @@ namespace ForteLibrary {
   }
 
   void ForteComponent::SetupConfig(){
-    mDev->setMGR_ID("localhost:61499");
     mDev->startDevice();
   }
 

--- a/src/arch/plcnext/ForteComponent.cpp
+++ b/src/arch/plcnext/ForteComponent.cpp
@@ -15,7 +15,6 @@
 namespace ForteLibrary {
 
   void ForteComponent::Initialize(){
-    mDev = CDevice::createDev("");
   }
 
   void ForteComponent::LoadSettings(const String& /*paSettingsPath*/){
@@ -31,7 +30,7 @@ namespace ForteLibrary {
   }
 
   void ForteComponent::SetupConfig(){
-    mDev->startDevice();
+    CDevice::startupNewDevice(pIpPort);
   }
 
   void ForteComponent::ResetConfig(){
@@ -41,14 +40,10 @@ namespace ForteLibrary {
   }
 
   void ForteComponent::Dispose(){
-    delete mDev;
-    mDev = 0;
   }
 
   void ForteComponent::PowerDown(){
-    if(0 != mDev){
-      mDev->changeFBExecutionState(EMGMCommandType::Kill);
-    }
+    CDevice::triggerDeviceShutdown();
   }
 
 } // end of namespace ForteLibrary

--- a/src/arch/plcnext/ForteComponent.cpp
+++ b/src/arch/plcnext/ForteComponent.cpp
@@ -30,7 +30,7 @@ namespace ForteLibrary {
   }
 
   void ForteComponent::SetupConfig(){
-    CDevice::startupNewDevice(pIpPort);
+    m4diacForteInstance.startupNewDevice(pIpPort);
   }
 
   void ForteComponent::ResetConfig(){
@@ -43,7 +43,7 @@ namespace ForteLibrary {
   }
 
   void ForteComponent::PowerDown(){
-    CDevice::triggerDeviceShutdown();
+    m4diacForteInstance.triggerDeviceShutdown();
   }
 
 } // end of namespace ForteLibrary

--- a/src/arch/plcnext/ForteComponent.h
+++ b/src/arch/plcnext/ForteComponent.h
@@ -18,7 +18,6 @@
 
 #include "ForteComponentProgramProvider.h"
 
-#include "../../stdfblib/ita/RMT_DEV.h"
 
 using namespace Arp;
 using namespace Arp::System::Acf;
@@ -51,7 +50,6 @@ namespace ForteLibrary{
 
     private:
         ForteComponentProgramProvider mProgramProvider;
-        RMT_DEV *mDev;
   };
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/arch/plcnext/ForteComponent.h
+++ b/src/arch/plcnext/ForteComponent.h
@@ -50,6 +50,8 @@ namespace ForteLibrary{
 
     private:
         ForteComponentProgramProvider mProgramProvider;
+
+        C4diacFORTEInstance m4diacForteInstance;
   };
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/arch/posix/main.cpp
+++ b/src/arch/posix/main.cpp
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include "../startuphook.h"
-#include "device.h"
+#include "forteinstance.h"
 
 #include "../utils/mainparam_utils.h"
 
@@ -32,6 +32,8 @@ void checkEndianess();
 
 void hookSignals();
 
+C4diacFORTEInstance g4diacForteInstance;
+
 //this keeps away a lot of rtti and exception handling stuff
 #ifndef __cpp_exceptions
 extern "C" void __cxa_pure_virtual(void){
@@ -43,7 +45,7 @@ extern "C" void __cxa_pure_virtual(void){
 #endif
 
 void endForte(int ){
-  CDevice::triggerDeviceShutdown();
+  g4diacForteInstance.triggerDeviceShutdown();
 }
 
 int main(int argc, char *arg[]){
@@ -61,9 +63,9 @@ int main(int argc, char *arg[]){
 
   const char *pIpPort = parseCommandLineArguments(argc, arg);
   if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))) {
-    if(CDevice::startupNewDevice(pIpPort)) {
+    if(g4diacForteInstance.startupNewDevice(pIpPort)) {
       DEVLOG_INFO("FORTE is up and running\n");
-      CDevice::awaitDeviceShutdown();
+      g4diacForteInstance.awaitDeviceShutdown();
       DEVLOG_INFO("FORTE finished\n");
     }
   }

--- a/src/arch/posix/main.cpp
+++ b/src/arch/posix/main.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2023 ACIN, Profactor GmbH, AIT, fortiss GmbH,
+ * Copyright (c) 2006, 2024 ACIN, Profactor GmbH, AIT, fortiss GmbH,
  *                          Primetals Technologies Austria GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include "../startuphook.h"
-#include "../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 
 #include "../utils/mainparam_utils.h"
 
@@ -51,16 +51,6 @@ void endForte(int paSig){
   }
 }
 
-/*!\brief Creates the Device-Object
- * \param paMGRID A string containing IP and Port like [IP]:[Port]
- */
-CDevice *createDev(const char *paMGRID){
-  RMT_DEV *dev = new RMT_DEV;
-  dev->initialize();
-  dev->setMGR_ID(paMGRID);
-  return dev;
-}
-
 int main(int argc, char *arg[]){
 
   checkEndianess();
@@ -76,7 +66,7 @@ int main(int argc, char *arg[]){
 
   const char *pIpPort = parseCommandLineArguments(argc, arg);
   if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))) {
-    gRunningDev = createDev(pIpPort);
+    gRunningDev = CDevice::createDev(pIpPort);
     if(gRunningDev != nullptr) {
       gRunningDev->startDevice();
       DEVLOG_INFO("FORTE is up and running\n");

--- a/src/arch/posix/main.cpp
+++ b/src/arch/posix/main.cpp
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include "../startuphook.h"
-#include <device.h>
+#include "device.h"
 
 #include "../utils/mainparam_utils.h"
 
@@ -42,13 +42,8 @@ extern "C" void __cxa_pure_virtual(void){
 }
 #endif
 
-CDevice *gRunningDev = nullptr;
-
-void endForte(int paSig){
-  (void) paSig;
-  if(gRunningDev != nullptr){
-    gRunningDev->changeFBExecutionState(EMGMCommandType::Kill);
-  }
+void endForte(int ){
+  CDevice::triggerDeviceShutdown();
 }
 
 int main(int argc, char *arg[]){
@@ -66,14 +61,10 @@ int main(int argc, char *arg[]){
 
   const char *pIpPort = parseCommandLineArguments(argc, arg);
   if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))) {
-    gRunningDev = CDevice::createDev(pIpPort);
-    if(gRunningDev != nullptr) {
-      gRunningDev->startDevice();
+    if(CDevice::startupNewDevice(pIpPort)) {
       DEVLOG_INFO("FORTE is up and running\n");
-      gRunningDev->awaitShutdown();
+      CDevice::awaitDeviceShutdown();
       DEVLOG_INFO("FORTE finished\n");
-      delete gRunningDev;
-      gRunningDev = nullptr;
     }
   }
   else{ //! Lists the help for FORTE

--- a/src/arch/rcX/forte_instance.cpp
+++ b/src/arch/rcX/forte_instance.cpp
@@ -17,7 +17,7 @@
 #include "forte_printer.h"
 #include <stdio.h>
 #include <string>
-#include "../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 
 #include "../utils/mainparam_utils.h"
 
@@ -95,7 +95,7 @@ void forteStopInstance(int paSig, TForteInstance pa_resultDevice){
     return;
   }
   (void) paSig;
-  RMT_DEV *poDev = static_cast<RMT_DEV*>(pa_resultDevice);
+  CDevice *poDev = static_cast<CDevice*>(pa_resultDevice);
   if(0 != poDev){
     poDev->changeFBExecutionState(EMGMCommandType::Kill);
     poDev->awaitShutdown();
@@ -109,10 +109,7 @@ void forteStopInstance(int paSig, TForteInstance pa_resultDevice){
  * \param The result
  */
 void createDev(const char *paMGRID, TForteInstance* pa_resultDevice){
-  RMT_DEV *poDev = new RMT_DEV;
-  poDev->initialize();
-
-  poDev->setMGR_ID(paMGRID);
+  CDevice *poDev = CDevice::createDev(paMGRID);
   poDev->startDevice();
   *pa_resultDevice = poDev;
   DEVLOG_INFO("FORTE is up and running\n");

--- a/src/arch/rcX/forte_instance.cpp
+++ b/src/arch/rcX/forte_instance.cpp
@@ -37,7 +37,7 @@ void forteGlobalDeinitialize(){
   CForteArchitecture::deinitialize();
 }
 
-int forteStartInstance(unsigned int pa_port, TForteInstance* pa_resultDevice){
+int forteStartInstance(unsigned int pa_port, TForteInstance* paResultDevice){
 
   if (65535 < pa_port){
     return FORTE_WRONG_PARAMETERS;
@@ -55,11 +55,11 @@ int forteStartInstance(unsigned int pa_port, TForteInstance* pa_resultDevice){
   strcat(address, port);
 
   char* arguments[] = { progName, flag, address };
-  return forteStartInstanceGeneric(3, arguments, pa_resultDevice);
+  return forteStartInstanceGeneric(3, arguments, paResultDevice);
 }
 
 
-int forteStartInstanceGeneric(int argc, char *arg[], TForteInstance* pa_resultDevice){
+int forteStartInstanceGeneric(int argc, char *arg[], TForteInstance* paResultDevice){
 
   if(!CForteArchitecture::isInitialized()){
     return FORTE_ARCHITECTURE_NOT_READY;
@@ -79,9 +79,12 @@ int forteStartInstanceGeneric(int argc, char *arg[], TForteInstance* pa_resultDe
 
   const char *pIpPort = parseCommandLineArguments(argc, arg);
   if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))){
-    if(!CDevice::startupNewDevice(ipPort)) {
+    C4diacFORTEInstance *instance = new C4diacFORTEInstance();
+    if(!instance->startupNewDevice(ipPort)) {
+      delete instance;
       return FORTE_COULD_NOT_CREATE_DEVICE;
     }
+    *paResultDevice = instance;
     DEVLOG_INFO("FORTE is up and running\n");
   }
   else{ //! If needed call listHelp() to list the help for FORTE
@@ -91,12 +94,14 @@ int forteStartInstanceGeneric(int argc, char *arg[], TForteInstance* pa_resultDe
   return FORTE_OK;
 }
 
-void forteStopInstance(int ){
-  if(!CForteArchitecture::isInitialized()){
+void forteStopInstance(int, TForteInstance paInstance){
+  if(!CForteArchitecture::isInitialized()|| paInstance != nullptr){
     return;
   }
-  CDevice::triggerDeviceShutdown();
-  CDevice::awaitDeviceShutdown();
+  C4diacFORTEInstance *instance = static_cast<C4diacFORTEInstance*>(paInstance);
+  instance->triggerDeviceShutdown();
+  instance->awaitDeviceShutdown();
+  delete instance;
   DEVLOG_INFO("FORTE finished\n");
 }
 

--- a/src/arch/rcX/forte_instance.h
+++ b/src/arch/rcX/forte_instance.h
@@ -37,9 +37,8 @@ extern "C" {
     FORTE_WRONG_ENDIANESS,
     FORTE_WRONG_PARAMETERS,
     FORTE_ARCHITECTURE_NOT_READY,
+    FORTE_COULD_NOT_CREATE_DEVICE
   };
-
-  typedef void* TForteInstance;
 
   /**
    * \brief Start forte instance
@@ -47,7 +46,7 @@ extern "C" {
    * @param pa_resultDevice Address of an instance of forte
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int pa_port, TForteInstance* pa_resultDevice);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int pa_port);
 
   /**
    * \brief Start forte instance with posibilities of more arguments
@@ -56,14 +55,14 @@ extern "C" {
    * @param pa_resultDevice Address of an instance of forte
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int argc, char *arg[], TForteInstance* pa_resultDevice);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int argc, char *arg[]);
 
   /**
    * \brief Terminates a Forte instance
    * @param signal  Signal value to terminate instance
    * @param pa_resultDevice Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int signal, TForteInstance pa_resultDevice);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int signal);
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started

--- a/src/arch/rcX/forte_instance.h
+++ b/src/arch/rcX/forte_instance.h
@@ -40,13 +40,14 @@ extern "C" {
     FORTE_COULD_NOT_CREATE_DEVICE
   };
 
+  typedef void* TForteInstance;
   /**
    * \brief Start forte instance
    * @param pa_port The port on which to forte will listen. Use 0 for default (normally 61499)
    * @param pa_resultDevice Address of an instance of forte
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int pa_port);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int pa_port, TForteInstance* paResultInstance);
 
   /**
    * \brief Start forte instance with posibilities of more arguments
@@ -55,14 +56,14 @@ extern "C" {
    * @param pa_resultDevice Address of an instance of forte
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int argc, char *arg[]);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int argc, char *arg[], TForteInstance* paResultInstance);
 
   /**
    * \brief Terminates a Forte instance
    * @param signal  Signal value to terminate instance
    * @param pa_resultDevice Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int signal);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int signal, TForteInstance paInstance);
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started

--- a/src/arch/vxworks/main.cpp
+++ b/src/arch/vxworks/main.cpp
@@ -12,11 +12,7 @@
 #include <fortenew.h>
 #include <stdio.h>
 #include <signal.h>
-#include "../../stdfblib/ita/RMT_DEV.h"
-
-#ifdef CONFIG_POWERLINK_USERSTACK
-#include <EplWrapper.h>
-#endif
+#include <device.h>
 
 /*!\brief Check if the correct endianess has been configured.
  *
@@ -34,7 +30,7 @@ extern "C" void __cxa_pure_virtual(void){
 }
 #endif
 
-RMT_DEV *poDev = 0;
+CDevice *poDev = 0;
 
 void endForte(int paSig){
   (void) paSig;
@@ -52,14 +48,7 @@ void createDev(const char *paMGRID){
   signal(SIGTERM, endForte);
   signal(SIGHUP, endForte);
 
-#ifdef CONFIG_POWERLINK_USERSTACK
-  CEplStackWrapper::eplMainInit();
-#endif
-
-  poDev = new RMT_DEV;
-  poDev->initialize();
-
-  poDev->setMGR_ID(paMGRID);
+  poDev = CDevice::createDev(paMGRID);
   poDev->startDevice();
   DEVLOG_INFO("FORTE is up and running\n");
   poDev->awaitShutdown();

--- a/src/arch/vxworks/main.cpp
+++ b/src/arch/vxworks/main.cpp
@@ -12,7 +12,7 @@
 #include <fortenew.h>
 #include <stdio.h>
 #include <signal.h>
-#include <device.h>
+#include "device.h"
 
 /*!\brief Check if the correct endianess has been configured.
  *
@@ -30,13 +30,8 @@ extern "C" void __cxa_pure_virtual(void){
 }
 #endif
 
-CDevice *poDev = 0;
-
-void endForte(int paSig){
-  (void) paSig;
-  if(0 != poDev){
-    poDev->changeFBExecutionState(EMGMCommandType::Kill);
-  }
+void endForte(int ){
+  CDevice::triggerDeviceShutdown();
 }
 
 /*!\brief Creates the Device-Object
@@ -48,12 +43,11 @@ void createDev(const char *paMGRID){
   signal(SIGTERM, endForte);
   signal(SIGHUP, endForte);
 
-  poDev = CDevice::createDev(paMGRID);
-  poDev->startDevice();
-  DEVLOG_INFO("FORTE is up and running\n");
-  poDev->awaitShutdown();
-  DEVLOG_INFO("FORTE finished\n");
-  delete poDev;
+  if(CDevice::startupNewDevice (pIpPort)) {
+    DEVLOG_INFO("FORTE is up and running\n");
+    CDevice::awaitDeviceShutdown();
+    DEVLOG_INFO("FORTE finished\n");
+  }
 }
 
 /*!\brief Lists the help for FORTE

--- a/src/arch/vxworks/main.cpp
+++ b/src/arch/vxworks/main.cpp
@@ -12,13 +12,15 @@
 #include <fortenew.h>
 #include <stdio.h>
 #include <signal.h>
-#include "device.h"
+#include "forteinstance.h"
 
 /*!\brief Check if the correct endianess has been configured.
  *
  * If the right endianess is not set this function will end FORTE.
  */
 void checkEndianess();
+
+C4diacFORTEInstance g4diacForteInstance;
 
 //this keeps away a lot of rtti and exception handling stuff
 #ifndef __cpp_exceptions
@@ -31,42 +33,22 @@ extern "C" void __cxa_pure_virtual(void){
 #endif
 
 void endForte(int ){
-  CDevice::triggerDeviceShutdown();
-}
-
-/*!\brief Creates the Device-Object
- * \param paMGRID A string containing IP and Port like [IP]:[Port]
- */
-void createDev(const char *paMGRID){
-
-  signal(SIGINT, endForte);
-  signal(SIGTERM, endForte);
-  signal(SIGHUP, endForte);
-
-  if(CDevice::startupNewDevice (pIpPort)) {
-    DEVLOG_INFO("FORTE is up and running\n");
-    CDevice::awaitDeviceShutdown();
-    DEVLOG_INFO("FORTE finished\n");
-  }
-}
-
-/*!\brief Lists the help for FORTE
- *
- */
-void listHelp(){
-  printf("\nUsage of FORTE:\n");
-  printf("   -h\t lists this help.\n");
-  printf("\n");
-  printf("   -c\t sets the destination for the connection.\n");
-  printf("     \t Usage: forte -c <IP>:<Port>");
-  printf("\n");
+  g4diacForteInstance.triggerDeviceShutdown();
 }
 
 int startForte(){
 
   checkEndianess();
 
-  createDev("localhost:61499");
+  signal(SIGINT, endForte);
+  signal(SIGTERM, endForte);
+  signal(SIGHUP, endForte);
+
+  if(g4diacForteInstance.startupNewDevice("")) {
+    DEVLOG_INFO("FORTE is up and running\n");
+    g4diacForteInstance.awaitDeviceShutdown();
+    DEVLOG_INFO("FORTE finished\n");
+  }
   return 0;
 }
 

--- a/src/arch/win32/forte_instance.cpp
+++ b/src/arch/win32/forte_instance.cpp
@@ -12,27 +12,21 @@
 #include "forte_instance.h"
 #include "fortenew.h"
 #include "forte_architecture.h"
-#include <device.h>
+#include "device.h"
 
 #include <forteinit.h>
 
-CDevice *gDev = nullptr;
 
 extern "C"
 void startupFORTE(){
   CForteArchitecture::initialize();
   initForte();
-  gDev = CDevice::createDev("");
-  gDev->startDevice();
+  CDevice::startupNewDevice("");
 }
 
 extern "C"
 void shutdownFORTE(){
-  if(0 != gDev){
-    gDev->changeFBExecutionState(EMGMCommandType::Kill);
-    gDev->awaitShutdown();
-    delete gDev;
-    gDev = 0;
-  }
+  CDevice::triggerDeviceShutdown();
+  CDevice::awaitDeviceShutdown();
 }
 

--- a/src/arch/win32/forte_instance.cpp
+++ b/src/arch/win32/forte_instance.cpp
@@ -12,17 +12,17 @@
 #include "forte_instance.h"
 #include "fortenew.h"
 #include "forte_architecture.h"
-#include "../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 
 #include <forteinit.h>
 
-RMT_DEV *gDev = 0;
+CDevice *gDev = nullptr;
 
 extern "C"
 void startupFORTE(){
   CForteArchitecture::initialize();
   initForte();
-  gDev = new RMT_DEV;
+  gDev = CDevice::createDev("");
   gDev->startDevice();
 }
 

--- a/src/arch/win32/forte_instance.cpp
+++ b/src/arch/win32/forte_instance.cpp
@@ -12,21 +12,22 @@
 #include "forte_instance.h"
 #include "fortenew.h"
 #include "forte_architecture.h"
-#include "device.h"
+#include "forteinstance.h"
 
 #include <forteinit.h>
 
+C4diacFORTEInstance g4diacForteLibInstance;
 
 extern "C"
 void startupFORTE(){
   CForteArchitecture::initialize();
   initForte();
-  CDevice::startupNewDevice("");
+  g4diacForteLibInstance.startupNewDevice("");
 }
 
 extern "C"
 void shutdownFORTE(){
-  CDevice::triggerDeviceShutdown();
-  CDevice::awaitDeviceShutdown();
+  g4diacForteLibInstance.triggerDeviceShutdown();
+  g4diacForteLibInstance.awaitDeviceShutdown();
 }
 

--- a/src/arch/win32/main.cpp
+++ b/src/arch/win32/main.cpp
@@ -13,7 +13,7 @@
 #include "../forte_architecture.h"
 #include "../devlog.h"
 #include "../startuphook.h"
-#include <device.h>
+#include "device.h"
 #include "../utils/mainparam_utils.h"
 
 #include <stdio.h>
@@ -31,13 +31,8 @@ extern "C" void __cxa_pure_virtual(void){
 }
 #endif
 
-CDevice *gRunningDev = nullptr;
-
-void endForte(int paSig){
-  (void) paSig;
-  if(gRunningDev != nullptr){
-    gRunningDev->changeFBExecutionState(EMGMCommandType::Kill);
-  }
+void endForte(int ){
+  CDevice::triggerDeviceShutdown();
 }
 
 int main(int argc, char *arg[]){
@@ -50,14 +45,10 @@ int main(int argc, char *arg[]){
 
     const char *pIpPort = parseCommandLineArguments(argc, arg);
     if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))){
-      gRunningDev = CDevice::createDev(pIpPort);
-      if(gRunningDev != nullptr){
-        gRunningDev->startDevice();
+      if(CDevice::startupNewDevice(pIpPort)) {
         DEVLOG_INFO("FORTE is up and running\n");
-        gRunningDev->awaitShutdown();
+        CDevice::awaitDeviceShutdown();
         DEVLOG_INFO("FORTE finished\n");
-        delete gRunningDev;
-        gRunningDev = nullptr;
       }
     }
     else{ //! Lists the help for FORTE

--- a/src/arch/win32/main.cpp
+++ b/src/arch/win32/main.cpp
@@ -13,7 +13,7 @@
 #include "../forte_architecture.h"
 #include "../devlog.h"
 #include "../startuphook.h"
-#include "../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 #include "../utils/mainparam_utils.h"
 
 #include <stdio.h>
@@ -40,17 +40,6 @@ void endForte(int paSig){
   }
 }
 
-/*!\brief Creates the Device-Object
- * \param paMGRID A string containing IP and Port like [IP]:[Port]
- * \return the newly created and configured device object
- */
-CDevice *createDev(const char *paMGRID){
-  RMT_DEV *dev = new RMT_DEV;
-  dev->initialize();
-  dev->setMGR_ID(paMGRID);
-  return dev;
-}
-
 int main(int argc, char *arg[]){
 
   if(CForteArchitecture::initialize()){
@@ -61,7 +50,7 @@ int main(int argc, char *arg[]){
 
     const char *pIpPort = parseCommandLineArguments(argc, arg);
     if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))){
-      gRunningDev = createDev(pIpPort);
+      gRunningDev = CDevice::createDev(pIpPort);
       if(gRunningDev != nullptr){
         gRunningDev->startDevice();
         DEVLOG_INFO("FORTE is up and running\n");

--- a/src/arch/win32/main.cpp
+++ b/src/arch/win32/main.cpp
@@ -13,13 +13,15 @@
 #include "../forte_architecture.h"
 #include "../devlog.h"
 #include "../startuphook.h"
-#include "device.h"
+#include "forteinstance.h"
 #include "../utils/mainparam_utils.h"
 
 #include <stdio.h>
 #include <signal.h>
 
 void hookSignals();
+
+C4diacFORTEInstance g4diacForteInstance;
 
 //this keeps away a lot of rtti and exception handling stuff
 #ifndef __cpp_exceptions
@@ -32,7 +34,7 @@ extern "C" void __cxa_pure_virtual(void){
 #endif
 
 void endForte(int ){
-  CDevice::triggerDeviceShutdown();
+  g4diacForteInstance.triggerDeviceShutdown();
 }
 
 int main(int argc, char *arg[]){
@@ -45,9 +47,9 @@ int main(int argc, char *arg[]){
 
     const char *pIpPort = parseCommandLineArguments(argc, arg);
     if((0 != strlen(pIpPort)) && (nullptr != strchr(pIpPort, ':'))){
-      if(CDevice::startupNewDevice(pIpPort)) {
+      if(g4diacForteInstance.startupNewDevice(pIpPort)) {
         DEVLOG_INFO("FORTE is up and running\n");
-        CDevice::awaitDeviceShutdown();
+        g4diacForteInstance.awaitDeviceShutdown();
         DEVLOG_INFO("FORTE finished\n");
       }
     }

--- a/src/arch/zephyr/forte_Init.cpp
+++ b/src/arch/zephyr/forte_Init.cpp
@@ -17,7 +17,7 @@
 #include "forte_printer.h"
 #include <stdio.h>
 #include <string>
-#include <device.h>
+#include "device.h"
 
 #include "../utils/mainparam_utils.h"
 
@@ -31,7 +31,6 @@ constexpr unsigned int forte_default_port = 61499;
  */
 
 bool checkEndianess();
-void createDev(const char *paMGRID, TForteInstance* paResultInstance);
 
 void forteGlobalInitialize() {
   CForteArchitecture::initialize();
@@ -41,7 +40,7 @@ void forteGlobalDeinitialize() {
   CForteArchitecture::deinitialize();
 }
 
-int forteStartInstance(unsigned int paPort, TForteInstance* paResultInstance) {
+int forteStartInstance(unsigned int paPort) {
 
   if(65535 < paPort) {
     return FORTE_WRONG_PARAMETERS;
@@ -58,10 +57,10 @@ int forteStartInstance(unsigned int paPort, TForteInstance* paResultInstance) {
   forte_snprintf(port, 6, "%u", paPort);
   strcat(address, port);
   char* arguments[] = { progName, flag, address };
-  return forteStartInstanceGeneric(3, arguments, paResultInstance);
+  return forteStartInstanceGeneric(3, arguments);
 }
 
-int forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResultInstance) {
+int forteStartInstanceGeneric(int paArgc, char *paArgv[]) {
 
   if(!CForteArchitecture::isInitialized()) {
     return FORTE_ARCHITECTURE_NOT_READY;
@@ -81,7 +80,10 @@ int forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResu
 
   const char *ipPort = parseCommandLineArguments(paArgc, paArgv);
   if((0 != strlen(ipPort)) && (NULL != strchr(ipPort, ':'))) {
-    createDev(ipPort, paResultInstance);
+    if(!CDevice::startupNewDevice(ipPort)){
+      return FORTE_COULD_NOT_CREATE_DEVICE;
+    }
+    DEVLOG_INFO("FORTE is up and running\n");
   } else { //! If needed call listHelp() to list the help for FORTE
     return FORTE_WRONG_PARAMETERS;
   }
@@ -89,36 +91,17 @@ int forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResu
   return FORTE_OK;
 }
 
-void forteJoinInstance(TForteInstance paInstance) {
-  CDevice *poDev = static_cast<CDevice*>(paInstance);
-  if(0 != poDev) {
-    poDev->awaitShutdown();
-  }
+void forteJoinInstance() {
+  CDevice::awaitDeviceShutdown();
 }
 
-void forteStopInstance(int paSig, TForteInstance paInstance) {
+void forteStopInstance(int ) {
   if(!CForteArchitecture::isInitialized()) {
     return;
   }
-  (void) paSig;
-  CDevice *poDev = static_cast<CDevice*>(paInstance);
-  if(0 != poDev) {
-    poDev->changeFBExecutionState(EMGMCommandType::Kill);
-    poDev->awaitShutdown();
-    DEVLOG_INFO("FORTE finished\n");
-    delete poDev;
-  }
-}
-
-/*!\brief Creates the Device-Object
- * \param paMGRID A string containing IP and Port like [IP]:[Port]
- * \param The result
- */
-void createDev(const char *paMGRID, TForteInstance* paInstance) {
-  CDevice *device = CDevice::createDev(paMGRID);
-  device->startDevice();
-  *paInstance = device;
-  DEVLOG_INFO("FORTE is up and running\n");
+  CDevice::triggerDeviceShutdown();
+  CDevice::awaitDeviceShutdown();
+  DEVLOG_INFO("FORTE finished\n");
 }
 
 bool checkEndianess() {

--- a/src/arch/zephyr/forte_Init.cpp
+++ b/src/arch/zephyr/forte_Init.cpp
@@ -17,7 +17,7 @@
 #include "forte_printer.h"
 #include <stdio.h>
 #include <string>
-#include "../../stdfblib/ita/RMT_DEV.h"
+#include <device.h>
 
 #include "../utils/mainparam_utils.h"
 
@@ -90,7 +90,7 @@ int forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResu
 }
 
 void forteJoinInstance(TForteInstance paInstance) {
-  RMT_DEV *poDev = static_cast<RMT_DEV*>(paInstance);
+  CDevice *poDev = static_cast<CDevice*>(paInstance);
   if(0 != poDev) {
     poDev->awaitShutdown();
   }
@@ -101,7 +101,7 @@ void forteStopInstance(int paSig, TForteInstance paInstance) {
     return;
   }
   (void) paSig;
-  RMT_DEV *poDev = static_cast<RMT_DEV*>(paInstance);
+  CDevice *poDev = static_cast<CDevice*>(paInstance);
   if(0 != poDev) {
     poDev->changeFBExecutionState(EMGMCommandType::Kill);
     poDev->awaitShutdown();
@@ -115,10 +115,7 @@ void forteStopInstance(int paSig, TForteInstance paInstance) {
  * \param The result
  */
 void createDev(const char *paMGRID, TForteInstance* paInstance) {
-  RMT_DEV *device = new RMT_DEV;
-  device->initialize();
-
-  device->setMGR_ID(paMGRID);
+  CDevice *device = CDevice::createDev(paMGRID);
   device->startDevice();
   *paInstance = device;
   DEVLOG_INFO("FORTE is up and running\n");

--- a/src/arch/zephyr/forte_Init.h
+++ b/src/arch/zephyr/forte_Init.h
@@ -36,9 +36,8 @@ extern "C" {
     FORTE_WRONG_ENDIANESS,
     FORTE_WRONG_PARAMETERS,
     FORTE_ARCHITECTURE_NOT_READY,
+    FORTE_COULD_NOT_CREATE_DEVICE
   };
-
-  typedef void* TForteInstance;
 
   /**
    * \brief Start forte instance
@@ -46,7 +45,7 @@ extern "C" {
    * @param paResultInstance Address of an instance of forte where the new instance is stored
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int paPort, TForteInstance* paResultInstance);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int paPort);
 
   /**
    * \brief Start forte instance with possibilities of more arguments
@@ -55,20 +54,20 @@ extern "C" {
    * @param paResultInstance Address of an instance of forte where the new instance is stored
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResultInstance);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int paArgc, char *paArgv[]);
 
   /**
    * \brief Terminates a Forte instance
    * @param paSignal  Signal value to terminate instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal, TForteInstance paInstance);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal);
 
   /**
    * \brief Terminates a Forte instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance(TForteInstance paInstance);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance();
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started

--- a/src/arch/zephyr/forte_Init.h
+++ b/src/arch/zephyr/forte_Init.h
@@ -39,13 +39,15 @@ extern "C" {
     FORTE_COULD_NOT_CREATE_DEVICE
   };
 
+  typedef void* TForteInstance;
+
   /**
    * \brief Start forte instance
    * @param paPort The port on which to forte will listen. Use 0 for default (normally 61499)
    * @param paResultInstance Address of an instance of forte where the new instance is stored
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int paPort);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstance(unsigned int paPort, TForteInstance* paResultInstance);
 
   /**
    * \brief Start forte instance with possibilities of more arguments
@@ -54,20 +56,20 @@ extern "C" {
    * @param paResultInstance Address of an instance of forte where the new instance is stored
    * @return FORTE_OK if no error occurred, other values otherwise
    */
-  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int paArgc, char *paArgv[]);
+  FORTE_SHARED_PREFIX int FORTE_SHARED_CALL forteStartInstanceGeneric(int paArgc, char *paArgv[], TForteInstance* paResultInstance);
 
   /**
    * \brief Terminates a Forte instance
    * @param paSignal  Signal value to terminate instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal, TForteInstance* paResultInstance);
 
   /**
    * \brief Terminates a Forte instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance();
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance(TForteInstance* paResultInstance);
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,7 +30,7 @@ forte_add_sourcefile_hcpp(conn dataconn inoutdataconn eventconn)
 forte_add_sourcefile_h(connectiondestinationtype.h)
 
 forte_add_sourcefile_h(esfb.h event.h mgmcmd.h fortenode.h fortelist.h genfb.h simplefb.h)
-forte_add_sourcefile_hcpp(basicfb cfb device devexec )
+forte_add_sourcefile_hcpp(basicfb cfb device devexec forteinstance)
 forte_add_sourcefile_hcpp(extevhan funcbloc fbcontainer if2indco)
 forte_add_sourcefile_hcpp(resource stringdict typelib ecet)
 forte_add_sourcefile_hcpp(adapterconn adapter anyadapter iec61131_functions)

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -17,6 +17,33 @@
 #include "ecet.h"
 #include <string.h>
 
+std::unique_ptr<CDevice> CDevice::smActiveDevice;
+
+bool CDevice::startupNewDevice(const std::string &paMGRID){
+  if(smActiveDevice){
+    //we have a current active device stop it
+    triggerDeviceShutdown();
+    awaitDeviceShutdown();
+  }
+  smActiveDevice.reset(createDev(paMGRID));
+  if(smActiveDevice){
+    smActiveDevice->startDevice();
+  }
+  return smActiveDevice.operator bool();
+}
+
+void CDevice::triggerDeviceShutdown() {
+  if(smActiveDevice) {
+    smActiveDevice->changeFBExecutionState(EMGMCommandType::Kill);
+  }
+}
+
+void CDevice::awaitDeviceShutdown() {
+  if(smActiveDevice) {
+    smActiveDevice->awaitShutdown();
+  }
+}
+
 EMGMResponse CDevice::executeMGMCommand(forte::core::SManagementCMD &paCommand){
   EMGMResponse retval = EMGMResponse::InvalidDst;
 

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -17,39 +17,6 @@
 #include "ecet.h"
 #include <string.h>
 
-#include "forte_device_config.h"
-
-std::unique_ptr<CDevice> CDevice::smActiveDevice;
-
-CDevice* CDevice::createDev(const std::string &paMGRID) {
-  return FORTE_DEVICE::createDev(paMGRID);
-}
-
-bool CDevice::startupNewDevice(const std::string &paMGRID){
-  if(smActiveDevice){
-    //we have a current active device stop it
-    triggerDeviceShutdown();
-    awaitDeviceShutdown();
-  }
-  smActiveDevice.reset(createDev(paMGRID));
-  if(smActiveDevice){
-    smActiveDevice->startDevice();
-  }
-  return smActiveDevice.operator bool();
-}
-
-void CDevice::triggerDeviceShutdown() {
-  if(smActiveDevice) {
-    smActiveDevice->changeFBExecutionState(EMGMCommandType::Kill);
-  }
-}
-
-void CDevice::awaitDeviceShutdown() {
-  if(smActiveDevice) {
-    smActiveDevice->awaitShutdown();
-  }
-}
-
 EMGMResponse CDevice::executeMGMCommand(forte::core::SManagementCMD &paCommand){
   EMGMResponse retval = EMGMResponse::InvalidDst;
 

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -17,7 +17,13 @@
 #include "ecet.h"
 #include <string.h>
 
+#include "forte_device_config.h"
+
 std::unique_ptr<CDevice> CDevice::smActiveDevice;
+
+CDevice* CDevice::createDev(const std::string &paMGRID) {
+  return FORTE_DEVICE::createDev(paMGRID);
+}
 
 bool CDevice::startupNewDevice(const std::string &paMGRID){
   if(smActiveDevice){

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2005 - 2015 ACIN, Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2005, 2024 ACIN, Profactor GmbH, fortiss GmbH,
+ *                          Primetals Technologies Austria GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -30,22 +31,19 @@
  (resources function blocks) and device parameters.
  */
 class CDevice : public CResource {
-  private:
-    /*! \brief
-     *
-     */
-    CDeviceExecution mDeviceExecution;
-
   public:
-    /*! \brief Sets up all the necessary data and classes necessary for execution.
+    /*  \brief Create an instance of the device that is configured for this 4diac FORTE instance
+     *
+     * This method is to be implemented by the code providing the device to be used for this 4diac FORTE instance.
+     *
+     * \param paMGRID  string for configuring the mgr id of this device (e.g., port address for a TCP port)
+     *                 if an empty string is given the device default mgr id will be used.
+     * \return pointer to the newly created device, nullptr if it could not be created.
      *
      */
-    CDevice(const SFBInterfaceSpec *paInterfaceSpec, const CStringDictionary::TStringId paInstanceNameId) :
-        CResource(paInterfaceSpec, paInstanceNameId), mDeviceExecution(*this) {
-    }
+    static CDevice *createDev(const std::string &paMGRID);
 
     ~CDevice() override = default;
-
 
     CStringDictionary::TStringId getFBTypeId() const override {
       return CStringDictionary::scmInvalidStringId;
@@ -98,6 +96,21 @@ class CDevice : public CResource {
     const CDevice* getDevice() const override {
       return this;
     }
+
+  protected:
+    /*! \brief Sets up all the necessary data and classes necessary for execution.
+     *
+     */
+    CDevice(const SFBInterfaceSpec *paInterfaceSpec, const CStringDictionary::TStringId paInstanceNameId) :
+        CResource(paInterfaceSpec, paInstanceNameId), mDeviceExecution(*this) {
+    }
+
+  private:
+    /*! \brief
+     *
+     */
+    CDeviceExecution mDeviceExecution;
+
 };
 
 #endif

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -32,14 +32,25 @@
  */
 class CDevice : public CResource {
   public:
-
-    static bool startupNewDevice(const std::string &paMGRID);
-
-    static void triggerDeviceShutdown();
-
-    static void awaitDeviceShutdown();
-
     ~CDevice() override = default;
+
+    /*! \brief Starts to execute FBNs.
+     *
+     *  This function will send a IEC 61499 start command to all existing resources in the device (if any).
+     *  The function will return after the start. The Forte HAL has to ensure that it is waited till the device
+     *  finishes its execution.
+     *  \return 0 on success -1 on error
+     */
+    virtual int startDevice() {
+      changeFBExecutionState(EMGMCommandType::Start);
+      return 1;
+    }
+
+    /*!\brief wait till the execution of this device ends.
+     *
+     * The execution of devices can be stopped by sending it the kill command.
+     */
+    virtual void awaitShutdown() = 0;
 
     CStringDictionary::TStringId getFBTypeId() const override {
       return CStringDictionary::scmInvalidStringId;
@@ -81,42 +92,11 @@ class CDevice : public CResource {
         CResource(paInterfaceSpec, paInstanceNameId), mDeviceExecution(*this) {
     }
 
-    /*! \brief Starts to execute FBNs.
-     *
-     *  This function will send a IEC 61499 start command to all existing resources in the device (if any).
-     *  The function will return after the start. The Forte HAL has to ensure that it is waited till the device
-     *  finishes its execution.
-     *  \return 0 on success -1 on error
-     */
-    virtual int startDevice() {
-      changeFBExecutionState(EMGMCommandType::Start);
-      return 1;
-    }
-
-    /*!\brief wait till the execution of this device ends.
-     *
-     * The execution of devices can be stopped by sending it the kill command.
-     */
-    virtual void awaitShutdown() = 0;
-
   private:
-    /*  \brief Create an instance of the device that is configured for this 4diac FORTE instance
-     *
-     * This method is to be implemented by the code providing the device to be used for this 4diac FORTE instance.
-     *
-     * \param paMGRID  string for configuring the mgr id of this device (e.g., port address for a TCP port)
-     *                 if an empty string is given the device default mgr id will be used.
-     * \return pointer to the newly created device, nullptr if it could not be created.
-     *
-     */
-    static CDevice *createDev(const std::string &paMGRID);
-
-    /*! \brief
+     /*! \brief
      *
      */
     CDeviceExecution mDeviceExecution;
-
-    static std::unique_ptr<CDevice> smActiveDevice;
 
 };
 

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -32,42 +32,18 @@
  */
 class CDevice : public CResource {
   public:
-    /*  \brief Create an instance of the device that is configured for this 4diac FORTE instance
-     *
-     * This method is to be implemented by the code providing the device to be used for this 4diac FORTE instance.
-     *
-     * \param paMGRID  string for configuring the mgr id of this device (e.g., port address for a TCP port)
-     *                 if an empty string is given the device default mgr id will be used.
-     * \return pointer to the newly created device, nullptr if it could not be created.
-     *
-     */
-    static CDevice *createDev(const std::string &paMGRID);
+
+    static bool startupNewDevice(const std::string &paMGRID);
+
+    static void triggerDeviceShutdown();
+
+    static void awaitDeviceShutdown();
 
     ~CDevice() override = default;
 
     CStringDictionary::TStringId getFBTypeId() const override {
       return CStringDictionary::scmInvalidStringId;
     }
-
-
-    /*! \brief Starts to execute FBNs.
-     *
-     *  This function will send a IEC 61499 start command to all existing resources in the device (if any).
-     *  The function will return after the start. The Forte HAL has to ensure that it is waited till the device
-     *  finishes its execution.
-     *  \return 0 on success -1 on error
-     */
-    virtual int startDevice() {
-      changeFBExecutionState(EMGMCommandType::Start);
-      return 1;
-    }
-
-
-    /*!\brief wait till the execution of this device ends.
-     *
-     * The execution of devices can be stopped by sending it the kill command.
-     */
-    virtual void awaitShutdown() = 0;
 
     /*!\brief Execute the given management command
      *
@@ -105,11 +81,42 @@ class CDevice : public CResource {
         CResource(paInterfaceSpec, paInstanceNameId), mDeviceExecution(*this) {
     }
 
+    /*! \brief Starts to execute FBNs.
+     *
+     *  This function will send a IEC 61499 start command to all existing resources in the device (if any).
+     *  The function will return after the start. The Forte HAL has to ensure that it is waited till the device
+     *  finishes its execution.
+     *  \return 0 on success -1 on error
+     */
+    virtual int startDevice() {
+      changeFBExecutionState(EMGMCommandType::Start);
+      return 1;
+    }
+
+    /*!\brief wait till the execution of this device ends.
+     *
+     * The execution of devices can be stopped by sending it the kill command.
+     */
+    virtual void awaitShutdown() = 0;
+
   private:
+    /*  \brief Create an instance of the device that is configured for this 4diac FORTE instance
+     *
+     * This method is to be implemented by the code providing the device to be used for this 4diac FORTE instance.
+     *
+     * \param paMGRID  string for configuring the mgr id of this device (e.g., port address for a TCP port)
+     *                 if an empty string is given the device default mgr id will be used.
+     * \return pointer to the newly created device, nullptr if it could not be created.
+     *
+     */
+    static CDevice *createDev(const std::string &paMGRID);
+
     /*! \brief
      *
      */
     CDeviceExecution mDeviceExecution;
+
+    static std::unique_ptr<CDevice> smActiveDevice;
 
 };
 

--- a/src/core/forteinstance.cpp
+++ b/src/core/forteinstance.cpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH, Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Alois Zoitl, Martin Jobst - initial implementation and rework communication
+ *                                infrastructure
+ *******************************************************************************/
+
+#include "forteinstance.h"
+#include "forte_device_config.h"
+
+
+std::unique_ptr<CDevice> C4diacFORTEInstance::createDev(const std::string &paMGRID) {
+  std::unique_ptr<FORTE_DEVICE> dev = (paMGRID.length() != 0) ? std::make_unique<FORTE_DEVICE>(paMGRID) : std::make_unique<FORTE_DEVICE>();
+  dev->initialize();
+  return dev;
+}
+
+bool C4diacFORTEInstance::startupNewDevice(const std::string &paMGRID){
+  if(mActiveDevice){
+    //we have a current active device stop it
+    triggerDeviceShutdown();
+    awaitDeviceShutdown();
+  }
+  mActiveDevice = createDev(paMGRID);
+  if(mActiveDevice){
+    mActiveDevice->startDevice();
+  }
+  return mActiveDevice.operator bool();
+}
+
+void C4diacFORTEInstance::triggerDeviceShutdown() {
+  if(mActiveDevice) {
+    mActiveDevice->changeFBExecutionState(EMGMCommandType::Kill);
+  }
+}
+
+void C4diacFORTEInstance::awaitDeviceShutdown() {
+  if(mActiveDevice) {
+    mActiveDevice->awaitShutdown();
+  }
+}
+
+
+

--- a/src/core/forteinstance.h
+++ b/src/core/forteinstance.h
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Primetals Technologies Austria GmbH, Martin Erich Jobst
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Alois Zoitl, Martin Jobst - initial implementation and rework communication infrastructure
+ *******************************************************************************/
+
+#include "device.h"
+
+class C4diacFORTEInstance {
+  public:
+    C4diacFORTEInstance() = default;
+
+    bool startupNewDevice(const std::string &paMGRID);
+
+    void triggerDeviceShutdown();
+
+    void awaitDeviceShutdown();
+
+  private:
+    /*  \brief Create an instance of the device that is configured for this 4diac FORTE instance
+     *
+     * This method is to be implemented by the code providing the device to be used for this 4diac FORTE instance.
+     *
+     * \param paMGRID  string for configuring the mgr id of this device (e.g., port address for a TCP port)
+     *                 if an empty string is given the device default mgr id will be used.
+     * \return pointer to the newly created device, nullptr if it could not be created.
+     *
+     */
+    static std::unique_ptr<CDevice>  createDev(const std::string &paMGRID);
+
+    std::unique_ptr<CDevice> mActiveDevice;
+
+};
+

--- a/src/forte_device_config.h.in
+++ b/src/forte_device_config.h.in
@@ -1,0 +1,4 @@
+#include "${FORTE_DEVICE}.h"
+
+using FORTE_DEVICE = ${FORTE_DEVICE};
+

--- a/src/stdfblib/ita/CMakeLists.txt
+++ b/src/stdfblib/ita/CMakeLists.txt
@@ -20,10 +20,6 @@ forte_add_sourcefile_hcpp(DEV_MGR  EMB_RES  RMT_DEV  RMT_RES)
 
 forte_add_device(RMT_DEV)
 
-if("${FORTE_DEVICE}" STREQUAL "RMT_DEV")
-  forte_add_sourcefile_hcpp(RMT_DEV)
-endif()
-
 if (FORTE_COM_OPC_UA)
   forte_add_sourcefile_hcpp(Config_EMB_RES)
   

--- a/src/stdfblib/ita/CMakeLists.txt
+++ b/src/stdfblib/ita/CMakeLists.txt
@@ -18,9 +18,20 @@
 SET(SOURCE_GROUP ${SOURCE_GROUP}\\ita)
 forte_add_sourcefile_hcpp(DEV_MGR  EMB_RES  RMT_DEV  RMT_RES)
 
+forte_add_device(RMT_DEV)
+
+if("${FORTE_DEVICE}" STREQUAL "RMT_DEV")
+  forte_add_sourcefile_hcpp(RMT_DEV)
+endif()
+
 if (FORTE_COM_OPC_UA)
-  forte_add_sourcefile_hcpp(OPCUA_DEV OPCUA_MGR Config_EMB_RES)
-endif (FORTE_COM_OPC_UA)
+  forte_add_sourcefile_hcpp(Config_EMB_RES)
+  
+  forte_add_device(OPCUA_DEV)
+  if("${FORTE_DEVICE}" STREQUAL "OPCUA_DEV")
+    forte_add_sourcefile_hcpp(OPCUA_DEV OPCUA_MGR)
+  endif()
+endif ()
 
 forte_add_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/stdfblib/ita/OPCUA_DEV.cpp
+++ b/src/stdfblib/ita/OPCUA_DEV.cpp
@@ -21,6 +21,15 @@ OPCUA_DEV::OPCUA_DEV() :
 OPCUA_DEV::~OPCUA_DEV() {
 }
 
+CDevice* OPCUA_DEV::createDev(const std::string &paMGRID) {
+  OPCUA_DEV *dev = new OPCUA_DEV;
+  dev->initialize();
+  if(paMGRID.length() != 0){
+    dev->setMGR_ID(paMGRID);
+  }
+  return dev;
+}
+
 int OPCUA_DEV::startDevice(void) {
   RMT_DEV::startDevice();
   if (mOPCUAMgr.initialize() != EMGMResponse::Ready) {

--- a/src/stdfblib/ita/OPCUA_DEV.cpp
+++ b/src/stdfblib/ita/OPCUA_DEV.cpp
@@ -13,21 +13,12 @@
 
 #include "OPCUA_DEV.h"
 
-OPCUA_DEV::OPCUA_DEV() :
-  RMT_DEV(), mOPCUAMgr(*this){
+OPCUA_DEV::OPCUA_DEV(const std::string &paMGRID) :
+  RMT_DEV(paMGRID), mOPCUAMgr(*this){
   changeFBExecutionState(EMGMCommandType::Reset);
 }
 
 OPCUA_DEV::~OPCUA_DEV() {
-}
-
-CDevice* OPCUA_DEV::createDev(const std::string &paMGRID) {
-  OPCUA_DEV *dev = new OPCUA_DEV;
-  dev->initialize();
-  if(paMGRID.length() != 0){
-    dev->setMGR_ID(paMGRID);
-  }
-  return dev;
 }
 
 int OPCUA_DEV::startDevice(void) {

--- a/src/stdfblib/ita/OPCUA_DEV.h
+++ b/src/stdfblib/ita/OPCUA_DEV.h
@@ -24,5 +24,7 @@ public:
   OPCUA_DEV();
   virtual ~OPCUA_DEV();
 
+  static CDevice *createDev(const std::string &paMGRID);
+
   virtual int startDevice(void);
 };

--- a/src/stdfblib/ita/OPCUA_DEV.h
+++ b/src/stdfblib/ita/OPCUA_DEV.h
@@ -21,10 +21,8 @@ public:
 
   OPCUA_MGR mOPCUAMgr;
 
-  OPCUA_DEV();
+  OPCUA_DEV(const std::string &paMGRID);
   virtual ~OPCUA_DEV();
-
-  static CDevice *createDev(const std::string &paMGRID);
 
   virtual int startDevice(void);
 };

--- a/src/stdfblib/ita/RMT_DEV.cpp
+++ b/src/stdfblib/ita/RMT_DEV.cpp
@@ -17,7 +17,7 @@
 #endif
 #include <stringdict.h>
 
-CDevice* CDevice::createDev(const std::string &paMGRID) {
+CDevice* RMT_DEV::createDev(const std::string &paMGRID) {
   RMT_DEV *dev = new RMT_DEV;
   dev->initialize();
   if(paMGRID.length() != 0){

--- a/src/stdfblib/ita/RMT_DEV.cpp
+++ b/src/stdfblib/ita/RMT_DEV.cpp
@@ -17,15 +17,6 @@
 #endif
 #include <stringdict.h>
 
-CDevice* RMT_DEV::createDev(const std::string &paMGRID) {
-  RMT_DEV *dev = new RMT_DEV;
-  dev->initialize();
-  if(paMGRID.length() != 0){
-    dev->setMGR_ID(paMGRID);
-  }
-  return dev;
-}
-
 const CStringDictionary::TStringId RMT_DEV::scmDINameIds[] = { g_nStringIdMGR_ID };
 const CStringDictionary::TStringId RMT_DEV::scmDIDataTypeIds[] = {g_nStringIdWSTRING};
 

--- a/src/stdfblib/ita/RMT_DEV.cpp
+++ b/src/stdfblib/ita/RMT_DEV.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2005 - 2015 ACIN, Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2005, 2015 ACIN, Profactor GmbH, fortiss GmbH,
+ *                          Primetals Technologies Austria GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,6 +16,15 @@
 #include "RMT_DEV_gen.cpp"
 #endif
 #include <stringdict.h>
+
+CDevice* CDevice::createDev(const std::string &paMGRID) {
+  RMT_DEV *dev = new RMT_DEV;
+  dev->initialize();
+  if(paMGRID.length() != 0){
+    dev->setMGR_ID(paMGRID);
+  }
+  return dev;
+}
 
 const CStringDictionary::TStringId RMT_DEV::scmDINameIds[] = { g_nStringIdMGR_ID };
 const CStringDictionary::TStringId RMT_DEV::scmDIDataTypeIds[] = {g_nStringIdWSTRING};
@@ -69,8 +79,8 @@ EMGMResponse RMT_DEV::changeFBExecutionState(EMGMCommandType paCommand){
   return eRetVal;
 }
 
-void RMT_DEV::setMGR_ID(const char * const paConn){
-  var_MGR_ID.fromString(paConn);
+void RMT_DEV::setMGR_ID(const std::string& paVal){
+  var_MGR_ID.fromString(paVal.c_str());
 }
 
 CIEC_ANY *RMT_DEV::getDI(const size_t paIndex) {

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -14,7 +14,7 @@
 #ifndef _RMT_DEV_H_
 #define _RMT_DEV_H_
 
-#include <device.h>
+#include "device.h"
 #include <if2indco.h>
 #include "RMT_RES.h"
 

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2005 - 2015 ACIN, Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2005, 2024 ACIN, Profactor GmbH, fortiss GmbH,
+ *                          Primetals Technologies Austria GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -38,7 +39,7 @@ class RMT_DEV : public CDevice{
 
     EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
 
-    void setMGR_ID(const char * const paConn);
+    void setMGR_ID(const std::string& paVal);
 
   private:
     CInterface2InternalDataConnection mDConnMGR_ID;

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -22,7 +22,7 @@
  */
 
 
-class RMT_DEV : public CDevice{
+ class RMT_DEV final : public CDevice{
   public:
     RMT_DEV(const std::string &paMGR_ID = "localhost:61499");
     ~RMT_DEV() override;

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -29,8 +29,6 @@
 
     bool initialize() override;
 
-    static CDevice *createDev(const std::string &paMGRID);
-
   /*! \brief Adds additional functionality to the originals execute func of the device.
   *
   * This is that it waits till the thread of the MGR resource has anded

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -22,12 +22,14 @@
  */
 
 
- class RMT_DEV final : public CDevice{
+ class RMT_DEV : public CDevice{
   public:
     RMT_DEV(const std::string &paMGR_ID = "localhost:61499");
     ~RMT_DEV() override;
 
     bool initialize() override;
+
+    static CDevice *createDev(const std::string &paMGRID);
 
   /*! \brief Adds additional functionality to the originals execute func of the device.
   *

--- a/tests/core/fbtests/fbtesterglobalfixture.cpp
+++ b/tests/core/fbtests/fbtesterglobalfixture.cpp
@@ -16,18 +16,6 @@
 #endif
 #include <boost/test/unit_test.hpp>
 
-const static SFBInterfaceSpec gscTestDevSpec = {
-  0, nullptr, nullptr, nullptr,
-  0, nullptr, nullptr, nullptr,
-  0, nullptr, nullptr,
-  0, nullptr, nullptr,
-  0, nullptr,
-  0, nullptr
-};
-
-CDevice *CFBTestDataGlobalFixture::smTestDev;
-CResource *CFBTestDataGlobalFixture::smTestRes;
-
 class CTesterDevice : public CDevice {
   public:
     CTesterDevice(const SFBInterfaceSpec *paInterfaceSpec, const CStringDictionary::TStringId paInstanceNameId) :
@@ -45,7 +33,22 @@ class CTesterDevice : public CDevice {
     CDataConnection **getDIConUnchecked(TPortId) override {
       return nullptr;
     }
+
+    friend CFBTestDataGlobalFixture;
+
 };
+
+const static SFBInterfaceSpec gscTestDevSpec = {
+  0, nullptr, nullptr, nullptr,
+  0, nullptr, nullptr, nullptr,
+  0, nullptr, nullptr,
+  0, nullptr, nullptr,
+  0, nullptr,
+  0, nullptr
+};
+
+CTesterDevice *CFBTestDataGlobalFixture::smTestDev;
+CResource *CFBTestDataGlobalFixture::smTestRes;
 
 CFBTestDataGlobalFixture::CFBTestDataGlobalFixture(){
   //setup is done in the setup so that boost_test can throw exceptions

--- a/tests/core/fbtests/fbtesterglobalfixture.h
+++ b/tests/core/fbtests/fbtesterglobalfixture.h
@@ -12,7 +12,9 @@
 #ifndef TESTS_CORE_FBTESTS_FBTESTERGLOBALFIXTURE_H_
 #define TESTS_CORE_FBTESTS_FBTESTERGLOBALFIXTURE_H_
 
-#include <device.h>
+#include "device.h"
+
+class CTesterDevice;
 
 /**Global fixture for providing the resource and device needed for fb testing
  *
@@ -28,7 +30,7 @@ class CFBTestDataGlobalFixture{
     }
 
   private:
-    static CDevice *smTestDev;
+    static CTesterDevice *smTestDev;
     static CResource *smTestRes;
 };
 

--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -19,7 +19,7 @@
 #include "fbtestfixture_gen.cpp"
 #endif
 #include "fbtesterglobalfixture.h"
-#include <device.h>
+#include "device.h"
 #include <criticalregion.h>
 #include <ecet.h>
 


### PR DESCRIPTION
With this change CDevice provides a static method that will create an isntance of the device to be used by this 4daic FORTE instance.

This reduces code duplication and wrong device creation. Furthermore it is the basis that different device types can be configured via CMake.