### PR TITLE
Fix signature mismatches from #131 letting Zephyr target compile again

### DIFF
--- a/src/arch/zephyr/forte_Init.h
+++ b/src/arch/zephyr/forte_Init.h
@@ -63,13 +63,13 @@ extern "C" {
    * @param paSignal  Signal value to terminate instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal, TForteInstance* paResultInstance);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteStopInstance(int paSignal, TForteInstance paInstance);
 
   /**
    * \brief Terminates a Forte instance
    * @param paInstance Instance to terminate
    */
-  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance(TForteInstance* paResultInstance);
+  FORTE_SHARED_PREFIX void FORTE_SHARED_CALL forteJoinInstance(TForteInstance paInstance);
 
   /**
    * \brief Initializes the architecture. Prepare all resources needed by the Forte's instances. Must be called once before the first Forte instance is started


### PR DESCRIPTION
[@azoitl Here's the fix you expected to be obsoleted by another PR shortly, but as usual, things are taking a little longer than they should :-)](https://github.com/eclipse-4diac/4diac-forte/pull/180)