### PR TITLE
Forte device restart option

### DIFF
--- a/src/arch/threadbase.h
+++ b/src/arch/threadbase.h
@@ -50,8 +50,13 @@ namespace forte {
          */
         void start();
 
-
         /*! \brief Stops the execution of the thread
+         *
+         *  This function immediately stops the execution of the thread (setting alive to false).
+         */
+        void stop();
+
+        /*! \brief Stops the execution of the thread and waits for its end
          *
          *  This function immediately stops the execution of the thread (setting alive to false) and waits till
          *  this is finished.

--- a/src/arch/threadbase.tpp
+++ b/src/arch/threadbase.tpp
@@ -43,13 +43,19 @@ void CThreadBase<TThreadHandle, nullHandle, ThreadDeletePolicy>::start(){
 }
 
 template <typename TThreadHandle, TThreadHandle nullHandle, typename ThreadDeletePolicy>
+void CThreadBase<TThreadHandle, nullHandle, ThreadDeletePolicy>::stop() {
+  if(nullHandle != mThreadHandle){
+    setAlive(false);
+    mThreadHandle = nullHandle;  //indicate that thread is in shutdownmode
+  }
+}
+
+template <typename TThreadHandle, TThreadHandle nullHandle, typename ThreadDeletePolicy>
 void CThreadBase<TThreadHandle, nullHandle, ThreadDeletePolicy>::end() {
   CCriticalRegion criticalRegion(mThreadMutex);
   if(nullHandle != mThreadHandle){
-    setAlive(false);
+    stop();
     join();
-    ThreadDeletePolicy::deleteThread(mThreadHandle);
-    mThreadHandle = nullHandle;
   }
 }
 
@@ -65,10 +71,12 @@ template <typename TThreadHandle, TThreadHandle nullHandle, typename ThreadDelet
 void CThreadBase<TThreadHandle, nullHandle, ThreadDeletePolicy>::runThread(CThreadBase *paThread) {
   // if pointer is ok
   if (nullptr != paThread) {
+    TThreadHandle threadHandle = paThread->mThreadHandle;
     paThread->setAlive(true);
     paThread->run();
     paThread->setAlive(false);
     paThread->mJoinSem.inc();
+    ThreadDeletePolicy::deleteThread(threadHandle);
   } else {
     DEVLOG_ERROR("pThread pointer is 0!");
   }

--- a/src/core/ecet.cpp
+++ b/src/core/ecet.cpp
@@ -98,8 +98,7 @@ void CEventChainExecutionThread::changeExecutionState(EMGMCommandType paCommand)
       clear();
       [[fallthrough]];
     case EMGMCommandType::Stop:
-      setAlive(false); //end thread in both cases
-      end();
+      stop();
       break;
     default:
       break;

--- a/src/core/ecet.cpp
+++ b/src/core/ecet.cpp
@@ -99,6 +99,7 @@ void CEventChainExecutionThread::changeExecutionState(EMGMCommandType paCommand)
       [[fallthrough]];
     case EMGMCommandType::Stop:
       setAlive(false); //end thread in both cases
+      end();
       break;
     default:
       break;

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -164,20 +164,20 @@ EMGMResponse CResource::executeMGMCommand(forte::core::SManagementCMD &paCommand
 
 EMGMResponse CResource::changeFBExecutionState(EMGMCommandType paCommand){
   EMGMResponse retVal = CFunctionBlock::changeFBExecutionState(paCommand);
-  if(EMGMResponse::Ready == retVal){
+  if(retVal == EMGMResponse::Ready){
     retVal = changeContainedFBsExecutionState(paCommand);
-    if(EMGMResponse::Ready == retVal){
-      if(EMGMCommandType::Start == paCommand && nullptr != mInterfaceSpec) { //on start, sample inputs
+    if(retVal == EMGMResponse::Ready){
+      if(paCommand == EMGMCommandType::Start && mInterfaceSpec != nullptr) { //on start, sample inputs
         for(TPortId i = 0; i < mInterfaceSpec->mNumDIs; ++i) {
           CDataConnection *conn = *getDIConUnchecked(i);
-          if(nullptr != conn) {
+          if(conn != nullptr) {
             conn->readData(*getDI(i));
           }
         }
-      }else if(EMGMCommandType::Reset == paCommand){
+      }else if(paCommand == EMGMCommandType::Reset){
         setInitialValues();
       }
-      if(nullptr != mResourceEventExecution){
+      if(mResourceEventExecution != nullptr){
         // if we have a mResourceEventExecution handle it
         mResourceEventExecution->changeExecutionState(paCommand);
       }

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -283,10 +283,6 @@ EMGMResponse CResource::writeValue(forte::core::TNameIdentifier &paNameList, con
 
 void CResource::setInitialValues() {
   CFunctionBlock::setInitialValues();
-  if(mInitialValues.empty()){
-    DEVLOG_ERROR("Error initializing values during reset\r\n");
-  }
-
   for(auto it : mInitialValues){
     it.getIECVariable().fromString(it.getInitString().c_str());
   }

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -270,10 +270,7 @@ EMGMResponse CResource::writeValue(forte::core::TNameIdentifier &paNameList, con
             con->writeData(*var);
           }
         }else{
-          InitValue value;
-          value.ptr = var;
-          value.str = paValue.getStorage().c_str();
-          mInitList.push_back(value);
+          mInitialValues.emplace_back(*var, paValue.getStorage());
         }
         retVal = EMGMResponse::Ready;
       }else{
@@ -282,6 +279,17 @@ EMGMResponse CResource::writeValue(forte::core::TNameIdentifier &paNameList, con
     }
   }
   return retVal;
+}
+
+void CResource::setInitialValues() {
+  CFunctionBlock::setInitialValues();
+  if(mInitialValues.empty()){
+    DEVLOG_ERROR("Error initializing values during reset\r\n");
+  }
+
+  for(auto it : mInitialValues){
+    it.getIECVariable().fromString(it.getInitString().c_str());
+  }
 }
 
 EMGMResponse CResource::readValue(forte::core::TNameIdentifier &paNameList, std::string & paValue){

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -174,6 +174,8 @@ EMGMResponse CResource::changeFBExecutionState(EMGMCommandType paCommand){
             conn->readData(*getDI(i));
           }
         }
+      }else if(EMGMCommandType::Reset == paCommand){
+        setInitialValues();
       }
       if(nullptr != mResourceEventExecution){
         // if we have a mResourceEventExecution handle it
@@ -267,6 +269,11 @@ EMGMResponse CResource::writeValue(forte::core::TNameIdentifier &paNameList, con
             //if we have got a connection it was a DO mirror the forced value there
             con->writeData(*var);
           }
+        }else{
+          InitValue value;
+          value.ptr = var;
+          value.str = paValue.getStorage().c_str();
+          mInitList.push_back(value);
         }
         retVal = EMGMResponse::Ready;
       }else{

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -270,7 +270,7 @@ EMGMResponse CResource::writeValue(forte::core::TNameIdentifier &paNameList, con
             con->writeData(*var);
           }
         }else{
-          mInitialValues.emplace_back(*var, paValue.getStorage());
+          mInitialValues.emplace_back(*var, paValue);
         }
         retVal = EMGMResponse::Ready;
       }else{

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -15,6 +15,8 @@
 #ifndef _RESOURCE_H_
 #define _RESOURCE_H_
 
+#include <utility>
+
 #include "fbcontainer.h"
 #include "funcbloc.h"
 #include "forte_sync.h"
@@ -148,12 +150,26 @@ class CResource : public CFunctionBlock, public forte::core::CFBContainer{
       return nullptr;
     }
 
-    struct InitValue {
-        CIEC_ANY* ptr;
-        std::string str;
+    class CInitialValue {
+      private:
+        CIEC_ANY& mIECVariable;
+        const std::string mInitString;
+
+      public:
+        CInitialValue(CIEC_ANY& paVariable, std::string paInitString) : mIECVariable(paVariable), mInitString(std::move(paInitString)) {}
+
+        [[nodiscard]]
+        const std::string& getInitString() const{
+          return mInitString;
+        }
+
+        CIEC_ANY& getIECVariable() {
+          return mIECVariable;
+        }
+
     };
 
-    std::vector<InitValue> mInitList;
+    std::vector<CInitialValue> mInitialValues;
 
     void setInitialValues() override;
 

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -148,6 +148,15 @@ class CResource : public CFunctionBlock, public forte::core::CFBContainer{
       return nullptr;
     }
 
+    struct InitValue {
+        CIEC_ANY* ptr;
+        std::string str;
+    };
+
+    std::vector<InitValue> mInitList;
+
+    void setInitialValues() override;
+
     /*! Wrapper for simplifying connection creation in resources
      *
      */

--- a/src/stdfblib/events/E_RESTART.cpp
+++ b/src/stdfblib/events/E_RESTART.cpp
@@ -89,9 +89,7 @@ EMGMResponse FORTE_E_RESTART::changeFBExecutionState(EMGMCommandType paCommand){
   if(EMGMResponse::Ready == eRetVal){
     switch(paCommand){
       case EMGMCommandType::Start:
-        if (scmEventWARMID != mEventToSend) {
-          mEventToSend = (scmEventSTOPID == mEventToSend) ? scmEventWARMID : scmEventCOLDID;
-        }
+        mEventToSend = (scmEventSTOPID == mEventToSend) ? scmEventWARMID : scmEventCOLDID;
         getDevice()->getDeviceExecution().startNewEventChain(this);
         break;
       case EMGMCommandType::Stop:
@@ -100,9 +98,6 @@ EMGMResponse FORTE_E_RESTART::changeFBExecutionState(EMGMCommandType paCommand){
         getDevice()->getDeviceExecution().startNewEventChain(this);
         // wait until semaphore is released, after STOP eventExecution was completed
         mSuspendSemaphore.waitIndefinitely();
-        break;
-      case EMGMCommandType::Reset:
-        mEventToSend = scmEventWARMID;
         break;
       default:
         mEventToSend = cgInvalidEventID;

--- a/src/stdfblib/events/E_RESTART.cpp
+++ b/src/stdfblib/events/E_RESTART.cpp
@@ -89,7 +89,9 @@ EMGMResponse FORTE_E_RESTART::changeFBExecutionState(EMGMCommandType paCommand){
   if(EMGMResponse::Ready == eRetVal){
     switch(paCommand){
       case EMGMCommandType::Start:
-        mEventToSend = (scmEventSTOPID == mEventToSend) ? scmEventWARMID : scmEventCOLDID;
+        if (scmEventWARMID != mEventToSend) {
+          mEventToSend = (scmEventSTOPID == mEventToSend) ? scmEventWARMID : scmEventCOLDID;
+        }
         getDevice()->getDeviceExecution().startNewEventChain(this);
         break;
       case EMGMCommandType::Stop:
@@ -98,6 +100,9 @@ EMGMResponse FORTE_E_RESTART::changeFBExecutionState(EMGMCommandType paCommand){
         getDevice()->getDeviceExecution().startNewEventChain(this);
         // wait until semaphore is released, after STOP eventExecution was completed
         mSuspendSemaphore.waitIndefinitely();
+        break;
+      case EMGMCommandType::Reset:
+        mEventToSend = scmEventWARMID;
         break;
       default:
         mEventToSend = cgInvalidEventID;


### PR DESCRIPTION
After forte receives a restart command (kill, reset, start) it will now start running again. The initial values are stored inside the resource during depolyment and are applied with a reset. 