### PR TITLE
Move dynamic interface setup to generic function block

### DIFF
--- a/src/com/opc_ua/FBs/LocalizedText2LocalizedText.cpp
+++ b/src/com/opc_ua/FBs/LocalizedText2LocalizedText.cpp
@@ -44,10 +44,19 @@ const SFBInterfaceSpec FORTE_LocalizedText2LocalizedText::scmFBInterfaceSpec = {
   0, nullptr, 0, nullptr
 };
 
+FORTE_LocalizedText2LocalizedText::FORTE_LocalizedText2LocalizedText(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+    CFunctionBlock(paContainer, &scmFBInterfaceSpec, paInstanceNameId),
+    var_IN(CIEC_LocalizedText()),
+    var_OUT(CIEC_LocalizedText()),
+    var_conn_OUT(var_OUT),
+    conn_CNF(this, 0),
+    conn_IN(nullptr),
+    conn_OUT(this, 0, &var_conn_OUT) {
+}
 
 void FORTE_LocalizedText2LocalizedText::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
   if(scmEventREQID == paEIID) {
-    st_OUT() = st_IN();
+    var_OUT = var_IN;
     sendOutputEvent(scmEventCNFID, paECET);
   }
 }
@@ -55,7 +64,7 @@ void FORTE_LocalizedText2LocalizedText::executeEvent(TEventID paEIID, CEventChai
 void FORTE_LocalizedText2LocalizedText::readInputData(TEventID paEIID) {
   switch(paEIID) {
     case scmEventREQID: {
-      readData(0, *mDIs[0], mDIConns[0]);
+      readData(0, var_IN, conn_IN);
       break;
     }
     default:
@@ -66,11 +75,46 @@ void FORTE_LocalizedText2LocalizedText::readInputData(TEventID paEIID) {
 void FORTE_LocalizedText2LocalizedText::writeOutputData(TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, *mDOs[0], mDOConns[0]);
+      writeData(0, var_OUT, conn_OUT);
       break;
     }
     default:
       break;
   }
+}
+
+CIEC_ANY *FORTE_LocalizedText2LocalizedText::getDI(size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_IN;
+  }
+  return nullptr;
+}
+
+CIEC_ANY *FORTE_LocalizedText2LocalizedText::getDO(size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_OUT;
+  }
+  return nullptr;
+}
+
+CEventConnection *FORTE_LocalizedText2LocalizedText::getEOConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_CNF;
+  }
+  return nullptr;
+}
+
+CDataConnection **FORTE_LocalizedText2LocalizedText::getDIConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_IN;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_LocalizedText2LocalizedText::getDOConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_OUT;
+  }
+  return nullptr;
 }
 

--- a/src/com/opc_ua/FBs/LocalizedText2LocalizedText.h
+++ b/src/com/opc_ua/FBs/LocalizedText2LocalizedText.h
@@ -10,53 +10,62 @@
  *   Jose Cabral - initial implementation
  *******************************************************************************/
 
-#ifndef _LOCALIZEDTEXT2LOCALIZEDTEXT_H_
-#define _LOCALIZEDTEXT2LOCALIZEDTEXT_H_
+#pragma once
 
 #include <funcbloc.h>
 #include <forte_localizedtext.h>
 
 class FORTE_LocalizedText2LocalizedText: public CFunctionBlock{
-  DECLARE_FIRMWARE_FB(FORTE_LocalizedText2LocalizedText)
+    DECLARE_FIRMWARE_FB(FORTE_LocalizedText2LocalizedText)
 
-private:
-  static const CStringDictionary::TStringId scmDataInputNames[];
-  static const CStringDictionary::TStringId scmDataInputTypeIds[];
-  CIEC_LocalizedText &st_IN() {
-    return *static_cast<CIEC_LocalizedText*>(getDI(0));
-  };
+  private:
+    static const CStringDictionary::TStringId scmDataInputNames[];
+    static const CStringDictionary::TStringId scmDataInputTypeIds[];
+    static const CStringDictionary::TStringId scmDataOutputNames[];
+    static const CStringDictionary::TStringId scmDataOutputTypeIds[];
+    static const TEventID scmEventREQID = 0;
+    static const TForteInt16 scmEIWithIndexes[];
+    static const TDataIOID scmEIWith[];
+    static const CStringDictionary::TStringId scmEventInputNames[];
 
-  static const CStringDictionary::TStringId scmDataOutputNames[];
-  static const CStringDictionary::TStringId scmDataOutputTypeIds[];
-  CIEC_LocalizedText &st_OUT() {
-    return *static_cast<CIEC_LocalizedText*>(getDO(0));
-  };
+    static const TEventID scmEventCNFID = 0;
+    static const TForteInt16 scmEOWithIndexes[];
+    static const TDataIOID scmEOWith[];
+    static const CStringDictionary::TStringId scmEventOutputNames[];
 
-  static const TEventID scmEventREQID = 0;
-  static const TForteInt16 scmEIWithIndexes[];
-  static const TDataIOID scmEIWith[];
-  static const CStringDictionary::TStringId scmEventInputNames[];
-
-  static const TEventID scmEventCNFID = 0;
-  static const TForteInt16 scmEOWithIndexes[];
-  static const TDataIOID scmEOWith[];
-  static const CStringDictionary::TStringId scmEventOutputNames[];
-
-  static const SFBInterfaceSpec scmFBInterfaceSpec;
+    static const SFBInterfaceSpec scmFBInterfaceSpec;
 
 
-  void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+    void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
-  void readInputData(TEventID paEIID) override;
-  void writeOutputData(TEventID paEIID) override;
+    void readInputData(TEventID paEIID) override;
+    void writeOutputData(TEventID paEIID) override;
 
-public:
-  FUNCTION_BLOCK_CTOR(FORTE_LocalizedText2LocalizedText){
-  };
+  public:
+    FORTE_LocalizedText2LocalizedText(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
 
-  ~FORTE_LocalizedText2LocalizedText() override = default;
+    CIEC_LocalizedText var_IN;
+    CIEC_LocalizedText var_OUT;
 
+    CIEC_LocalizedText var_conn_OUT;
+    CEventConnection conn_CNF;
+    CDataConnection *conn_IN;
+    CDataConnection conn_OUT;
+
+    CIEC_ANY *getDI(size_t) override;
+    CIEC_ANY *getDO(size_t) override;
+    CEventConnection *getEOConUnchecked(TPortId) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+    CDataConnection *getDOConUnchecked(TPortId) override;
+
+    void evt_REQ(const CIEC_LocalizedText &pa_IN, CIEC_LocalizedText &pa_OUT) {
+      var_IN = pa_IN;
+      receiveInputEvent(scmEventREQID, nullptr);
+      pa_OUT = var_OUT;
+    }
+
+    void operator()(const CIEC_LocalizedText &pa_IN, CIEC_LocalizedText &pa_OUT) {
+      evt_REQ(pa_IN, pa_OUT);
+    }
 };
-
-#endif //close the ifdef sequence from the beginning of the file
 

--- a/src/core/adapter.cpp
+++ b/src/core/adapter.cpp
@@ -21,7 +21,7 @@
 #include "ecet.h"
 
 CAdapter::CAdapter(forte::core::CFBContainer &paContainer, const SFBInterfaceSpec *paInterfaceSpecSocket, const CStringDictionary::TStringId paInstanceNameId, const SFBInterfaceSpec *paInterfaceSpecPlug, bool paIsPlug) :
-  CFunctionBlock(paContainer, (paIsPlug) ? paInterfaceSpecPlug : paInterfaceSpecSocket, paInstanceNameId),
+  CGenFunctionBlock<CFunctionBlock>(paContainer, (paIsPlug) ? paInterfaceSpecPlug : paInterfaceSpecSocket, paInstanceNameId),
   mParentAdapterListEventID(0),
   mIsPlug(paIsPlug),
   mPeer(nullptr),
@@ -30,7 +30,7 @@ CAdapter::CAdapter(forte::core::CFBContainer &paContainer, const SFBInterfaceSpe
 }
 
 bool CAdapter::initialize() {
-  if(!CFunctionBlock::initialize()) {
+  if(!CGenFunctionBlock<CFunctionBlock>::initialize()) {
     return false;
   }
   setupEventEntryList();
@@ -48,6 +48,11 @@ CAdapter::~CAdapter(){
     }
   }
   delete[] mEventEntry;
+}
+
+bool CAdapter::createInterfaceSpec(const char *, SFBInterfaceSpec &paInterfaceSpec) {
+  paInterfaceSpec = *mInterfaceSpec;
+  return true;
 }
 
 void CAdapter::fillEventEntryList(CFunctionBlock* paParentFB){

--- a/src/core/adapter.h
+++ b/src/core/adapter.h
@@ -17,7 +17,7 @@
 #ifndef _ADAPTER_H_
 #define _ADAPTER_H_
 
-#include "funcbloc.h"
+#include "genfb.h"
 
 class CAdapterConnection;
 
@@ -32,7 +32,7 @@ class CAdapterConnection;
 /*!\ingroup CORE\brief Class for handling adapters.
  *
  */
-class CAdapter : public CFunctionBlock{
+class CAdapter : public CGenFunctionBlock<CFunctionBlock> {
   public:
     /*!\brief The main constructor for an adapter instance.
      */
@@ -41,6 +41,8 @@ class CAdapter : public CFunctionBlock{
     ~CAdapter() override;
 
     bool initialize() override;
+
+    bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
     /*!\brief Returns if Adapter instance is a Plug
      */

--- a/src/core/anyadapter.cpp
+++ b/src/core/anyadapter.cpp
@@ -63,7 +63,6 @@ bool CAnyAdapter::disconnect(CAdapterConnection *paAdConn){
   bool bRetVal = CAdapter::disconnect(paAdConn);
 
   //clean interface data and reset to empty interface
-  freeAllData();
   setupFBInterface(&scmFBInterfaceSpec);
 
   return bRetVal;

--- a/src/core/cfb.cpp
+++ b/src/core/cfb.cpp
@@ -50,8 +50,8 @@ bool CCompositeFB::initialize() {
 
   //remove adapter-references for CFB
   for(TPortId i = 0; i < mInterfaceSpec->mNumAdapters; i++){
-    if(nullptr != mAdapters){
-      static_cast<CAdapter*>(mAdapters[i])->setParentFB(nullptr, 0);
+    if(CAdapter* adapter = getAdapterUnchecked(i); adapter != nullptr) {
+      adapter->setParentFB(nullptr, 0);
     }
   }
   return true;
@@ -359,7 +359,7 @@ CFunctionBlock *CCompositeFB::getFunctionBlock(int paFBNum){
     if(scmAdapterMarker == (scmAdapterMarker & fbNum)){
       fbNum &= scmAdapterFBRange;
       if(fbNum < mInterfaceSpec->mNumAdapters){
-        return mAdapters[fbNum];
+        return getAdapterUnchecked(fbNum);
       }
     } else{
       if(fbNum < cmFBNData.mNumFBs){

--- a/src/core/funcbloc.cpp
+++ b/src/core/funcbloc.cpp
@@ -57,10 +57,10 @@ bool CFunctionBlock::initialize() {
 }
 
 CFunctionBlock::~CFunctionBlock(){
-  freeAllData();
+  freeFBInterfaceData();
 }
 
-void CFunctionBlock::freeAllData(){
+void CFunctionBlock::freeFBInterfaceData(){
   if(nullptr != mInterfaceSpec){
     if(nullptr != mEOConns) {
       std::destroy_n(mEOConns, mInterfaceSpec->mNumEOs);
@@ -103,11 +103,8 @@ void CFunctionBlock::freeAllData(){
   operator delete(mFBVarsData);
   mFBVarsData = nullptr;
 
-#ifdef  FORTE_SUPPORT_MONITORING
-  delete[] mEOMonitorCount;
-  mEOMonitorCount = nullptr;
-  delete[] mEIMonitorCount;
-  mEIMonitorCount = nullptr;
+#ifdef FORTE_SUPPORT_MONITORING
+  freeEventMonitoringData();
 #endif //FORTE_SUPPORT_MONITORING
 }
 
@@ -602,7 +599,7 @@ size_t CFunctionBlock::calculateFBVarsDataSize(const SFBInterfaceSpec &paInterfa
 }
 
 void CFunctionBlock::setupFBInterface(const SFBInterfaceSpec *paInterfaceSpec) {
-  freeAllData();
+  freeFBInterfaceData();
 
   mInterfaceSpec = const_cast<SFBInterfaceSpec *>(paInterfaceSpec);
 
@@ -687,17 +684,25 @@ TPortId CFunctionBlock::getPortId(CStringDictionary::TStringId paPortNameId, TPo
 //********************************** below here are monitoring specific functions **********************************************************
 #ifdef FORTE_SUPPORT_MONITORING
 void CFunctionBlock::setupEventMonitoringData(){
-  if(0 != mInterfaceSpec->mNumEIs){
-    mEIMonitorCount = new TForteUInt32[mInterfaceSpec->mNumEIs];
-    memset(mEIMonitorCount, 0, sizeof(TForteUInt32) * mInterfaceSpec->mNumEIs);
-  }
+  freeEventMonitoringData();
 
-  if(0 != mInterfaceSpec->mNumEOs){
-    mEOMonitorCount = new TForteUInt32[mInterfaceSpec->mNumEOs];
-    memset(mEOMonitorCount, 0, sizeof(TForteUInt32) * mInterfaceSpec->mNumEOs);
+  if(mInterfaceSpec) {
+    if (0 != mInterfaceSpec->mNumEIs) {
+      mEIMonitorCount = new TForteUInt32[mInterfaceSpec->mNumEIs];
+    }
+
+    if (0 != mInterfaceSpec->mNumEOs) {
+      mEOMonitorCount = new TForteUInt32[mInterfaceSpec->mNumEOs];
+    }
   }
 }
 
+void CFunctionBlock::freeEventMonitoringData(){
+  delete[] mEOMonitorCount;
+  mEOMonitorCount = nullptr;
+  delete[] mEIMonitorCount;
+  mEIMonitorCount = nullptr;
+}
 
 CFunctionBlock *CFunctionBlock::getFB(forte::core::TNameIdentifier::CIterator &paNameListIt){
   CFunctionBlock *retVal = nullptr;

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -645,7 +645,7 @@ class CFunctionBlock {
 
     static EMGMResponse changeInternalFBExecutionState(const EMGMCommandType paCommand, const size_t paAmountOfInternalFBs, TFunctionBlockPtr *const paInternalFBs);
 
-    void freeAllData();
+    void freeFBInterfaceData();
 
     const SFBInterfaceSpec *mInterfaceSpec; //!< Pointer to the interface specification
     CEventConnection *mEOConns; //!< A list of event connections pointers storing for each event output the event connection. If the output event is not connected the pointer is nullptr.
@@ -695,6 +695,7 @@ class CFunctionBlock {
 
 #ifdef FORTE_SUPPORT_MONITORING
     void setupEventMonitoringData();
+    void freeEventMonitoringData();
 
     // monitoring stuff
     TForteUInt32 *mEOMonitorCount;

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -282,7 +282,9 @@ class CFunctionBlock {
      * \param paAdapterNameId  StringId of the adapter name.
      * \return Pointer to the adapter or nullptr.
      */
-    CAdapter* getAdapter(CStringDictionary::TStringId paAdapterNameId) const;
+    CAdapter* getAdapter(CStringDictionary::TStringId paAdapterNameId);
+
+    const CAdapter* getAdapter(CStringDictionary::TStringId paAdapterNameId) const;
 
     TPortId getAdapterPortId(CStringDictionary::TStringId paAdapterNameId) const;
 
@@ -556,7 +558,7 @@ class CFunctionBlock {
      * \param paEID Event ID where event should be fired.
      * \param paExecEnv Event chain execution environment where the event will be sent to.
      */
-    void sendAdapterEvent(TPortId paAdapterID, TEventID paEID, CEventChainExecutionThread * const paECET) const;
+    void sendAdapterEvent(TPortId paAdapterID, TEventID paEID, CEventChainExecutionThread * const paECET);
 
     void setupAdapters(const SFBInterfaceSpec *paInterfaceSpec, TForteByte *paFBData);
 
@@ -597,6 +599,10 @@ class CFunctionBlock {
 
     virtual CInOutDataConnection *getDIOOutConUnchecked(TPortId) {
       return nullptr;
+    }
+
+    virtual CAdapter *getAdapterUnchecked(TPortId paAdapterNum) {
+      return mAdapters[paAdapterNum];
     }
 
     /*!\brief helper function for changeing the FB execution state for FBs with internal FBs

--- a/src/core/genfb.tpp
+++ b/src/core/genfb.tpp
@@ -16,25 +16,46 @@
 
 template<class T>
 CGenFunctionBlock<T>::CGenFunctionBlock(forte::core::CFBContainer &paContainer, const CStringDictionary::TStringId paInstanceNameId) :
-    T(paContainer, nullptr, paInstanceNameId),
-    mConfiguredFBTypeNameId(CStringDictionary::scmInvalidStringId), mGenInterfaceSpec() {
+        T(paContainer, nullptr, paInstanceNameId),
+        mEOConns(nullptr), mDIConns(nullptr), mDOConns(nullptr), mDIs(nullptr), mDOs(nullptr),
+        mAdapters(nullptr),
+        mConfiguredFBTypeNameId(CStringDictionary::scmInvalidStringId),
+        mGenInterfaceSpec(),
+        mFBConnData(nullptr), mFBVarsData(nullptr)
+{
+}
 
-  static_assert((std::is_base_of_v<CFunctionBlock, T>), "TFunctionBlock");
+template<class T>
+CGenFunctionBlock<T>::CGenFunctionBlock(forte::core::CFBContainer &paContainer, const SFBInterfaceSpec *paInterfaceSpec,
+                                        const CStringDictionary::TStringId paInstanceNameId) :
+        T(paContainer, paInterfaceSpec, paInstanceNameId),
+        mEOConns(nullptr), mDIConns(nullptr), mDOConns(nullptr), mDIs(nullptr), mDOs(nullptr),
+        mAdapters(nullptr),
+        mConfiguredFBTypeNameId(CStringDictionary::scmInvalidStringId),
+        mGenInterfaceSpec(),
+        mFBConnData(nullptr), mFBVarsData(nullptr)
+{
 }
 
 template<class T>
 CGenFunctionBlock<T>::~CGenFunctionBlock(){
   if(nullptr != T::mInterfaceSpec){
-    T::freeFBInterfaceData();  //clean the interface and connections first.
+    freeFBInterfaceData();  //clean the interface and connections first.
     T::mInterfaceSpec = nullptr; //this stops the base classes from any wrong clean-up
   }
+}
+
+template<class T>
+bool CGenFunctionBlock<T>::initialize() {
+  setupFBInterface(T::mInterfaceSpec);
+  return true;
 }
 
 template<class T>
 bool CGenFunctionBlock<T>::configureFB(const char *paConfigString){
   setConfiguredTypeNameId(CStringDictionary::getInstance().insert(paConfigString));
   if(createInterfaceSpec(paConfigString, mGenInterfaceSpec)){
-    T::setupFBInterface(&mGenInterfaceSpec);
+    setupFBInterface(&mGenInterfaceSpec);
     return true;
   }
   return false;
@@ -123,6 +144,168 @@ void CGenFunctionBlock<T>::fillDataPointSpec(const CIEC_ANY &paValue, CStringDic
       fillDataPointSpec(arrayValue[arrayValue.getLowerBound()], paDataTypeIds);
     } else {
       *(paDataTypeIds++) = arrayValue.getElementTypeNameID();
+    }
+  }
+}
+
+template<class T>
+size_t CGenFunctionBlock<T>::calculateFBConnDataSize(const SFBInterfaceSpec &paInterfaceSpec) {
+  return sizeof(CEventConnection) * paInterfaceSpec.mNumEOs +
+         sizeof(TDataConnectionPtr) * paInterfaceSpec.mNumDIs +
+         sizeof(CDataConnection) * paInterfaceSpec.mNumDOs;
+}
+
+template<class T>
+size_t CGenFunctionBlock<T>::calculateFBVarsDataSize(const SFBInterfaceSpec &paInterfaceSpec) {
+  size_t result = 0;
+  const CStringDictionary::TStringId *pnDataIds;
+
+  result += paInterfaceSpec.mNumDIs * sizeof(CIEC_ANY *);
+  pnDataIds = paInterfaceSpec.mDIDataTypeNames;
+  for (TPortId i = 0; i < paInterfaceSpec.mNumDIs; ++i) {
+    result += T::getDataPointSize(pnDataIds);
+  }
+
+  result += paInterfaceSpec.mNumDOs * sizeof(CIEC_ANY *);
+  pnDataIds = paInterfaceSpec.mDODataTypeNames;
+  for (TPortId i = 0; i < paInterfaceSpec.mNumDOs; ++i) {
+    result += T::getDataPointSize(pnDataIds) * 2; // * 2 for connection buffer value
+  }
+
+  result += paInterfaceSpec.mNumAdapters * sizeof(TAdapterPtr);
+  return result;
+}
+
+template<class T>
+void CGenFunctionBlock<T>::setupFBInterface(const SFBInterfaceSpec *paInterfaceSpec) {
+  freeFBInterfaceData();
+
+  T::mInterfaceSpec = const_cast<SFBInterfaceSpec *>(paInterfaceSpec);
+
+  if (nullptr != paInterfaceSpec) {
+    size_t connDataSize = calculateFBConnDataSize(*paInterfaceSpec);
+    size_t varsDataSize = calculateFBVarsDataSize(*paInterfaceSpec);
+    mFBConnData = connDataSize ? operator new(connDataSize) : nullptr;
+    mFBVarsData = varsDataSize ? operator new(varsDataSize) : nullptr;
+
+    auto *connData = reinterpret_cast<TForteByte *>(mFBConnData);
+    auto *varsData = reinterpret_cast<TForteByte *>(mFBVarsData);
+
+    TPortId i;
+    if (T::mInterfaceSpec->mNumEOs) {
+      mEOConns = reinterpret_cast<CEventConnection *>(connData);
+
+      for (i = 0; i < T::mInterfaceSpec->mNumEOs; ++i) {
+        //create an event connection for each event output and initialize its source port
+        new(connData)CEventConnection(this, i);
+        connData += sizeof(CEventConnection);
+      }
+    } else {
+      mEOConns = nullptr;
+    }
+
+    const CStringDictionary::TStringId *pnDataIds;
+    if (T::mInterfaceSpec->mNumDIs) {
+      mDIConns = reinterpret_cast<TDataConnectionPtr *>(connData);
+      connData += sizeof(TDataConnectionPtr) * T::mInterfaceSpec->mNumDIs;
+
+      mDIs = reinterpret_cast<CIEC_ANY **>(varsData);
+      varsData += T::mInterfaceSpec->mNumDIs * sizeof(CIEC_ANY *);
+
+      pnDataIds = paInterfaceSpec->mDIDataTypeNames;
+      for (i = 0; i < T::mInterfaceSpec->mNumDIs; ++i) {
+        mDIs[i] = T::createDataPoint(pnDataIds, varsData);
+        mDIConns[i] = nullptr;
+      }
+    } else {
+      mDIConns = nullptr;
+      mDIs = nullptr;
+    }
+
+    if (T::mInterfaceSpec->mNumDOs) {
+      //let mDOConns point to the first data output connection
+      mDOConns = reinterpret_cast<CDataConnection *>(connData);
+
+      mDOs = reinterpret_cast<CIEC_ANY **>(varsData);
+      varsData += T::mInterfaceSpec->mNumDOs * sizeof(CIEC_ANY *);
+
+      pnDataIds = paInterfaceSpec->mDODataTypeNames;
+      for (i = 0; i < T::mInterfaceSpec->mNumDOs; ++i) {
+        mDOs[i] = T::createDataPoint(pnDataIds, varsData);
+        CIEC_ANY* connVar = mDOs[i]->clone(varsData);
+        varsData += connVar->getSizeof();
+        new(connData)CDataConnection(this, i, connVar);
+        connData += sizeof(CDataConnection);
+      }
+    } else {
+      mDOConns = nullptr;
+      mDOs = nullptr;
+    }
+    if (T::mInterfaceSpec->mNumAdapters) {
+      setupAdapters(paInterfaceSpec, varsData);
+    }
+
+#ifdef FORTE_SUPPORT_MONITORING
+    T::setupEventMonitoringData();
+#endif
+  }
+}
+
+template<class T>
+void CGenFunctionBlock<T>::freeFBInterfaceData(){
+  if(nullptr != T::mInterfaceSpec){
+    if(nullptr != mEOConns) {
+      std::destroy_n(mEOConns, T::mInterfaceSpec->mNumEOs);
+    }
+
+    if(nullptr != mDOConns) {
+      for (TPortId i = 0; i < T::mInterfaceSpec->mNumDOs; ++i) {
+        if(CIEC_ANY* value = mDOConns[i].getValue(); nullptr != value) {
+          std::destroy_at(value);
+        }
+      }
+      std::destroy_n(mDOConns, T::mInterfaceSpec->mNumDOs);
+    }
+
+    if(nullptr != mDIs) {
+      for (TPortId i = 0; i < T::mInterfaceSpec->mNumDIs; ++i) {
+        if(CIEC_ANY* value = mDIs[i]; nullptr != value) {
+          std::destroy_at(value);
+        }
+      }
+    }
+
+    if(nullptr != mDOs) {
+      for (TPortId i = 0; i < T::mInterfaceSpec->mNumDOs; ++i) {
+        if(CIEC_ANY* value = mDOs[i]; nullptr != value) {
+          std::destroy_at(value);
+        }
+      }
+    }
+
+    if(nullptr != mAdapters) {
+      for (TPortId i = 0; i < T::mInterfaceSpec->mNumAdapters; ++i) {
+        T::destroyAdapter(mAdapters[i]);
+      }
+    }
+  }
+
+  operator delete(mFBConnData);
+  mFBConnData = nullptr;
+  operator delete(mFBVarsData);
+  mFBVarsData = nullptr;
+
+#ifdef FORTE_SUPPORT_MONITORING
+  T::freeEventMonitoringData();
+#endif //FORTE_SUPPORT_MONITORING
+}
+
+template<class T>
+void CGenFunctionBlock<T>::setupAdapters(const SFBInterfaceSpec *paInterfaceSpec, TForteByte *paFBData){
+  if((nullptr != paInterfaceSpec) && (nullptr != paFBData) && (paInterfaceSpec->mNumAdapters)) {
+    mAdapters = reinterpret_cast<TAdapterPtr *>(paFBData);
+    for(TPortId i = 0; i < paInterfaceSpec->mNumAdapters; ++i) {
+      mAdapters[i] = T::createAdapter(paInterfaceSpec->mAdapterInstanceDefinition[i], static_cast<TForteUInt8>(i));
     }
   }
 }

--- a/src/core/genfb.tpp
+++ b/src/core/genfb.tpp
@@ -25,7 +25,7 @@ CGenFunctionBlock<T>::CGenFunctionBlock(forte::core::CFBContainer &paContainer, 
 template<class T>
 CGenFunctionBlock<T>::~CGenFunctionBlock(){
   if(nullptr != T::mInterfaceSpec){
-    T::freeAllData();  //clean the interface and connections first.
+    T::freeFBInterfaceData();  //clean the interface and connections first.
     T::mInterfaceSpec = nullptr; //this stops the base classes from any wrong clean-up
   }
 }

--- a/src/core/io/configFB/io_base.cpp
+++ b/src/core/io/configFB/io_base.cpp
@@ -16,8 +16,13 @@
 using namespace forte::core::io;
 
 IOConfigFBBase::IOConfigFBBase(forte::core::CFBContainer &paContainer, const SFBInterfaceSpec *paInterfaceSpec, const CStringDictionary::TStringId paInstanceNameId) :
-    CEventSourceFB(paContainer, paInterfaceSpec, paInstanceNameId) {
+    CGenFunctionBlock<CEventSourceFB>(paContainer, paInterfaceSpec, paInstanceNameId) {
 }
 
 IOConfigFBBase::~IOConfigFBBase() = default;
+
+bool IOConfigFBBase::createInterfaceSpec(const char *, SFBInterfaceSpec &paInterfaceSpec) {
+  paInterfaceSpec = *mInterfaceSpec;
+  return true;
+}
 

--- a/src/core/io/configFB/io_base.h
+++ b/src/core/io/configFB/io_base.h
@@ -14,16 +14,18 @@
 #ifndef SRC_CORE_IO_CONFIGFB_BASE_H_
 #define SRC_CORE_IO_CONFIGFB_BASE_H_
 
-#include <esfb.h>
+#include "esfb.h"
+#include "genfb.h"
 
 namespace forte {
   namespace core {
     namespace io {
 
-      class IOConfigFBBase : public CEventSourceFB {
+      class IOConfigFBBase : public CGenFunctionBlock<CEventSourceFB> {
         public:
           IOConfigFBBase(forte::core::CFBContainer &paContainer, const SFBInterfaceSpec *paInterfaceSpec, const CStringDictionary::TStringId paInstanceNameId);
           ~IOConfigFBBase() override;
+          bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
       };
 
     } //namespace IO

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -136,6 +136,18 @@ class CResource : public CFunctionBlock, public forte::core::CFBContainer{
       // nothing to write to for a resource
     }
 
+    CIEC_ANY *getDO(size_t) override {
+      return nullptr;
+    }
+
+    CEventConnection *getEOConUnchecked(TPortId) override {
+      return nullptr;
+    }
+
+    CDataConnection *getDOConUnchecked(TPortId) override {
+      return nullptr;
+    }
+
     /*! Wrapper for simplifying connection creation in resources
      *
      */

--- a/src/modules/utils/STEST_END.cpp
+++ b/src/modules/utils/STEST_END.cpp
@@ -10,24 +10,30 @@
  *   Michael Hofmann, Alois Zoitl
  *   - initial API and implementation and/or initial documentation
  *******************************************************************************/
+
 #include "STEST_END.h"
 #ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
 #include "STEST_END_gen.cpp"
 #endif
+
 #include "../../stdfblib/ita/RMT_DEV.h"
-#include <forte_thread.h>
+#include "forte_thread.h"
 
 DEFINE_FIRMWARE_FB(FORTE_STEST_END, g_nStringIdSTEST_END)
 
 const TForteInt16 FORTE_STEST_END::scmEIWithIndexes[] = {-1};
 const CStringDictionary::TStringId FORTE_STEST_END::scmEventInputNames[] = {g_nStringIdREQ};
-
 const SFBInterfaceSpec FORTE_STEST_END::scmFBInterfaceSpec = {
-  1,  scmEventInputNames,  nullptr,  scmEIWithIndexes,
-  0,  nullptr,  nullptr, nullptr,  0,  nullptr, nullptr,
-  0,  nullptr, nullptr,
+  1, scmEventInputNames, nullptr, scmEIWithIndexes,
+  0, nullptr, nullptr, nullptr,
+  0, nullptr, nullptr,
+  0, nullptr, nullptr,
   0, nullptr,
   0, nullptr
+};
+
+FORTE_STEST_END::FORTE_STEST_END(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+    CFunctionBlock(paContainer, &scmFBInterfaceSpec, paInstanceNameId) {
 };
 
 void FORTE_STEST_END::executeEvent(TEventID paEIID, CEventChainExecutionThread *const) {
@@ -37,5 +43,31 @@ void FORTE_STEST_END::executeEvent(TEventID paEIID, CEventChainExecutionThread *
   }
 }
 
+void FORTE_STEST_END::readInputData(TEventID) {
+  // nothing to do
+}
 
+void FORTE_STEST_END::writeOutputData(TEventID) {
+  // nothing to do
+}
+
+CIEC_ANY *FORTE_STEST_END::getDI(size_t) {
+  return nullptr;
+}
+
+CIEC_ANY *FORTE_STEST_END::getDO(size_t) {
+  return nullptr;
+}
+
+CEventConnection *FORTE_STEST_END::getEOConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection **FORTE_STEST_END::getDIConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection *FORTE_STEST_END::getDOConUnchecked(TPortId) {
+  return nullptr;
+}
 

--- a/src/modules/utils/STEST_END.h
+++ b/src/modules/utils/STEST_END.h
@@ -13,39 +13,44 @@
  *   - initial API and implementation and/or initial documentation
  *   Martin Jobst - add readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _STEST_END_H_
-#define _STEST_END_H_
 
-#include <funcbloc.h>
-#include <mgmcmdstruct.h>
+#pragma once
 
-class FORTE_STEST_END: public CFunctionBlock{
+#include "funcbloc.h"
+#include "mgmcmdstruct.h"
+
+
+class FORTE_STEST_END final : public CFunctionBlock {
   DECLARE_FIRMWARE_FB(FORTE_STEST_END)
 
-private:
-  static const TEventID scmEventREQID = 0;
-  static const TForteInt16 scmEIWithIndexes[];
-  static const CStringDictionary::TStringId scmEventInputNames[];
+  private:
+    static const TEventID scmEventREQID = 0;
+    static const TForteInt16 scmEIWithIndexes[];
+    static const CStringDictionary::TStringId scmEventInputNames[];
 
-  static const TForteInt16 scmEOWithIndexes[];
-  static const SFBInterfaceSpec scmFBInterfaceSpec;
+    static const SFBInterfaceSpec scmFBInterfaceSpec;
 
+    void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
-  void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+    void readInputData(TEventID paEIID) override;
+    void writeOutputData(TEventID paEIID) override;
 
-  void readInputData(TEventID) override {
-  }
+  public:
+    FORTE_STEST_END(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
 
-  void writeOutputData(TEventID) override {
-  }
+    CIEC_ANY *getDI(size_t) override;
+    CIEC_ANY *getDO(size_t) override;
+    CEventConnection *getEOConUnchecked(TPortId) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+    CDataConnection *getDOConUnchecked(TPortId) override;
 
-public:
-  FUNCTION_BLOCK_CTOR(FORTE_STEST_END){
-  };
+    void evt_REQ() {
+      executeEvent(scmEventREQID, nullptr);
+    }
 
-  ~FORTE_STEST_END() override = default;
-
+    void operator()() {
+      evt_REQ();
+    }
 };
 
-#endif //close the ifdef sequence from the beginning of the file
 

--- a/src/modules/utils/TEST_CONDITION.cpp
+++ b/src/modules/utils/TEST_CONDITION.cpp
@@ -30,22 +30,30 @@ bool FORTE_TEST_CONDITION::smfinalReportPrinted = false;
 DEFINE_FIRMWARE_FB(FORTE_TEST_CONDITION, g_nStringIdTEST_CONDITION)
 
 const CStringDictionary::TStringId FORTE_TEST_CONDITION::scmDataInputNames[] = {g_nStringIdcheck};
-
 const CStringDictionary::TStringId FORTE_TEST_CONDITION::scmDataInputTypeIds[] = {g_nStringIdBOOL};
-
-const TForteInt16 FORTE_TEST_CONDITION::scmEIWithIndexes[] = {0};
 const TDataIOID FORTE_TEST_CONDITION::scmEIWith[] = {0, scmWithListDelimiter};
+const TForteInt16 FORTE_TEST_CONDITION::scmEIWithIndexes[] = {0};
 const CStringDictionary::TStringId FORTE_TEST_CONDITION::scmEventInputNames[] = {g_nStringIdREQ};
-
+const TForteInt16 FORTE_TEST_CONDITION::scmEOWithIndexes[] = {-1};
 const CStringDictionary::TStringId FORTE_TEST_CONDITION::scmEventOutputNames[] = {g_nStringIdCNF};
-
 const SFBInterfaceSpec FORTE_TEST_CONDITION::scmFBInterfaceSpec = {
-  1,  scmEventInputNames,  scmEIWith,  scmEIWithIndexes,
-  1,  scmEventOutputNames,  nullptr, nullptr,  1,  scmDataInputNames, scmDataInputTypeIds,
-  0,  nullptr, nullptr,
+  1, scmEventInputNames, scmEIWith, scmEIWithIndexes,
+  1, scmEventOutputNames, nullptr, scmEOWithIndexes,
+  1, scmDataInputNames, scmDataInputTypeIds,
+  0, nullptr, nullptr,
   0, nullptr,
   0, nullptr
 };
+
+FORTE_TEST_CONDITION::FORTE_TEST_CONDITION(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, &scmFBInterfaceSpec, paInstanceNameId),
+        conn_CNF(this, 0),
+        conn_check(nullptr) {
+};
+
+void FORTE_TEST_CONDITION::setInitialValues() {
+  var_check = 0_BOOL;
+}
 
 FORTE_TEST_CONDITION::~FORTE_TEST_CONDITION() {
   CCriticalRegion finalReportRegion(mFinalReportMutex);
@@ -66,7 +74,7 @@ FORTE_TEST_CONDITION::~FORTE_TEST_CONDITION() {
 void FORTE_TEST_CONDITION::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
   if(scmEventREQID == paEIID) {
     smExecutedTests++;
-    if(check()) {
+    if(var_check) {
       DEVLOG_INFO(" ------------------------------ [TEST_CONDITION_PASSED] %s.%s passed\n", getResource()->getInstanceName(), getInstanceName());
     } else {
       DEVLOG_ERROR("------------------------------ [TEST_CONDITION_FAILED] %s.%s failed ------------------------------\n", getResource()->getInstanceName(),
@@ -77,10 +85,47 @@ void FORTE_TEST_CONDITION::executeEvent(TEventID paEIID, CEventChainExecutionThr
   }
 }
 
-void FORTE_TEST_CONDITION::readInputData(TEventID) {
-  readData(0, *mDIs[0], mDIConns[0]);
+void FORTE_TEST_CONDITION::readInputData(const TEventID paEIID) {
+  switch(paEIID) {
+    case scmEventREQID: {
+      readData(0, var_check, conn_check);
+      break;
+    }
+    default:
+      break;
+  }
 }
 
 void FORTE_TEST_CONDITION::writeOutputData(TEventID) {
+  // nothing to do
+}
+
+CIEC_ANY *FORTE_TEST_CONDITION::getDI(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_check;
+  }
+  return nullptr;
+}
+
+CIEC_ANY *FORTE_TEST_CONDITION::getDO(size_t) {
+  return nullptr;
+}
+
+CEventConnection *FORTE_TEST_CONDITION::getEOConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_CNF;
+  }
+  return nullptr;
+}
+
+CDataConnection **FORTE_TEST_CONDITION::getDIConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_check;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_TEST_CONDITION::getDOConUnchecked(TPortId) {
+  return nullptr;
 }
 

--- a/src/stdfblib/events/E_CYCLE.cpp
+++ b/src/stdfblib/events/E_CYCLE.cpp
@@ -23,7 +23,7 @@ void E_CYCLE::executeEvent(TEventID paEIID, CEventChainExecutionThread *const pa
   if(paEIID == csmEventSTARTID) {
     if(!mActive){
       setEventChainExecutor(paECET);
-      getTimer().registerPeriodicTimedFB(this, DT());
+      getTimer().registerPeriodicTimedFB(this, var_DT);
       mActive = true;
     }
   } else {

--- a/src/stdfblib/events/E_DELAY.cpp
+++ b/src/stdfblib/events/E_DELAY.cpp
@@ -33,7 +33,7 @@ void E_DELAY::executeEvent(TEventID paEIID, CEventChainExecutionThread * const p
     case csmEventSTARTID:
       if(!mActive){
         setEventChainExecutor(paECET); // E_DELAY will execute in the same thread on as from where it has been triggered.
-        getTimer().registerOneShotTimedFB(this, DT());
+        getTimer().registerOneShotTimedFB(this, var_DT);
         mActive = true;
       }
       break;

--- a/src/stdfblib/events/E_RDELAY.cpp
+++ b/src/stdfblib/events/E_RDELAY.cpp
@@ -33,7 +33,7 @@ void E_RDELAY::executeEvent(TEventID paEIID, CEventChainExecutionThread * const 
         getTimer().unregisterTimedFB(this);
       }
       setEventChainExecutor(paECET);  // E_RDELAY will execute in the same thread on as from where it has been triggered.
-      getTimer().registerOneShotTimedFB(this, DT());
+      getTimer().registerOneShotTimedFB(this, var_DT);
       mActive = true;
       break;
     default:

--- a/src/stdfblib/events/E_RESTART.cpp
+++ b/src/stdfblib/events/E_RESTART.cpp
@@ -17,27 +17,32 @@
 #endif
 #include "../../core/device.h"
 
-DEFINE_FIRMWARE_FB(E_RESTART, g_nStringIdE_RESTART)
+DEFINE_FIRMWARE_FB(FORTE_E_RESTART, g_nStringIdE_RESTART)
 
-const CStringDictionary::TStringId E_RESTART::scmEONameIds[] = {g_nStringIdCOLD, g_nStringIdWARM, g_nStringIdSTOP};
-
-const TEventID E_RESTART::csmCOLDID;
-const TEventID E_RESTART::csmWARMID;
-const TEventID E_RESTART::csmSTOPID;
-
-const SFBInterfaceSpec E_RESTART::scmFBInterfaceSpec = {
+const TForteInt16 FORTE_E_RESTART::scmEOWithIndexes[] = {-1, -1, -1};
+const CStringDictionary::TStringId FORTE_E_RESTART::scmEventOutputNames[] = {g_nStringIdCOLD, g_nStringIdWARM, g_nStringIdSTOP};
+const SFBInterfaceSpec FORTE_E_RESTART::scmFBInterfaceSpec = {
   0, nullptr, nullptr, nullptr,
-  3, scmEONameIds, nullptr, nullptr,
+  3, scmEventOutputNames, nullptr, scmEOWithIndexes,
   0, nullptr, nullptr,
   0, nullptr, nullptr,
   0, nullptr,
   0, nullptr
 };
 
-void E_RESTART::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
+FORTE_E_RESTART::FORTE_E_RESTART(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CEventSourceFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId),
+        mEventToSend(cgInvalidEventID),
+        conn_COLD(this, 0),
+        conn_WARM(this, 1),
+        conn_STOP(this, 2) {
+  setEventChainExecutor(getResource()->getResourceEventExecution());
+};
+
+void FORTE_E_RESTART::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
   if(cgExternalEventID == paEIID && cgInvalidEventID != mEventToSend) {
     sendOutputEvent(mEventToSend, paECET);
-    if(csmSTOPID == mEventToSend) {
+    if(scmEventSTOPID == mEventToSend) {
       //stop event is sent put the FB finally into the stopped state
       CFunctionBlock::changeFBExecutionState(EMGMCommandType::Stop);
       // release semaphore to indicate that the stop event was sent now
@@ -46,22 +51,49 @@ void E_RESTART::executeEvent(TEventID paEIID, CEventChainExecutionThread *const 
   }
 }
 
-void E_RESTART::readInputData(TEventID) {
+void FORTE_E_RESTART::readInputData(TEventID) {
+  // nothing to do
 }
 
-void E_RESTART::writeOutputData(TEventID) {
+void FORTE_E_RESTART::writeOutputData(TEventID) {
+  // nothing to do
 }
 
-EMGMResponse E_RESTART::changeFBExecutionState(EMGMCommandType paCommand){
+CIEC_ANY *FORTE_E_RESTART::getDI(size_t) {
+  return nullptr;
+}
+
+CIEC_ANY *FORTE_E_RESTART::getDO(size_t) {
+  return nullptr;
+}
+
+CEventConnection *FORTE_E_RESTART::getEOConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_COLD;
+    case 1: return &conn_WARM;
+    case 2: return &conn_STOP;
+  }
+  return nullptr;
+}
+
+CDataConnection **FORTE_E_RESTART::getDIConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_RESTART::getDOConUnchecked(TPortId) {
+  return nullptr;
+}
+
+EMGMResponse FORTE_E_RESTART::changeFBExecutionState(EMGMCommandType paCommand){
   EMGMResponse eRetVal = CFunctionBlock::changeFBExecutionState(paCommand);
   if(EMGMResponse::Ready == eRetVal){
     switch(paCommand){
       case EMGMCommandType::Start:
-        mEventToSend = (csmSTOPID == mEventToSend) ? csmWARMID : csmCOLDID;
+        mEventToSend = (scmEventSTOPID == mEventToSend) ? scmEventWARMID : scmEventCOLDID;
         getDevice()->getDeviceExecution().startNewEventChain(this);
         break;
       case EMGMCommandType::Stop:
-        mEventToSend = csmSTOPID;
+        mEventToSend = scmEventSTOPID;
         CFunctionBlock::changeFBExecutionState(EMGMCommandType::Start);   //keep FB in running state until stop event is delivered.
         getDevice()->getDeviceExecution().startNewEventChain(this);
         // wait until semaphore is released, after STOP eventExecution was completed

--- a/src/stdfblib/events/E_RTimeOut.cpp
+++ b/src/stdfblib/events/E_RTimeOut.cpp
@@ -33,8 +33,15 @@ const SFBInterfaceSpec FORTE_E_RTimeOut::scmFBInterfaceSpec = {
 };
 
 FORTE_E_RTimeOut::FORTE_E_RTimeOut(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
-    CCompositeFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {
+    CCompositeFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId, scmFBNData),
+    var_TimeOutSocket(g_nStringIdTimeOutSocket, getContainer(), false) {
 };
+
+bool FORTE_E_RTimeOut::initialize() {
+  if(!var_TimeOutSocket.initialize()) { return false; }
+  var_TimeOutSocket.setParentFB(this, 0);
+  return CCompositeFB::initialize();
+}
 
 const SCFB_FBInstanceData FORTE_E_RTimeOut::scmInternalFBs[] = {
   {g_nStringIdDLY, g_nStringIdE_RDELAY}
@@ -61,14 +68,15 @@ const SCFB_FBNData FORTE_E_RTimeOut::scmFBNData = {
   0, nullptr
 };
 
-
+void FORTE_E_RTimeOut::readInternal2InterfaceOutputData(TEventID) {
+  // nothing to do
+}
 void FORTE_E_RTimeOut::readInputData(TEventID) {
+  // nothing to do
 }
 
 void FORTE_E_RTimeOut::writeOutputData(TEventID) {
-}
-
-void FORTE_E_RTimeOut::readInternal2InterfaceOutputData(TEventID) {
+  // nothing to do
 }
 
 CIEC_ANY *FORTE_E_RTimeOut::getDI(size_t) {
@@ -76,6 +84,13 @@ CIEC_ANY *FORTE_E_RTimeOut::getDI(size_t) {
 }
 
 CIEC_ANY *FORTE_E_RTimeOut::getDO(size_t) {
+  return nullptr;
+}
+
+CAdapter *FORTE_E_RTimeOut::getAdapterUnchecked(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_TimeOutSocket;
+  }
   return nullptr;
 }
 
@@ -90,5 +105,4 @@ CDataConnection **FORTE_E_RTimeOut::getDIConUnchecked(TPortId) {
 CDataConnection *FORTE_E_RTimeOut::getDOConUnchecked(TPortId) {
   return nullptr;
 }
-
 

--- a/src/stdfblib/events/E_RTimeOut.h
+++ b/src/stdfblib/events/E_RTimeOut.h
@@ -22,40 +22,39 @@
 #include "ARTimeOut.h"
 
 
-class FORTE_E_RTimeOut: public CCompositeFB {
+class FORTE_E_RTimeOut final : public CCompositeFB {
   DECLARE_FIRMWARE_FB(FORTE_E_RTimeOut)
 
-private:
-  static const int scmTimeOutSocketAdpNum = 0;
-  
-  static const SAdapterInstanceDef scmAdapterInstances[];
+  private:
+    static const int scmTimeOutSocketAdpNum = 0;
+    static const SAdapterInstanceDef scmAdapterInstances[];
 
-  static const SFBInterfaceSpec scmFBInterfaceSpec;
+    static const SFBInterfaceSpec scmFBInterfaceSpec;
 
-  static const SCFB_FBInstanceData scmInternalFBs[];
-  static const SCFB_FBParameter scmParamters[];
-  static const SCFB_FBConnectionData scmEventConnections[];
-  static const SCFB_FBFannedOutConnectionData scmFannedOutEventConnections[];
-  static const SCFB_FBConnectionData scmDataConnections[];
-  static const SCFB_FBFannedOutConnectionData scmFannedOutDataConnections[];
-  static const SCFB_FBNData scmFBNData;
+    static const SCFB_FBInstanceData scmInternalFBs[];
+    static const SCFB_FBParameter scmParamters[];
+    static const SCFB_FBConnectionData scmEventConnections[];
+    static const SCFB_FBFannedOutConnectionData scmFannedOutEventConnections[];
+    static const SCFB_FBConnectionData scmDataConnections[];
+    static const SCFB_FBFannedOutConnectionData scmFannedOutDataConnections[];
+    static const SCFB_FBNData scmFBNData;
 
-  void readInputData(TEventID paEIID) override;
-  void writeOutputData(TEventID paEIID) override;
-  void readInternal2InterfaceOutputData(TEventID paEOID) override;
+    void readInputData(TEventID paEIID) override;
+    void writeOutputData(TEventID paEIID) override;
+    void readInternal2InterfaceOutputData(TEventID paEOID) override;
 
-public:
-  FORTE_E_RTimeOut(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+  public:
+    FORTE_E_RTimeOut(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+    bool initialize() override;
 
-  CIEC_ANY *getDI(size_t) override;
-  CIEC_ANY *getDO(size_t) override;
-  FORTE_ARTimeOut &var_TimeOutSocket() {
-    return *static_cast<FORTE_ARTimeOut*>(mAdapters[0]);
-  };
-  
-  CEventConnection *getEOConUnchecked(TPortId) override;
-  CDataConnection **getDIConUnchecked(TPortId) override;
-  CDataConnection *getDOConUnchecked(TPortId) override;
+    FORTE_ARTimeOut var_TimeOutSocket;
+
+    CIEC_ANY *getDI(size_t) override;
+    CIEC_ANY *getDO(size_t) override;
+    CAdapter *getAdapterUnchecked(size_t) override;
+    CEventConnection *getEOConUnchecked(TPortId) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+    CDataConnection *getDOConUnchecked(TPortId) override;
 };
 
 

--- a/src/stdfblib/events/E_TimeOut.cpp
+++ b/src/stdfblib/events/E_TimeOut.cpp
@@ -20,8 +20,9 @@
 
 DEFINE_FIRMWARE_FB(FORTE_E_TimeOut, g_nStringIdE_TimeOut)
 
-const SAdapterInstanceDef FORTE_E_TimeOut::scmAdapterInstances[] = { { g_nStringIdATimeOut, g_nStringIdTimeOutSocket, false } };
-
+const SAdapterInstanceDef FORTE_E_TimeOut::scmAdapterInstances[] = {
+  {g_nStringIdATimeOut, g_nStringIdTimeOutSocket, false}
+};
 const SFBInterfaceSpec FORTE_E_TimeOut::scmFBInterfaceSpec = {
   0, nullptr, nullptr, nullptr,
   0, nullptr, nullptr, nullptr,
@@ -31,19 +32,31 @@ const SFBInterfaceSpec FORTE_E_TimeOut::scmFBInterfaceSpec = {
   1, scmAdapterInstances
 };
 
+FORTE_E_TimeOut::FORTE_E_TimeOut(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+    CEventSourceFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId),
+    mActive(false),
+    var_TimeOutSocket(g_nStringIdTimeOutSocket, getContainer(), false) {
+};
+
+bool FORTE_E_TimeOut::initialize() {
+  if(!var_TimeOutSocket.initialize()) { return false; }
+  var_TimeOutSocket.setParentFB(this, 0);
+  return CEventSourceFB::initialize();
+}
+
 void FORTE_E_TimeOut::executeEvent(TEventID paEIID, CEventChainExecutionThread * const paECET){
   if(cgExternalEventID == paEIID){
     mActive = false;
     sendAdapterEvent(scmTimeOutSocketAdpNum, FORTE_ATimeOut::scmEventTimeOutID, paECET);
   }
-  else if(var_TimeOutSocket().evt_START() == paEIID){
+  else if(var_TimeOutSocket.evt_START() == paEIID){
     if(!mActive){
       setEventChainExecutor(paECET);  // delay notification should be execute in the same thread on as from where it has been triggered.
-      getTimer().registerOneShotTimedFB(this, var_TimeOutSocket().var_DT());
+      getTimer().registerOneShotTimedFB(this, var_TimeOutSocket.var_DT());
       mActive = true;
     }
   }
-  else if(var_TimeOutSocket().evt_STOP() == paEIID){
+  else if(var_TimeOutSocket.evt_STOP() == paEIID){
     if(mActive){
       getTimer().unregisterTimedFB(this);
       mActive = false;
@@ -52,9 +65,38 @@ void FORTE_E_TimeOut::executeEvent(TEventID paEIID, CEventChainExecutionThread *
 }
 
 void FORTE_E_TimeOut::readInputData(TEventID) {
+  // nothing to do
 }
 
 void FORTE_E_TimeOut::writeOutputData(TEventID) {
+  // nothing to do
+}
+
+CIEC_ANY *FORTE_E_TimeOut::getDI(size_t) {
+  return nullptr;
+}
+
+CIEC_ANY *FORTE_E_TimeOut::getDO(size_t) {
+  return nullptr;
+}
+
+CAdapter *FORTE_E_TimeOut::getAdapterUnchecked(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_TimeOutSocket;
+  }
+  return nullptr;
+}
+
+CEventConnection *FORTE_E_TimeOut::getEOConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection **FORTE_E_TimeOut::getDIConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_TimeOut::getDOConUnchecked(TPortId) {
+  return nullptr;
 }
 
 EMGMResponse FORTE_E_TimeOut::changeFBExecutionState(EMGMCommandType paCommand){

--- a/src/stdfblib/events/E_TimeOut.h
+++ b/src/stdfblib/events/E_TimeOut.h
@@ -23,34 +23,35 @@
 
 #include "../arch/timerha.h"
 
-// cppcheck-suppress noConstructor
-class FORTE_E_TimeOut : public CEventSourceFB{
+class FORTE_E_TimeOut final : public CEventSourceFB {
   DECLARE_FIRMWARE_FB(FORTE_E_TimeOut)
 
   private:
+    static const int scmTimeOutSocketAdpNum = 0;
     static const SAdapterInstanceDef scmAdapterInstances[];
 
-    FORTE_ATimeOut& var_TimeOutSocket(){
-      return *static_cast<FORTE_ATimeOut*>(mAdapters[0]);
-    }
-    ;
-    static const int scmTimeOutSocketAdpNum = 0;
     static const SFBInterfaceSpec scmFBInterfaceSpec;
 
     bool mActive; //!> flag to indicate that the timed fb is currently active
 
     void executeEvent(TEventID paEIID, CEventChainExecutionThread * const paECET) override;
 
-    void readInputData(TEventID paEI) override;
-    void writeOutputData(TEventID paEO) override;
+    void readInputData(TEventID paEIID) override;
+    void writeOutputData(TEventID paEIID) override;
 
   public:
-    EVENT_SOURCE_FUNCTION_BLOCK_CTOR(FORTE_E_TimeOut), mActive(false) {
-    };
+    FORTE_E_TimeOut(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+    bool initialize() override;
 
-  ~FORTE_E_TimeOut() override = default;
+    FORTE_ATimeOut var_TimeOutSocket;
 
-  EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+    CIEC_ANY *getDI(size_t) override;
+    CIEC_ANY *getDO(size_t) override;
+    CAdapter *getAdapterUnchecked(size_t) override;
+    CEventConnection *getEOConUnchecked(TPortId) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+    CDataConnection *getDOConUnchecked(TPortId) override;
 
+    EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
 };
 

--- a/src/stdfblib/ita/DEV_MGR.cpp
+++ b/src/stdfblib/ita/DEV_MGR.cpp
@@ -597,7 +597,7 @@ bool DEV_MGR::initialize() {
 }
 
 DEV_MGR::~DEV_MGR(){
-  freeAllData();
+  freeFBInterfaceData();
   mInterfaceSpec = nullptr;  //block any wrong cleanup in the generic fb base class of CBaseCommFB
 }
 

--- a/src/stdfblib/ita/EMB_RES.cpp
+++ b/src/stdfblib/ita/EMB_RES.cpp
@@ -42,3 +42,11 @@ bool EMB_RES::initialize() {
 
 EMB_RES::~EMB_RES() = default;
 
+CIEC_ANY *EMB_RES::getDI(const size_t) {
+  return nullptr;
+}
+
+CDataConnection **EMB_RES::getDIConUnchecked(const TPortId) {
+  return nullptr;
+}
+

--- a/src/stdfblib/ita/EMB_RES.h
+++ b/src/stdfblib/ita/EMB_RES.h
@@ -25,6 +25,9 @@ class EMB_RES : public CResource{
 
     bool initialize() override;
 
+    CIEC_ANY *getDI(size_t) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+
   private:
     static const SFBInterfaceSpec scmFBInterfaceSpec;
 };

--- a/src/stdfblib/ita/RMT_DEV.cpp
+++ b/src/stdfblib/ita/RMT_DEV.cpp
@@ -28,17 +28,20 @@ const SFBInterfaceSpec RMT_DEV::scmFBInterfaceSpec = {
   0, nullptr
 };
 
-RMT_DEV::RMT_DEV() :
-  CDevice(&scmFBInterfaceSpec, CStringDictionary::scmInvalidStringId),
-      MGR(g_nStringIdMGR, *this){
+RMT_DEV::RMT_DEV(const std::string &paMGR_ID) :
+        CDevice(&scmFBInterfaceSpec, CStringDictionary::scmInvalidStringId),
+        var_MGR_ID(paMGR_ID.c_str()),
+        MGR(g_nStringIdMGR, *this) {
 }
 
 bool RMT_DEV::initialize() {
   if(!CDevice::initialize()) {
     return false;
   }
-  MGR.initialize();
-  MGR_ID().fromString("localhost:61499");
+
+  if(!MGR.initialize()) {
+    return false;
+  }
 
   //we nee to manually crate this interface2internal connection as the MGR is not managed by device
   mDConnMGR_ID.setSource(this, 0);
@@ -67,5 +70,20 @@ EMGMResponse RMT_DEV::changeFBExecutionState(EMGMCommandType paCommand){
 }
 
 void RMT_DEV::setMGR_ID(const char * const paConn){
-  MGR_ID().fromString(paConn);
+  var_MGR_ID.fromString(paConn);
 }
+
+CIEC_ANY *RMT_DEV::getDI(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_MGR_ID;
+  }
+  return nullptr;
+}
+
+CDataConnection **RMT_DEV::getDIConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_MGR_ID;
+  }
+  return nullptr;
+}
+

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -23,7 +23,7 @@
 
 class RMT_DEV : public CDevice{
   public:
-    RMT_DEV();
+    RMT_DEV(const std::string &paMGR_ID = "localhost:61499");
     ~RMT_DEV() override;
 
     bool initialize() override;
@@ -48,9 +48,11 @@ class RMT_DEV : public CDevice{
     static const CStringDictionary::TStringId scmDINameIds[];
     static const CStringDictionary::TStringId scmDIDataTypeIds[];
 
-    CIEC_WSTRING& MGR_ID() {
-      return *static_cast<CIEC_WSTRING*>(getDI(0));
-    }
+    CIEC_WSTRING var_MGR_ID;
+    CDataConnection *conn_MGR_ID;
+
+    CIEC_ANY *getDI(size_t) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
 
     RMT_RES MGR;
 };

--- a/src/stdfblib/ita/RMT_RES.cpp
+++ b/src/stdfblib/ita/RMT_RES.cpp
@@ -100,3 +100,18 @@ RMT_RES::~RMT_RES() = default;
 void RMT_RES::joinResourceThread() const {
   getResourceEventExecution()->joinEventChainExecutionThread();
 }
+
+CIEC_ANY *RMT_RES::getDI(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_MGR_ID;
+  }
+  return nullptr;
+}
+
+CDataConnection **RMT_RES::getDIConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_MGR_ID;
+  }
+  return nullptr;
+}
+

--- a/src/stdfblib/ita/RMT_RES.h
+++ b/src/stdfblib/ita/RMT_RES.h
@@ -26,6 +26,12 @@ class RMT_RES : public CResource{
 
     void joinResourceThread() const;
 
+    CIEC_WSTRING var_MGR_ID;
+    CDataConnection *conn_MGR_ID;
+
+    CIEC_ANY *getDI(size_t) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+
   private:
     static const SFBInterfaceSpec scmFBInterfaceSpec;
 

--- a/src/stdfblib/timedfb.cpp
+++ b/src/stdfblib/timedfb.cpp
@@ -37,7 +37,8 @@ const SFBInterfaceSpec CTimedFB::scmFBInterfaceSpec = {
 };
 
 CTimedFB::CTimedFB(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
-      CEventSourceFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId){
+      CEventSourceFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId),
+      conn_EO(this, 0) {
   setEventChainExecutor(getResource()->getResourceEventExecution());
   mActive = false;
 }
@@ -59,10 +60,39 @@ void CTimedFB::executeEvent(TEventID paEIID, CEventChainExecutionThread * const 
 }
 
 void CTimedFB::readInputData(TEventID) {
-  readData(0, *mDIs[0], mDIConns[0]);
+  readData(0, var_DT, conn_DT);
 }
 
 void CTimedFB::writeOutputData(TEventID) {
+}
+
+CIEC_ANY *CTimedFB::getDI(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_DT;
+  }
+  return nullptr;
+}
+
+CIEC_ANY *CTimedFB::getDO(const size_t) {
+  return nullptr;
+}
+
+CEventConnection *CTimedFB::getEOConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_EO;
+  }
+  return nullptr;
+}
+
+CDataConnection **CTimedFB::getDIConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_DT;
+  }
+  return nullptr;
+}
+
+CDataConnection *CTimedFB::getDOConUnchecked(const TPortId) {
+  return nullptr;
 }
 
 EMGMResponse CTimedFB::changeFBExecutionState(EMGMCommandType paCommand){

--- a/src/stdfblib/timedfb.h
+++ b/src/stdfblib/timedfb.h
@@ -24,7 +24,6 @@
 /*!\brief Base class for timed function block like E_CYCLE or E_DELAY providing this interface
  */
 class CTimedFB : public CEventSourceFB{
-private:
 protected:
   static const SFBInterfaceSpec scmFBInterfaceSpec;
   static const CStringDictionary::TStringId scmEINameIds[];
@@ -51,15 +50,18 @@ protected:
   void readInputData(TEventID paEI) override;
   void writeOutputData(TEventID paEO) override;
 
-  CIEC_TIME& DT() {
-     return *static_cast<CIEC_TIME*>(getDI(0));
-  }
-
 public:
-  ~CTimedFB() override = default;
+  CIEC_TIME var_DT;
+  CDataConnection *conn_DT;
+  CEventConnection conn_EO;
+
+  CIEC_ANY *getDI(size_t) override;
+  CIEC_ANY *getDO(size_t) override;
+  CEventConnection *getEOConUnchecked(TPortId) override;
+  CDataConnection **getDIConUnchecked(TPortId) override;
+  CDataConnection *getDOConUnchecked(TPortId) override;
 
   EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
-
 };
 
 #endif /*TIMEDFB_H_*/

--- a/tests/core/cominfra/fbdkasn1layerdeser_test.cpp
+++ b/tests/core/cominfra/fbdkasn1layerdeser_test.cpp
@@ -87,7 +87,7 @@ class CDeserTestMockCommFB : public forte::com_infra::CCommFB{
     }
 
     virtual ~CDeserTestMockCommFB(){
-      freeAllData();
+      freeFBInterfaceData();
       mInterfaceSpec = nullptr;
     }
 

--- a/tests/core/fbtests/fbtesterglobalfixture.cpp
+++ b/tests/core/fbtests/fbtesterglobalfixture.cpp
@@ -38,6 +38,13 @@ class CTesterDevice : public CDevice {
       // nothing to be done to join
     }
 
+    CIEC_ANY *getDI(size_t) override {
+      return nullptr;
+    }
+
+    CDataConnection **getDIConUnchecked(TPortId) override {
+      return nullptr;
+    }
 };
 
 CFBTestDataGlobalFixture::CFBTestDataGlobalFixture(){

--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -50,7 +50,7 @@ class CFBTestConn : public CDataConnection {
 };
 
 CFBTestFixtureBase::CFBTestFixtureBase(CStringDictionary::TStringId paTypeId) :
-    CFunctionBlock(CFBTestDataGlobalFixture::getResource(), nullptr, 0), mTypeId(paTypeId),
+        CGenFunctionBlock<CFunctionBlock>(CFBTestDataGlobalFixture::getResource(), nullptr, 0), mTypeId(paTypeId),
         mFBUnderTest(CTypeLib::createFB(paTypeId, paTypeId, CFBTestDataGlobalFixture::getResource())) {
 }
 
@@ -150,6 +150,11 @@ void CFBTestFixtureBase::setup(const char* paConfigString){
   createEventOutputConnections();
   createDataInputConnections();
   createDataOutputConnections();
+}
+
+bool CFBTestFixtureBase::createInterfaceSpec(const char *, SFBInterfaceSpec &paInterfaceSpec) {
+  paInterfaceSpec = *mInterfaceSpec;
+  return true;
 }
 
 void CFBTestFixtureBase::executeEvent(TEventID paEIID, CEventChainExecutionThread *const) {

--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -93,7 +93,7 @@ CFBTestFixtureBase::~CFBTestFixtureBase(){
   performFBDeleteTests();
 
   if(nullptr != mInterfaceSpec){
-    freeAllData();  //clean the interface and connections first.
+    freeFBInterfaceData();  //clean the interface and connections first.
     delete mInterfaceSpec;
     mInterfaceSpec = nullptr; //this stops the base classes from any wrong clean-up
   }

--- a/tests/core/fbtests/fbtestfixture.h
+++ b/tests/core/fbtests/fbtestfixture.h
@@ -17,17 +17,17 @@
 #ifndef TESTS_CORE_FBTESTS_FBTESTFIXTURE_H_
 #define TESTS_CORE_FBTESTS_FBTESTFIXTURE_H_
 
-#include <fortenew.h>
-#include <funcbloc.h>
-#include <if2indco.h>
-#include <forte_sync.h>
+#include "fortenew.h"
+#include "genfb.h"
+#include "if2indco.h"
+#include "forte_sync.h"
 #include <boost/test/unit_test.hpp>
 #include <vector>
 #include <deque>
 
 #include "forte_boost_output_support.h"
 
-class CFBTestFixtureBase : public CFunctionBlock{
+class CFBTestFixtureBase : public CGenFunctionBlock<CFunctionBlock> {
   public:
     ~CFBTestFixtureBase();
 
@@ -41,6 +41,8 @@ class CFBTestFixtureBase : public CFunctionBlock{
     explicit CFBTestFixtureBase(CStringDictionary::TStringId paTypeId);
 
     void setup(const char* paConfigString = nullptr);
+
+    bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
     /*!\brief invoke the FB under Test with the given event id
      *

--- a/tests/core/funcbloctests.cpp
+++ b/tests/core/funcbloctests.cpp
@@ -63,6 +63,26 @@ BOOST_AUTO_TEST_CASE(FB_TO_STRING_BUFFER_SIZE_TEST_WITH_INRENAL_VAR){
 
         void writeOutputData(TEventID) override {
         }
+
+        CIEC_ANY *getDI(size_t) override {
+                return nullptr;
+        }
+
+        CIEC_ANY *getDO(size_t) override {
+                return nullptr;
+        }
+
+        CEventConnection *getEOConUnchecked(TPortId) override {
+                return nullptr;
+        }
+
+        CDataConnection **getDIConUnchecked(TPortId) override {
+                return nullptr;
+        }
+
+        CDataConnection *getDOConUnchecked(TPortId) override {
+                return nullptr;
+        }
 };
 
     CStringDictionary::TStringId varInternalNames[] = {g_nStringIdQU, g_nStringIdQD, g_nStringIdCV};

--- a/tests/core/internalvartests.cpp
+++ b/tests/core/internalvartests.cpp
@@ -55,6 +55,26 @@ class CInternalVarTestFB : public CBasicFB{
 
     void writeOutputData(TEventID) override{
     }
+
+    CIEC_ANY *getDI(size_t) override {
+      return nullptr;
+    }
+
+    CIEC_ANY *getDO(size_t) override {
+      return nullptr;
+    }
+
+    CEventConnection *getEOConUnchecked(TPortId) override {
+      return nullptr;
+    }
+
+    CDataConnection **getDIConUnchecked(TPortId) override {
+      return nullptr;
+    }
+
+    CDataConnection *getDOConUnchecked(TPortId) override {
+      return nullptr;
+    }
 };
 
 BOOST_AUTO_TEST_SUITE(internal_vars)

--- a/tests/core/mgmstatemachinetest.cpp
+++ b/tests/core/mgmstatemachinetest.cpp
@@ -44,6 +44,26 @@ class CFunctionBlockMock : public CFunctionBlock{
 
     void writeOutputData(TEventID) override{
     }
+
+    CIEC_ANY *getDI(size_t) override {
+      return nullptr;
+    }
+
+    CIEC_ANY *getDO(size_t) override {
+      return nullptr;
+    }
+
+    CEventConnection *getEOConUnchecked(TPortId) override {
+      return nullptr;
+    }
+
+    CDataConnection **getDIConUnchecked(TPortId) override {
+      return nullptr;
+    }
+
+    CDataConnection *getDOConUnchecked(TPortId) override {
+      return nullptr;
+    }
 };
 
 

--- a/tests/stdfblib/CFB_TEST.h
+++ b/tests/stdfblib/CFB_TEST.h
@@ -9,66 +9,89 @@
  * Contributors:
  *   Alois Zoitl  - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef _CFB_TEST_H_
-#define _CFB_TEST_H_
 
-#include <cfb.h>
-#include <typelib.h>
-#include <forte_bool.h>
+#pragma once
 
-class FORTE_CFB_TEST: public CCompositeFB{
+#include "cfb.h"
+#include "typelib.h"
+#include "forte_bool.h"
+
+
+class FORTE_CFB_TEST final : public CCompositeFB {
   DECLARE_FIRMWARE_FB(FORTE_CFB_TEST)
 
-private:
-  static const CStringDictionary::TStringId scmDataInputNames[];
-  static const CStringDictionary::TStringId scmDataInputTypeIds[];
-  CIEC_BOOL &QI() {
-    return *static_cast<CIEC_BOOL*>(getDI(0));
-  };
+  private:
+    static const CStringDictionary::TStringId scmDataInputNames[];
+    static const CStringDictionary::TStringId scmDataInputTypeIds[];
+    static const CStringDictionary::TStringId scmDataOutputNames[];
+    static const CStringDictionary::TStringId scmDataOutputTypeIds[];
+    static const TEventID scmEventSETID = 0;
+    static const TEventID scmEventRESETID = 1;
+    static const TDataIOID scmEIWith[];
+    static const TForteInt16 scmEIWithIndexes[];
+    static const CStringDictionary::TStringId scmEventInputNames[];
+    static const TEventID scmEventCNFID = 0;
+    static const TEventID scmEventCHANGEDID = 1;
+    static const TDataIOID scmEOWith[];
+    static const TForteInt16 scmEOWithIndexes[];
+    static const CStringDictionary::TStringId scmEventOutputNames[];
 
-  static const CStringDictionary::TStringId scmDataOutputNames[];
-  static const CStringDictionary::TStringId scmDataOutputTypeIds[];
-  CIEC_BOOL &SR() {
-    return *static_cast<CIEC_BOOL*>(getDO(0));
-  };
-
-  static const TEventID scmEventSETID = 0;
-  static const TEventID scmEventRESETID = 1;
-  static const TForteInt16 scmEIWithIndexes[];
-  static const TDataIOID scmEIWith[];
-  static const CStringDictionary::TStringId scmEventInputNames[];
-
-  static const TEventID scmEventCNFID = 0;
-  static const TEventID scmEventCHANGEDID = 1;
-  static const TForteInt16 scmEOWithIndexes[];
-  static const TDataIOID scmEOWith[];
-  static const CStringDictionary::TStringId scmEventOutputNames[];
-
-  static const SFBInterfaceSpec scmFBInterfaceSpec;
+    static const SFBInterfaceSpec scmFBInterfaceSpec;
 
 
-  static const SCFB_FBInstanceData scmInternalFBs[];
+    static const SCFB_FBInstanceData scmInternalFBs[];
 
-  static const SCFB_FBConnectionData scmEventConnections[];
+    static const SCFB_FBConnectionData scmEventConnections[];
 
-  static const SCFB_FBFannedOutConnectionData scmFannedOutEventConnections[];
+    static const SCFB_FBFannedOutConnectionData scmFannedOutEventConnections[];
 
-  static const SCFB_FBConnectionData scmDataConnections[];
+    static const SCFB_FBConnectionData scmDataConnections[];
 
-  static const SCFB_FBFannedOutConnectionData scmFannedOutDataConnections[];
-  static const SCFB_FBNData scmFBNData;
+    static const SCFB_FBFannedOutConnectionData scmFannedOutDataConnections[];
+    static const SCFB_FBNData scmFBNData;
 
-  void readInputData(TEventID paEI) override;
-  void writeOutputData(TEventID paEO) override;
-  void readInternal2InterfaceOutputData(TEventID paEOID) override;
+    void readInputData(TEventID paEIID) override;
+    void writeOutputData(TEventID paEIID) override;
+    void readInternal2InterfaceOutputData(TEventID paEOID) override;
+    void setInitialValues() override;
 
-public:
-  COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_CFB_TEST){
-  };
+  public:
+    FORTE_CFB_TEST(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
 
-  ~FORTE_CFB_TEST() override = default;
+    CIEC_BOOL var_QI;
 
+    CIEC_BOOL var_QO;
+
+    CIEC_BOOL var_conn_QO;
+
+    CEventConnection conn_CNF;
+    CEventConnection conn_CHANGED;
+
+    CDataConnection *conn_QI;
+
+    CDataConnection conn_QO;
+
+    CIEC_ANY *getDI(size_t) override;
+    CIEC_ANY *getDO(size_t) override;
+    CEventConnection *getEOConUnchecked(TPortId) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+    CDataConnection *getDOConUnchecked(TPortId) override;
+
+    void evt_SET(const CIEC_BOOL &paQI, CIEC_BOOL &paQO) {
+      var_QI = paQI;
+      executeEvent(scmEventSETID, nullptr);
+      paQO = var_QO;
+    }
+
+    void evt_RESET(const CIEC_BOOL &paQI, CIEC_BOOL &paQO) {
+      var_QI = paQI;
+      executeEvent(scmEventRESETID, nullptr);
+      paQO = var_QO;
+    }
+
+    void operator()(const CIEC_BOOL &paQI, CIEC_BOOL &paQO) {
+      evt_SET(paQI, paQO);
+    }
 };
 
-#endif //close the ifdef sequence from the beginning of the file
 


### PR DESCRIPTION
Move the dynamic interface setup and required variables to the generic function block and make accessor functions pure virtual.

This avoids duplicate memory allocations for function blocks following the new memory layout.