### PR TITLE
Replaced CIEC_STRING with std::string in SManagementCMD

### DIFF
--- a/src/core/datatypes/forte_any_string.h
+++ b/src/core/datatypes/forte_any_string.h
@@ -87,7 +87,7 @@ class CIEC_ANY_STRING : public CIEC_ANY_CHARS {
      *
      * @return number of bytes that this string has allocated for use
      */
-    TForteUInt16 getCapacity() const {
+    virtual TForteUInt16 getCapacity() const {
       return (nullptr != getGenData()) ? (*((TForteUInt16 *)(getGenData() + 2))) : static_cast<TForteUInt16>(0);
     }
 

--- a/src/core/datatypes/forte_string.h
+++ b/src/core/datatypes/forte_string.h
@@ -182,6 +182,10 @@ class CIEC_STRING : public CIEC_ANY_STRING {
       return scmMaxStringLen;
     }
 
+    TForteUInt16 getCapacity() const override {
+      return static_cast<TForteUInt16>(mValue.capacity());
+    }
+
     void reserve(const TForteUInt16 paRequestedSize) override;
 
     void assign(const char *paData, const TForteUInt16 paLen) override;

--- a/src/core/fbcontainer.h
+++ b/src/core/fbcontainer.h
@@ -21,6 +21,7 @@
 
 class CFunctionBlock;
 class CDevice;
+class CResource;
 
 namespace forte {
   namespace core {

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -157,7 +157,7 @@ class CFunctionBlock {
 
     /*!\brief Returns the type name of this FB instance
      */
-    const char * getFBTypeName(){
+    const char * getFBTypeName() const {
       return CStringDictionary::getInstance().get(getFBTypeId());
     }
 

--- a/src/core/mgmcmdstruct.h
+++ b/src/core/mgmcmdstruct.h
@@ -14,8 +14,9 @@
 #define MGMCMDSTRUCT_H_
 
 #include "mgmcmd.h"
-#include "datatypes/forte_string.h"
 #include "utils/fixedcapvector.h"
+#include "stringdict.h"
+#include <string>
 
 namespace forte {
   namespace core {
@@ -70,7 +71,7 @@ namespace forte {
 
         /*!\brief Additional params needed by a MGM command (e.g., to return results of query commands)
          */
-        CIEC_STRING mAdditionalParams;
+        std::string mAdditionalParams;
 
         /*\brief pointer to the ID to generate the correct response */
         char *mID;

--- a/src/core/monitoring.cpp
+++ b/src/core/monitoring.cpp
@@ -506,7 +506,7 @@ void CMonitoringHandler::appendEventWatch(std::string &paResponse, SEventWatchEn
   paResponse += "\"/>\n</Port>"s;
 }
 
-void CMonitoringHandler::createFullFBName(CIEC_STRING &paFullName, forte::core::TNameIdentifier &paNameList){
+void CMonitoringHandler::createFullFBName(std::string &paFullName, forte::core::TNameIdentifier &paNameList){
   for(forte::core::TNameIdentifier::CIterator runner(paNameList.begin()); runner != paNameList.end(); ++runner){
     paFullName.append(CStringDictionary::getInstance().get(*runner));
     if(!runner.isLastEntry()){

--- a/src/core/monitoring.h
+++ b/src/core/monitoring.h
@@ -76,7 +76,7 @@ namespace forte {
         typedef CSinglyLinkedList<SEventWatchEntry> TEventWatchList;
 
         struct SFBMonitoringEntry{
-            CIEC_STRING mFullFBName;
+            std::string mFullFBName;
             CFunctionBlock *mFB;
             TDataWatchList mWatchedDataPoints;
             TEventWatchList mWatchedEventPoints;
@@ -106,7 +106,7 @@ namespace forte {
         static void appendPortTag(std::string &paResponse, CStringDictionary::TStringId paPortId);
         void appendEventWatch(std::string &paResponse, SEventWatchEntry &paEventWatchEntry);
 
-        static void createFullFBName(CIEC_STRING &paFullName, forte::core::TNameIdentifier &paNameList);
+        static void createFullFBName(std::string &paFullName, forte::core::TNameIdentifier &paNameList);
 
         static size_t getExtraSizeForEscapedChars(const CIEC_ANY& paDataValue);
 

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -101,7 +101,7 @@ class CResource : public CFunctionBlock, public forte::core::CFBContainer{
      * @param paValue the value to be writen
      * @return response of the command execution as defined in IEC 61499
      */
-    virtual EMGMResponse writeValue(forte::core::TNameIdentifier &paNameList, const CIEC_STRING & paValue, bool paForce = false);
+    virtual EMGMResponse writeValue(forte::core::TNameIdentifier &paNameList, const std::string & paValue, bool paForce = false);
 
 #ifdef FORTE_SUPPORT_MONITORING
     forte::core::CMonitoringHandler &getMonitoringHandler(){
@@ -193,48 +193,50 @@ class CResource : public CFunctionBlock, public forte::core::CFBContainer{
      * @param paValue the destination for the value to be read
      * @return response of the command execution as defined in IEC 61499
      */
-    EMGMResponse readValue(forte::core::TNameIdentifier &paNameList, CIEC_STRING & paValue);
+    EMGMResponse readValue(forte::core::TNameIdentifier &paNameList, std::string & paValue);
 
 #ifdef FORTE_SUPPORT_QUERY_CMD
     /*!\brief Read the existing fb types.
      *
      * @return response of the command execution as defined in IEC 61499
      */
-    static EMGMResponse queryAllFBTypes(CIEC_STRING& paValue);
+    static EMGMResponse queryAllFBTypes(std::string& paValue);
 
     /*!\brief Read the existing adapter types.
      *
      * @return response of the command execution as defined in IEC 61499
      */
-    static EMGMResponse queryAllAdapterTypes(CIEC_STRING& paValue);
+    static EMGMResponse queryAllAdapterTypes(std::string& paValue);
+
+    static void appedTypeNameList(std::string & paValue, CTypeLib::CTypeEntry *paTypeListStart);
 
     /*!\brief Retrieve the list of FB instances
      *
      * @param paValue the result of the query
      * @return response of the command execution as defined in IEC 61499
      */
-    EMGMResponse queryFBs(CIEC_STRING& paValue);
-    void createFBResponseMessage(const CFunctionBlock& paFb, const char* fullName, CIEC_STRING& paValue);
+    EMGMResponse queryFBs(std::string& paValue);
+    void createFBResponseMessage(const CFunctionBlock& paFb, const char* fullName, std::string& paValue);
 
-    EMGMResponse querySubapps(CIEC_STRING& paValue, CFBContainer& container, std::string prefix);
+    EMGMResponse querySubapps(std::string& paValue, CFBContainer& container, std::string prefix);
 
-    EMGMResponse queryConnections(CIEC_STRING &paValue, CFBContainer& container);
-    void createEOConnectionResponse(const CFunctionBlock& paFb, CIEC_STRING& paReqResult);
-    void createDOConnectionResponse(const CFunctionBlock& paFb, CIEC_STRING& paReqResult);
-    void createAOConnectionResponse(const CFunctionBlock& paFb, CIEC_STRING& paReqResult);
+    EMGMResponse queryConnections(std::string &paValue, CFBContainer& container);
+    void createEOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
+    void createDOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
+    void createAOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
     void createConnectionResponseMessage(const CStringDictionary::TStringId srcId, const CStringDictionary::TStringId dstId, const CFunctionBlock& paDstFb,
-        const CFunctionBlock& paFb, CIEC_STRING& paValue) const;
+        const CFunctionBlock& paFb, std::string& paValue) const;
 
-    EMGMResponse createFBTypeResponseMessage(const CStringDictionary::TStringId paValue, CIEC_STRING & paReqResult);
-    EMGMResponse createAdapterTypeResponseMessage(const CStringDictionary::TStringId paValue, CIEC_STRING & paReqResult);
-    EMGMResponse createXTypeResponseMessage(const CTypeLib::CSpecTypeEntry* paInterfaceSpec, const CStringDictionary::TStringId paValue, EMGMResponse retVal, CIEC_STRING& paReqResult);
-    void createEventInterfaceResponseMessage(const SFBInterfaceSpec* paInterfaceSpec, CIEC_STRING& paReqResult);
-    void createDataInterfaceResponseMessage(const SFBInterfaceSpec* paInterfaceSpec, CIEC_STRING& paReqResult);
-    void createAdapterInterfaceResponseMessage(const SFBInterfaceSpec* paInterfaceSpec, CIEC_STRING& paReqResult);
-    void createInterfaceResponseMessages(CIEC_STRING& paReqResult, const char *paCommand, const CStringDictionary::TStringId* paNameList,
+    EMGMResponse createFBTypeResponseMessage(const CStringDictionary::TStringId paValue, std::string & paReqResult);
+    EMGMResponse createAdapterTypeResponseMessage(const CStringDictionary::TStringId paValue, std::string & paReqResult);
+    EMGMResponse createXTypeResponseMessage(const CTypeLib::CSpecTypeEntry* paInterfaceSpec, const CStringDictionary::TStringId paValue, EMGMResponse retVal, std::string& paReqResult);
+    void createEventInterfaceResponseMessage(const SFBInterfaceSpec* paInterfaceSpec, std::string& paReqResult);
+    void createDataInterfaceResponseMessage(const SFBInterfaceSpec* paInterfaceSpec, std::string& paReqResult);
+    void createAdapterInterfaceResponseMessage(const SFBInterfaceSpec* paInterfaceSpec, std::string& paReqResult);
+    void createInterfaceResponseMessages(std::string& paReqResult, const char *paCommand, const CStringDictionary::TStringId* paNameList,
         const CStringDictionary::TStringId* paTypeList, const TEventID paNumberOfElements = 0, const TDataIOID* paEWith = nullptr, const TForteInt16* paEWithIndexes = nullptr,
         const CStringDictionary::TStringId* paDNameList = nullptr);
-    void createInterfaceResponseMessage(CIEC_STRING& paReqResult, const char* paCommand, const CIEC_STRING& paName, const CIEC_STRING& paType,
+    void createInterfaceResponseMessage(std::string& paReqResult, const char* paCommand, const std::string& paName, const std::string& paType,
         const TDataIOID* paEWith = nullptr, const TForteInt16* paEWithIndexes = nullptr, const TEventID paIndex = 0,
         const CStringDictionary::TStringId* paENameList = nullptr) const;
 

--- a/src/core/typelib.h
+++ b/src/core/typelib.h
@@ -145,6 +145,8 @@ class CTypeLib{
       virtual ~CTypeEntry();
 
       CStringDictionary::TStringId getTypeNameId() const { return mTypeNameId; };
+
+      const char * getTypeName() const { return CStringDictionary::getInstance().get(getTypeNameId()); };
   };
 
   class CSpecTypeEntry : public CTypeEntry {

--- a/src/modules/reconfiguration/ST_SET_PARM_fbt.cpp
+++ b/src/modules/reconfiguration/ST_SET_PARM_fbt.cpp
@@ -84,7 +84,7 @@ void FORTE_ST_SET_PARM::executeRQST() {
   theCommand.mDestination = CStringDictionary::getInstance().getId(var_DST.getValue());
   theCommand.mFirstParam.pushBack(CStringDictionary::getInstance().getId(var_ELEM_NAME.getValue()));
   theCommand.mFirstParam.pushBack(CStringDictionary::getInstance().getId(var_ELEM_DATA_IN.getValue()));
-  theCommand.mAdditionalParams = func_WSTRING_TO_STRING(var_PARM_VAL);
+  theCommand.mAdditionalParams = func_WSTRING_TO_STRING(var_PARM_VAL).getStorage();
   theCommand.mCMD = EMGMCommandType::Write;
 
   EMGMResponse resp = getDevice()->executeMGMCommand(theCommand);

--- a/src/stdfblib/ita/DEV_MGR.cpp
+++ b/src/stdfblib/ita/DEV_MGR.cpp
@@ -176,7 +176,7 @@ bool DEV_MGR::parseXType(char *paRequestPartLeft, forte::core::SManagementCMD &p
       char* endOfRequest = strchr(paRequestPartLeft, '<');
       *endOfRequest = '\0';
       forte::core::util::transformEscapedXMLToNonEscapedText(paRequestPartLeft);
-      paCommand.mAdditionalParams = CIEC_STRING(paRequestPartLeft);
+      paCommand.mAdditionalParams = paRequestPartLeft;
       retVal = true;
     }
   }
@@ -267,11 +267,10 @@ bool DEV_MGR::parseWriteConnectionData(char *paRequestPartLeft, forte::core::SMa
       return false;
     }
     *endOfSource = '\0';
-    paCommand.mAdditionalParams = CIEC_STRING(paRequestPartLeft, strlen(paRequestPartLeft));
-    char *addParams = new char[paCommand.mAdditionalParams.getStorage().length() + 1]();
-    strcpy(addParams, paCommand.mAdditionalParams.getStorage().c_str());
+    char *addParams = new char[strlen(paRequestPartLeft) + 1]();
+    strcpy(addParams, paRequestPartLeft);
     forte::core::util::transformEscapedXMLToNonEscapedText(addParams);
-    paCommand.mAdditionalParams.assign(addParams, static_cast<TForteUInt16>(strlen(addParams)));
+    paCommand.mAdditionalParams = addParams;
     delete[](addParams);
     *endOfSource = '"'; // restore the string
     paRequestPartLeft = strchr(endOfSource + 1, '\"');
@@ -382,13 +381,13 @@ void DEV_MGR::parseWriteData(char *paRequestPartLeft, forte::core::SManagementCM
         paCommand.mCMD = EMGMCommandType::MonitoringClearForce;
       }
     } else if ((2 == paCommand.mAdditionalParams.length()) &&
-      (('$' == paCommand.mAdditionalParams.getStorage()[0]) &&
-        (('e' == paCommand.mAdditionalParams.getStorage()[1]) ||('E' == paCommand.mAdditionalParams.getStorage()[1]) ))){
+      (('$' == paCommand.mAdditionalParams[0]) &&
+        (('e' == paCommand.mAdditionalParams[1]) ||('E' == paCommand.mAdditionalParams[1]) ))){
       paCommand.mCMD = EMGMCommandType::MonitoringTriggerEvent;
     }else if ((3 == paCommand.mAdditionalParams.length()) &&
-      (('$' == paCommand.mAdditionalParams.getStorage()[0]) &&
-       (('e' == paCommand.mAdditionalParams.getStorage()[1]) ||('E' == paCommand.mAdditionalParams.getStorage()[1]) ) &&
-       (('r' == paCommand.mAdditionalParams.getStorage()[2]) ||('R' == paCommand.mAdditionalParams.getStorage()[2]) ) )){
+      (('$' == paCommand.mAdditionalParams[0]) &&
+       (('e' == paCommand.mAdditionalParams[1]) ||('E' == paCommand.mAdditionalParams[1]) ) &&
+       (('r' == paCommand.mAdditionalParams[2]) ||('R' == paCommand.mAdditionalParams[2]) ) )){
       paCommand.mCMD = EMGMCommandType::MonitoringResetEventCount;
     }else
 #endif // FORTE_SUPPORT_MONITORING
@@ -607,7 +606,7 @@ EMGMResponse DEV_MGR::parseAndExecuteMGMCommand(const char *const paDest, char *
     mCommand.mDestination = (strlen(paDest) != 0) ? CStringDictionary::getInstance().insert(paDest) : CStringDictionary::scmInvalidStringId;
     mCommand.mFirstParam.clear();
     mCommand.mSecondParam.clear();
-    if ( 255 <= mCommand.mAdditionalParams.getCapacity()) {
+    if ( 255 <= mCommand.mAdditionalParams.capacity()) {
       mCommand.mAdditionalParams.reserve(255);
     }
     mCommand.mID=nullptr;

--- a/src/stdfblib/ita/OPCUA_MGR.cpp
+++ b/src/stdfblib/ita/OPCUA_MGR.cpp
@@ -1280,7 +1280,7 @@ void OPCUA_MGR::setMGMCommand(EMGMCommandType paCMD, CStringDictionary::TStringI
     mCommand.mSecondParam.pushBack(CStringDictionary::getInstance().insert(paSecondParam));
   }
   if (paAdditionalParams != nullptr) {
-    mCommand.mAdditionalParams = CIEC_STRING(paAdditionalParams);
+    mCommand.mAdditionalParams = paAdditionalParams;
   }
 }
 
@@ -1301,7 +1301,7 @@ void OPCUA_MGR::setMGMCommand(EMGMCommandType paCMD, CStringDictionary::TStringI
     }
   }
   if (paAdditionalParams != nullptr) {
-    mCommand.mAdditionalParams = CIEC_STRING(paAdditionalParams);
+    mCommand.mAdditionalParams = paAdditionalParams;
   }
 }
 


### PR DESCRIPTION
SManagementCMD stillused a CIEC_STRING for mAdditionalParams. With this clean-up this is finally migrated to std::string.