### PR TITLE
Reset event counters to 0 on initialization

### DIFF
--- a/src/core/funcbloc.cpp
+++ b/src/core/funcbloc.cpp
@@ -541,11 +541,11 @@ void CFunctionBlock::setupEventMonitoringData(){
 
   if(mInterfaceSpec) {
     if (0 != mInterfaceSpec->mNumEIs) {
-      mEIMonitorCount = new TForteUInt32[mInterfaceSpec->mNumEIs];
+      mEIMonitorCount = new TForteUInt32[mInterfaceSpec->mNumEIs]{};
     }
 
     if (0 != mInterfaceSpec->mNumEOs) {
-      mEOMonitorCount = new TForteUInt32[mInterfaceSpec->mNumEOs];
+      mEOMonitorCount = new TForteUInt32[mInterfaceSpec->mNumEOs]{};
     }
   }
 }


### PR DESCRIPTION
In #131 the memset clearing the event counters was removed, this results in random values showing up on the event counters