### PR TITLE
Migrated LuaFBs to new GenericFB template

### DIFF
--- a/src/core/lua/luabfb.cpp
+++ b/src/core/lua/luabfb.cpp
@@ -54,7 +54,7 @@ const char CLuaBFB::LUA_NAME[] = "FORTE_CLuaFB";
 const luaL_Reg CLuaBFB::LUA_FUNCS[] = { { "__index", CLuaFB_index }, { "__newindex", CLuaFB_newindex }, { "__call", CLuaFB_call }, { nullptr, nullptr } };
 
 CLuaBFB::CLuaBFB(CStringDictionary::TStringId paInstanceNameId, const CLuaBFBTypeEntry* paTypeEntry, forte::core::CFBContainer &paContainer) :
-    CBasicFB(paContainer, paTypeEntry->getInterfaceSpec(), paInstanceNameId, paTypeEntry->getInternalVarsInformation()),
+    CGenFunctionBlock<CBasicFB>(paContainer, paTypeEntry->getInterfaceSpec(), paInstanceNameId, paTypeEntry->getInternalVarsInformation()),
         mTypeEntry(paTypeEntry) {
   CLuaEngine *luaEngine = getResource()->getLuaEngine();
   luaEngine->registerType<CLuaBFB>();
@@ -67,7 +67,7 @@ CLuaBFB::~CLuaBFB() = default;
 bool CLuaBFB::initialize() {
   //before calling super we need to configure the interface of the FB
   setupFBInterface(getFBInterfaceSpec());
-  return CBasicFB::initialize();
+  return CGenFunctionBlock<CBasicFB>::initialize();
 }
 
 void CLuaBFB::executeEvent(TEventID paEIID, CEventChainExecutionThread *paECET) {

--- a/src/core/lua/luabfb.h
+++ b/src/core/lua/luabfb.h
@@ -14,6 +14,7 @@
 #ifndef SRC_CORE_LUABFB_H_
 #define SRC_CORE_LUABFB_H_
 
+#include "genfb.h"
 #include "basicfb.h"
 #include "luabfbtypeentry.h"
 
@@ -28,7 +29,7 @@ extern "C" {
   int CLuaFB_call(lua_State *luaState);
 }
 
-class CLuaBFB : public CBasicFB {
+class CLuaBFB : public CGenFunctionBlock<CBasicFB> {
   private:
     static constexpr TForteUInt32 scmLuaFBVarMax = 65535;
     static constexpr TForteUInt32 scmLuaAdpVarMax = 255;
@@ -56,6 +57,11 @@ class CLuaBFB : public CBasicFB {
     ~CLuaBFB() override;
 
     bool initialize() override;
+
+    bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override {
+      paInterfaceSpec = *mInterfaceSpec;
+      return true;
+    }
 
     void executeEvent(TEventID paEIID, CEventChainExecutionThread *paECET) override;
 

--- a/src/core/lua/luacfb.cpp
+++ b/src/core/lua/luacfb.cpp
@@ -17,7 +17,7 @@
 #include "criticalregion.h"
 
 CLuaCFB::CLuaCFB(CStringDictionary::TStringId paInstanceNameId, const CLuaCFBTypeEntry* paTypeEntry, SCFB_FBNData &paFbnData, forte::core::CFBContainer &paContainer) :
-    CCompositeFB(paContainer, paTypeEntry->getInterfaceSpec(), paInstanceNameId, paFbnData), mTypeEntry(paTypeEntry) {
+    CGenFunctionBlock<CCompositeFB>(paContainer, paTypeEntry->getInterfaceSpec(), paInstanceNameId, paFbnData), mTypeEntry(paTypeEntry) {
 }
 
 CLuaCFB::~CLuaCFB() = default;
@@ -26,7 +26,7 @@ CLuaCFB::~CLuaCFB() = default;
 bool CLuaCFB::initialize() {
   //before calling super we need to configure the interface of the FB
   setupFBInterface(getFBInterfaceSpec());
-  return CCompositeFB::initialize();
+  return CGenFunctionBlock<CCompositeFB>::initialize();
 }
 
 void CLuaCFB::readInputData(TEventID paEIID) {

--- a/src/core/lua/luacfb.h
+++ b/src/core/lua/luacfb.h
@@ -15,10 +15,11 @@
 #ifndef SRC_CORE_LUACFB_H_
 #define SRC_CORE_LUACFB_H_
 
+#include "genfb.h"
 #include "cfb.h"
 #include "luacfbtypeentry.h"
 
-class CLuaCFB : public CCompositeFB {
+class CLuaCFB : public CGenFunctionBlock<CCompositeFB> {
   public:
     CLuaCFB(CStringDictionary::TStringId paInstanceNameId, const CLuaCFBTypeEntry* paTypeEntry, SCFB_FBNData &paFbnData, forte::core::CFBContainer &paContainer);
     ~CLuaCFB() override;
@@ -28,6 +29,11 @@ class CLuaCFB : public CCompositeFB {
     }
 
     bool initialize() override;
+
+    bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override {
+      paInterfaceSpec = *mInterfaceSpec;
+      return true;
+    }
 
   protected:
     virtual void readInternal2InterfaceOutputData(TEventID paEOID);


### PR DESCRIPTION
In oder that the lua fbs are correctly creating their interface they need to use the GenericFB infrastructure.