### PR TITLE
faketime: duration mode was broken due to latest changes

### DIFF
--- a/src/arch/fake_time/faketimerha.h
+++ b/src/arch/fake_time/faketimerha.h
@@ -53,7 +53,7 @@ class CFakeTimerHandler : public CTimerHandler, public CThread {
   private:
     struct napinfo {
       uint_fast64_t napDuration;
-      uint_fast64_t wakupTime;
+      uint_fast64_t wakeupTime;
       CFunctionBlock *fakeSleepFb;
     };
 


### PR DESCRIPTION
if no wakeuptime was given an invalid duration was computed from the 0-value