### PR TITLE
update writeValue in FakeTimeDev to use std::string...

### DIFF
--- a/src/stdfblib/ita/FakeTimeDev.cpp
+++ b/src/stdfblib/ita/FakeTimeDev.cpp
@@ -92,7 +92,7 @@ CDataConnection **FakeTimeDev::getDIConUnchecked(const TPortId paIndex) {
   return nullptr;
 }
 
-EMGMResponse FakeTimeDev::writeValue(forte::core::TNameIdentifier &paNameList, const CIEC_STRING & paValue, bool paForce) {
+EMGMResponse FakeTimeDev::writeValue(forte::core::TNameIdentifier &paNameList, const std::string & paValue, bool paForce) {
   // parent writeValue is modifying the name list so we need to get the name as backup here
   CStringDictionary::TStringId portName = paNameList.back();
   EMGMResponse eRetVal = CDevice::writeValue(paNameList, paValue, paForce);

--- a/src/stdfblib/ita/FakeTimeDev.h
+++ b/src/stdfblib/ita/FakeTimeDev.h
@@ -36,7 +36,7 @@ class FakeTimeDev : public CDevice{
 
     EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
 
-    EMGMResponse writeValue(forte::core::TNameIdentifier &paNameList, const CIEC_STRING & paValue, bool paForce = false) override;
+    EMGMResponse writeValue(forte::core::TNameIdentifier &paNameList, const std::string & paValue, bool paForce = false) override;
 
   private:
     CInterface2InternalDataConnection mDConnMGR_ID;


### PR DESCRIPTION
... instead of CIEC_STRING

required due to https://github.com/eclipse-4diac/4diac-forte/pull/177