### PR TITLE
Use FBContainer for all Function Blocks

### DIFF
--- a/src/arch/be_m1/fortemodule.cpp
+++ b/src/arch/be_m1/fortemodule.cpp
@@ -247,7 +247,7 @@ SINT32 CFORTEModule::AppEOI(VOID){
  *-------------------------------------------------------------------------*/
 SINT32 CFORTEModule::AppStop(VOID){
   if(0 != mDev){
-    mDev->changeFBExecutionState(EMGMCommandType::Stop);
+    mDev->changeExecutionState(EMGMCommandType::Stop);
   }
 
   return OK;

--- a/src/core/basicfb.cpp
+++ b/src/core/basicfb.cpp
@@ -28,6 +28,15 @@ bool CBasicFB::initialize() {
   if(!CFunctionBlock::initialize()) {
     return false;
   }
+  // initialize all internal FBs
+  for(TFBContainerList::iterator it(getChildren().begin()); it != getChildren().end(); ++it){
+    if((*it)->isFB()) {
+      if(!static_cast<CFunctionBlock &>(**it).initialize()){
+        return false;
+      }
+    }
+  }
+
   if((nullptr != cmVarInternals) && (cmVarInternals->mNumIntVars)) {
     size_t basicVarsDataSize = calculateBasicFBVarsDataSize(*cmVarInternals);
     mBasicFBVarsData = basicVarsDataSize ? operator new(basicVarsDataSize) : nullptr;
@@ -53,6 +62,8 @@ CBasicFB::~CBasicFB() {
   }
   operator delete(mBasicFBVarsData);
   mBasicFBVarsData = nullptr;
+  //CFBContainer shall not handle internal function blocks therefore we are clearing the list here
+  getChildren().clear();
 }
 
 void CBasicFB::setInitialValues() {
@@ -102,24 +113,6 @@ CIEC_ANY* CBasicFB::getInternalVar(CStringDictionary::TStringId paInternalName) 
   }
   return retVal;
 }
-
-TFunctionBlockPtr *CBasicFB::createInternalFBs(const size_t paAmountOfInternalFBs, const SCFB_FBInstanceData *const paInternalFBData, forte::core::CFBContainer &paContainer) {
-  TFunctionBlockPtr *internalFBs = nullptr;
-  if (paAmountOfInternalFBs) {
-    internalFBs = new TFunctionBlockPtr[paAmountOfInternalFBs];
-    for(size_t i = 0; i < paAmountOfInternalFBs; ++i) {
-      internalFBs[i] = CTypeLib::createFB(paInternalFBData[i].mFBInstanceNameId, paInternalFBData[i].mFBTypeNameId, paContainer);
-    }
-  }
-  return internalFBs;
-}
-
-void CBasicFB::deleteInternalFBs(const size_t paAmountOfInternalFBs, TFunctionBlockPtr *const paInternalFBs) {
-  for (size_t i = 0; i < paAmountOfInternalFBs; ++i) {
-    delete paInternalFBs[i];
-  }
-  delete[] paInternalFBs;
-};
 
 int CBasicFB::toString(char *paValue, size_t paBufferSize) const {
   int usedBuffer = CFunctionBlock::toString(paValue, paBufferSize);

--- a/src/core/basicfb.h
+++ b/src/core/basicfb.h
@@ -69,28 +69,8 @@ class CBasicFB : public CFunctionBlock {
       return const_cast<CBasicFB *>(this)->getVarInternal(paVarIntNum);
     }
 
-    virtual size_t getInternalFBNum() const {
-      return 0;
-    }
-
-    virtual const SCFB_FBInstanceData *getInternalFBDefinition(size_t) const {
-      return nullptr;
-    }
-
-    virtual CFunctionBlock *getInternalFB(size_t) {
-      return nullptr;
-    }
-
-    const CFunctionBlock *getInternalFB(size_t paIntFBNum) const {
-      return const_cast<CBasicFB *>(this)->getInternalFB(paIntFBNum);
-    }
-
     CIEC_STATE mECCState; //! the current state of the ecc. start value is 0 = initial state id
     const SInternalVarsInformation *const cmVarInternals; //!< struct holding the information on the internal vars.
-
-    static TFunctionBlockPtr *createInternalFBs(const size_t paAmountOfInternalFBs, const SCFB_FBInstanceData *const pa_InternalFBData, forte::core::CFBContainer &paContainer);
-
-    static void deleteInternalFBs(const size_t paAmountOfInternalFBs, TFunctionBlockPtr *paInternalFBs);
 
     static size_t calculateBasicFBVarsDataSize(const SInternalVarsInformation &paVarInternals);
 

--- a/src/core/cfb.cpp
+++ b/src/core/cfb.cpp
@@ -25,7 +25,6 @@
 CCompositeFB::CCompositeFB(forte::core::CFBContainer &paContainer, const SFBInterfaceSpec *paInterfaceSpec,
                            CStringDictionary::TStringId paInstanceNameId, const SCFB_FBNData & paFBNData) :
         CFunctionBlock(paContainer, paInterfaceSpec, paInstanceNameId),
-        forte::core::CFBContainer(paInstanceNameId, paContainer, paFBNData.mNumFBs),
         mIf2InDConns(nullptr),
         mIn2IfDConns(nullptr),
         cmFBNData(paFBNData),
@@ -117,37 +116,15 @@ bool CCompositeFB::configureGenericDO(TPortId paDOPortId, const CIEC_ANY &paRefV
   return bRetVal;
 }
 
-EMGMResponse CCompositeFB::changeFBExecutionState(EMGMCommandType paCommand){
-  EMGMResponse nRetVal = CFunctionBlock::changeFBExecutionState(paCommand);
-  if (EMGMResponse::Ready == nRetVal) {
-    nRetVal = CFBContainer::changeContainedFBsExecutionState(paCommand);
-  }
+EMGMResponse CCompositeFB::changeExecutionState(EMGMCommandType paCommand){
+  EMGMResponse nRetVal = CFunctionBlock::changeExecutionState(paCommand);
+
   //Update FB parameters that maybe got overwritten by default values of the FB
   if((EMGMCommandType::Reset == paCommand) && (E_FBStates::Idle == getState())){
     setParams();
   }
   return nRetVal;
 }
-
-#ifdef FORTE_SUPPORT_MONITORING
-
-CFunctionBlock *CCompositeFB::getFB(forte::core::TNameIdentifier::CIterator &paNameListIt){
-  CFunctionBlock *retVal = forte::core::CFBContainer::getFB(*paNameListIt);
-
-  if(retVal != nullptr){
-      if(!paNameListIt.isLastEntry()){
-         //we are looking for a child of this fB
-        ++paNameListIt;
-        retVal = retVal->getFB(paNameListIt);
-      }
-  } else {
-    //check if it is an adapter of the function block
-    retVal = CFunctionBlock::getFB(paNameListIt);
-  }
-  return retVal;
-}
-
-#endif
 
 CIEC_ANY *CCompositeFB::getVar(CStringDictionary::TStringId *paNameList, unsigned int paNameListSize){
   CIEC_ANY *retVal = nullptr;

--- a/src/core/cfb.h
+++ b/src/core/cfb.h
@@ -80,7 +80,7 @@ GENERATE_CONNECTION_PORT_ID_2_ARG(CStringDictionary::scmInvalidStringId, PortNam
 /*!\ingroup CORE
  * \brief Class for handling firmware composite function blocks.
  */
-class CCompositeFB: public CFunctionBlock, public forte::core::CFBContainer {
+class CCompositeFB: public CFunctionBlock {
 
   public:
     /*! \brief Indicator that the given FB id is an adapter.
@@ -124,11 +124,7 @@ class CCompositeFB: public CFunctionBlock, public forte::core::CFBContainer {
     CIEC_ANY* getVar(CStringDictionary::TStringId *paNameList,
         unsigned int paNameListSize) override;
 
-    EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
-
-#ifdef FORTE_SUPPORT_MONITORING
-    CFunctionBlock *getFB(forte::core::TNameIdentifier::CIterator &paNameListIt) override;
-#endif
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
   protected:
     CDataConnection *getIn2IfConUnchecked(TPortId paIndex) {

--- a/src/core/cominfra/basecommfb.cpp
+++ b/src/core/cominfra/basecommfb.cpp
@@ -50,8 +50,8 @@ CBaseCommFB::~CBaseCommFB() {
   }
 }
 
-EMGMResponse CBaseCommFB::changeFBExecutionState(EMGMCommandType paCommand) {
-  EMGMResponse retVal = CEventSourceFB::changeFBExecutionState(paCommand);
+EMGMResponse CBaseCommFB::changeExecutionState(EMGMCommandType paCommand) {
+  EMGMResponse retVal = CEventSourceFB::changeExecutionState(paCommand);
   if ((EMGMResponse::Ready == retVal) && (EMGMCommandType::Kill == paCommand)) {
     //when we are killed we'll close the connection so that it can safely be opened again after an reset
     closeConnection();

--- a/src/core/cominfra/basecommfb.h
+++ b/src/core/cominfra/basecommfb.h
@@ -34,7 +34,7 @@ namespace forte {
     public:
       ~CBaseCommFB() override;
 
-      EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+      EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
       forte::com_infra::EComServiceType getComServiceType() const {
         return mCommServiceType;

--- a/src/core/cominfra/commfb.cpp
+++ b/src/core/cominfra/commfb.cpp
@@ -43,8 +43,8 @@ CCommFB::CCommFB(const CStringDictionary::TStringId paInstanceNameId, forte::cor
 
 CCommFB::~CCommFB() = default;
 
-EMGMResponse CCommFB::changeFBExecutionState(EMGMCommandType paCommand) {
-  EMGMResponse retVal = CEventSourceFB::changeFBExecutionState(paCommand);
+EMGMResponse CCommFB::changeExecutionState(EMGMCommandType paCommand) {
+  EMGMResponse retVal = CEventSourceFB::changeExecutionState(paCommand);
   if ((EMGMResponse::Ready == retVal) && (EMGMCommandType::Kill == paCommand)) {
     //when we are killed we'll close the connection so that it can safely be opened again after an reset
     closeConnection();

--- a/src/core/cominfra/commfb.h
+++ b/src/core/cominfra/commfb.h
@@ -30,7 +30,7 @@ namespace forte {
     public:
       ~CCommFB() override;
 
-      EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+      EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
     protected:
       CCommFB(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer, forte::com_infra::EComServiceType paCommServiceType);

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -24,7 +24,7 @@ EMGMResponse CDevice::executeMGMCommand(forte::core::SManagementCMD &paCommand){
     retval = CResource::executeMGMCommand(paCommand);
   }
   else{
-    CResource *res = static_cast<CResource *>(CFBContainer::getFB(paCommand.mDestination));
+    CResource *res = static_cast<CResource *>(CFBContainer::getChild(paCommand.mDestination));
     if(nullptr != res){
       paCommand.mDestination = CStringDictionary::scmInvalidStringId;
       retval = res->executeMGMCommand(paCommand);
@@ -33,9 +33,9 @@ EMGMResponse CDevice::executeMGMCommand(forte::core::SManagementCMD &paCommand){
   return retval;
 }
 
-EMGMResponse CDevice::changeFBExecutionState(EMGMCommandType paCommand){
+EMGMResponse CDevice::changeExecutionState(EMGMCommandType paCommand){
   if(EMGMCommandType::Kill == paCommand){
     mDeviceExecution.disableHandlers();
   }
-  return CResource::changeFBExecutionState(paCommand);
+  return CResource::changeExecutionState(paCommand);
 }

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -42,7 +42,7 @@ class CDevice : public CResource {
      *  \return 0 on success -1 on error
      */
     virtual int startDevice() {
-      changeFBExecutionState(EMGMCommandType::Start);
+      changeExecutionState(EMGMCommandType::Start);
       return 1;
     }
 
@@ -65,7 +65,7 @@ class CDevice : public CResource {
      */
     EMGMResponse executeMGMCommand(forte::core::SManagementCMD &paCommand) override;
 
-    EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
     //! Retrieve the device execution of this device
     CDeviceExecution &getDeviceExecution() {

--- a/src/core/fbcontainer.cpp
+++ b/src/core/fbcontainer.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015 - 2016 fortiss GmbH, 2018 TU Wien/ACIN
- *                      2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2015, 2024 fortiss GmbH, 2018 TU Wien/ACIN,
+ *                          Primetals Technologies Austria GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,13 +8,11 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    Alois Zoitl
- *      - initial implementation and rework communication infrastructure
- *    Martin Jobst - adapt for LUA integration
- *    Martin Melik Merkumians
- *      - implementation for checkForActionEquivalentState
- *    Fabio Gandolfi
- *      - refactored fb and container list to sorted vectors
+ *   Alois Zoitl  - initial implementation and rework communication infrastructure
+ *   Martin Jobst - adapt for LUA integration
+ *   Martin Melik Merkumians - implementation for checkForActionEquivalentState
+ *   Fabio Gandolfi - refactored fb and container list to sorted vectors
+ *   Alois Zoitl  - merged fbs and containers in one list
  *******************************************************************************/
 #include "funcbloc.h"
 #include "fbcontainer.h"
@@ -36,34 +34,24 @@ EMGMResponse checkForActionEquivalentState(const CFunctionBlock &paFB, const EMG
   return EMGMResponse::InvalidState;
 }
 
-CFBContainer::CFBContainer(CStringDictionary::TStringId paContainerName, CFBContainer &paParent) :
-    mContainerName(paContainerName), mParent(paParent) {
-}
-
-CFBContainer::CFBContainer(CStringDictionary::TStringId paContainerName, CFBContainer &paParent, size_t paNumFBs) :
-    mContainerName(paContainerName), mParent(paParent) {
-  mFunctionBlocks.reserve(paNumFBs);
+CFBContainer::CFBContainer(CStringDictionary::TStringId paContInstanceName, CFBContainer &paParent) :
+    mContInstanceName(paContInstanceName), mParent(paParent) {
 }
 
 CFBContainer::~CFBContainer() {
-  for (TFunctionBlockList::iterator itRunner(mFunctionBlocks.begin()); itRunner != mFunctionBlocks.end(); ++itRunner) {
-    CTypeLib::deleteFB(*itRunner);
-  }
-  mFunctionBlocks.clear();
-
-  for (TFBContainerList::iterator itRunner(mSubContainers.begin()); itRunner != mSubContainers.end(); ++itRunner) {
+  for (TFBContainerList::iterator itRunner(mChildren.begin()); itRunner != mChildren.end(); ++itRunner) {
     delete (*itRunner);
   }
-  mSubContainers.clear();
+  mChildren.clear();
 }
 
-EMGMResponse CFBContainer::addFB(CFunctionBlock* paFuncBlock){
-  EMGMResponse eRetVal = EMGMResponse::InvalidObject;
+EMGMResponse CFBContainer::addFB(CFunctionBlock* paFuncBlock) {
+  EMGMResponse retVal = EMGMResponse::InvalidObject;
   if(nullptr != paFuncBlock){
-    mFunctionBlocks.insert(getFBIterator(paFuncBlock->getInstanceNameId()), paFuncBlock);
-    eRetVal = EMGMResponse::Ready;
+    mChildren.insert(getChildrenIterator(paFuncBlock->getInstanceNameId()), paFuncBlock);
+    retVal = EMGMResponse::Ready;
   }
-  return eRetVal;
+  return retVal;
 }
 
 std::string CFBContainer::getFullQualifiedApplicationInstanceName(const char sepChar) const {
@@ -71,32 +59,33 @@ std::string CFBContainer::getFullQualifiedApplicationInstanceName(const char sep
   if(!result.empty()){
     result += sepChar;
   }
-  result += getName();
+  result += getInstanceName();
   return result;
 }
 
 EMGMResponse CFBContainer::createFB(forte::core::TNameIdentifier::CIterator &paNameListIt, CStringDictionary::TStringId paTypeName){
   if(paNameListIt.isLastEntry()){
     return createFB(*paNameListIt, paTypeName);
-  } else{
+  } else if(!isFB()) {
     //we have more than one name in the fb name list. Find or create the container and hand the create command to this container.
     CFBContainer *childCont = findOrCreateContainer(*paNameListIt);
-    if(nullptr != childCont){
+    if(childCont != nullptr && !childCont->isFB()){
       //remove the container from the name list
       ++paNameListIt;
       return childCont->createFB(paNameListIt, paTypeName);
     }
   }
-  return EMGMResponse::InvalidState;
+  return EMGMResponse::InvalidDst;
 }
 
 EMGMResponse CFBContainer::createFB(CStringDictionary::TStringId paInstanceNameId, CStringDictionary::TStringId paTypeName) {
+  TFBContainerList::iterator childIt = getChildrenIterator(paInstanceNameId);
   // test if the container does not contain any FB or a container with the same name
-  if((nullptr == getFB(paInstanceNameId)) && (nullptr == getFBContainer(paInstanceNameId))) {
+  if(!isChild(childIt, paInstanceNameId)) {
     CFunctionBlock *newFB = CTypeLib::createFB(paInstanceNameId, paTypeName, *this);
-    if(nullptr != newFB) {
+    if(newFB != nullptr) {
       //we could create a FB now add it to the list of contained FBs
-      addFB(newFB);
+      mChildren.insert(childIt, newFB);
       return EMGMResponse::Ready;
     }
     return CTypeLib::getLastError();
@@ -107,23 +96,22 @@ EMGMResponse CFBContainer::createFB(CStringDictionary::TStringId paInstanceNameI
 EMGMResponse CFBContainer::deleteFB(forte::core::TNameIdentifier::CIterator &paNameListIt){
   EMGMResponse retval = EMGMResponse::NoSuchObject;
 
-  if(!paNameListIt.isLastEntry()){
-    //we have more than one name in the fb name list. Find or create the container and hand the create command to this container.
-    CFBContainer *childCont = findOrCreateContainer(*paNameListIt);
-    if(nullptr != childCont){
-      //remove the container from the name list
-      ++paNameListIt;
-      retval = childCont->deleteFB(paNameListIt);
-    }
-  }
-  else{
-    CStringDictionary::TStringId fBNameId = *paNameListIt;
-
-    if((CStringDictionary::scmInvalidStringId != fBNameId) && (!mFunctionBlocks.empty())) {
-      TFunctionBlockList::iterator it = getFBIterator(fBNameId);
-      if(fBIteratorIsValid(it,fBNameId) && (*it)->isCurrentlyDeleteable()){
-        CTypeLib::deleteFB(*it);
-        mFunctionBlocks.erase(it);
+  CStringDictionary::TStringId childName = *paNameListIt;
+  TFBContainerList::iterator childIt = getChildrenIterator(childName);
+  if(isChild(childIt, childName)){
+    CFBContainer *child = *childIt;
+    if(!paNameListIt.isLastEntry()){
+      //we have more than one name in the fb name list. Hand the process on to the child if it is not an FB
+      if(!child->isFB()){
+        //remove the container from the name list
+        ++paNameListIt;
+        retval = child->deleteFB(paNameListIt);
+      }
+    } else if(child->isFB()){
+      CFunctionBlock *fb = static_cast<CFunctionBlock *>(child);
+      if(fb->isCurrentlyDeleteable()){
+        CTypeLib::deleteFB(fb);
+        mChildren.erase(childIt);
         retval = EMGMResponse::Ready;
       } else {
         retval = EMGMResponse::InvalidState;
@@ -135,95 +123,70 @@ EMGMResponse CFBContainer::deleteFB(forte::core::TNameIdentifier::CIterator &paN
 
 CFunctionBlock *CFBContainer::getFB(CStringDictionary::TStringId paFBName) {
   if(CStringDictionary::scmInvalidStringId != paFBName){
-    TFunctionBlockList::iterator retIter = getFBIterator(paFBName);
-    if(fBIteratorIsValid(retIter,paFBName))
-      return *retIter;
+    CFBContainer *child = getChild(paFBName);
+    if(child != nullptr && child->isFB()){
+      return static_cast<CFunctionBlock *>(child);
+    }
   }
   return nullptr;
 }
 
-CFBContainer::TFunctionBlockList::iterator CFBContainer::getFBIterator(CStringDictionary::TStringId paFBName){
-  if(CStringDictionary::scmInvalidStringId != paFBName) {
-    return lower_bound(mFunctionBlocks.begin(), mFunctionBlocks.end(), paFBName,
-                              [](CFunctionBlock *fb,
-                                 CStringDictionary::TStringId fbName) {
-                                return fb->getInstanceNameId() < fbName;
-                              });
-  }
-  return mFunctionBlocks.end();;
-}
 
-CFunctionBlock* CFBContainer::getContainedFB(forte::core::TNameIdentifier::CIterator &paNameListIt)  {
+CFunctionBlock* CFBContainer::getFB(forte::core::TNameIdentifier::CIterator &paNameListIt)  {
   if(!paNameListIt.isLastEntry()){
     //we have more than one name in the fb name list. Find or create the container and hand the create command to this container.
-    CFBContainer *childCont = getFBContainer(*paNameListIt);
-    if(nullptr != childCont){
+    CFBContainer *childCont = getChild(*paNameListIt);
+    if(childCont != nullptr){
       //remove the container from the name list
       ++paNameListIt;
-      return childCont->getContainedFB(paNameListIt);
+      return childCont->getFB(paNameListIt);
     }
   }
-
   return getFB(*paNameListIt);
 }
 
-CFBContainer* CFBContainer::getFBContainer(CStringDictionary::TStringId paContainerName)  {
-  TFBContainerList::iterator it = getFBContainerIterator(paContainerName);
-  if(it != mSubContainers.end() && (*it)->getNameId() == paContainerName){
-    return *it;
-  }
-  return nullptr;
+CFBContainer* CFBContainer::getChild(CStringDictionary::TStringId paName)  {
+  TFBContainerList::iterator it = getChildrenIterator(paName);
+  return isChild(it, paName) ? *it : nullptr;
 }
 
-CFBContainer::TFBContainerList::iterator CFBContainer::getFBContainerIterator(CStringDictionary::TStringId paContainerName)  {
-  if(CStringDictionary::scmInvalidStringId != paContainerName && !mSubContainers.empty()){
-    return std::lower_bound(mSubContainers.begin(), mSubContainers.end(), paContainerName,
+CFBContainer::TFBContainerList::iterator CFBContainer::getChildrenIterator(CStringDictionary::TStringId paName)  {
+  if(paName != CStringDictionary::scmInvalidStringId && !mChildren.empty()){
+    return std::lower_bound(mChildren.begin(), mChildren.end(), paName,
                                                      [](CFBContainer* container, CStringDictionary::TStringId containerName)
-                                                     { return container->getNameId() < containerName; });
+                                                     { return container->getInstanceNameId() < containerName; });
   }
-  return mSubContainers.end();
+  return mChildren.end();
 }
 
 CFBContainer *CFBContainer::findOrCreateContainer(CStringDictionary::TStringId paContainerName) {
   CFBContainer *retVal;
-  if (mSubContainers.empty()) {
+  if (mChildren.empty()) {
     retVal = new CFBContainer(paContainerName, *this);
-    mSubContainers.insert(mSubContainers.begin(), retVal);
+    mChildren.insert(mChildren.begin(), retVal);
   } else {
-    TFBContainerList::iterator it = getFBContainerIterator(paContainerName);
-    if (nullptr == getFB(paContainerName) && (it == mSubContainers.end() || (*it)->getNameId() != paContainerName)) {
+    TFBContainerList::iterator childIt = getChildrenIterator(paContainerName);
+    if (isChild(childIt, paContainerName)) {
+      retVal = *childIt;
+    } else {
       //the container with the given name does not exist but only create it if there is no FB with the same name.
       retVal = new CFBContainer(paContainerName, *this);
-      mSubContainers.insert(it, retVal);
-    } else {
-      retVal = (*it);
+      mChildren.insert(childIt, retVal);
     }
   }
   return retVal;
 }
 
-EMGMResponse CFBContainer::changeContainedFBsExecutionState(EMGMCommandType paCommand){
+EMGMResponse CFBContainer::changeExecutionState(EMGMCommandType paCommand){
   EMGMResponse retVal = EMGMResponse::Ready;
 
-  for(TFBContainerList::iterator it(mSubContainers.begin());
-      ((it != mSubContainers.end()) && (EMGMResponse::Ready == retVal));
+  for(TFBContainerList::iterator it(mChildren.begin());
+      ((it != mChildren.end()) && (EMGMResponse::Ready == retVal));
       ++it){
-    retVal = (*it)->changeContainedFBsExecutionState(paCommand);
-  }
-
-  if(EMGMResponse::Ready == retVal){
-    for(TFunctionBlockList::iterator itRunner = mFunctionBlocks.begin();
-        ((itRunner != mFunctionBlocks.end()) && (EMGMResponse::Ready == retVal));
-        ++itRunner){
-      retVal = (*itRunner)->changeFBExecutionState(paCommand);
-      if(EMGMResponse::Ready != retVal) {
-        retVal = checkForActionEquivalentState(*(*itRunner), paCommand);
-      }
+    retVal = (*it)->changeExecutionState(paCommand);
+    if((EMGMResponse::Ready != retVal) && (*it)->isFB()) {
+      retVal = checkForActionEquivalentState(static_cast<CFunctionBlock &>(**it), paCommand);
     }
   }
   return retVal;
-}
-
-bool CFBContainer::fBIteratorIsValid(CFBContainer::TFunctionBlockList::iterator iterator,CStringDictionary::TStringId paFBName){
-  return (iterator != mFunctionBlocks.end() && paFBName == ((*(*iterator)).getInstanceNameId()));
 }

--- a/src/core/fbcontainer.h
+++ b/src/core/fbcontainer.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 fortiss GmbH
+ * Copyright (c) 2015, 2024 fortiss GmbH, Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    Alois Zoitl
- *      - initial implementation and rework communication infrastructure
+ *   Alois Zoitl - initial implementation and rework communication infrastructure
+ *               - merged fbs and containers in one list
  *******************************************************************************/
 #ifndef _FBCONTAINER_H_
 #define _FBCONTAINER_H_
@@ -28,41 +28,35 @@ namespace forte {
 
     class CFBContainer{
       public:
-        CFBContainer(CStringDictionary::TStringId paContainerName, CFBContainer &paParent);
+        CFBContainer(CStringDictionary::TStringId paContInstanceName, CFBContainer &paParent);
         virtual ~CFBContainer();
 
-        CStringDictionary::TStringId getNameId() const{
-          return mContainerName;
+        CStringDictionary::TStringId getInstanceNameId() const{
+          return mContInstanceName;
         }
 
-        const char* getName() const {
-          return CStringDictionary::getInstance().get(mContainerName);
+        const char* getInstanceName() const {
+          return CStringDictionary::getInstance().get(mContInstanceName);
         }
 
-        /*!\brief Gets a function block from the container or recursively from its subcontainers
-         *
-         * @param paNameList itartor to the name hierarchy the requested function block, if retval is not 0 it will point to the the item which found the FB
-         * @return pointer to the requested function block, returns 0 if function block is not in the list
-         */
-        CFunctionBlock* getContainedFB(forte::core::TNameIdentifier::CIterator &paNameListIt);
-
-        /*!\brief Adds a created function block to the FB-List
+        /*!\brief Adds a function block created via the typelib to the FB-List
          *
          * @param paFuncBlock new function block to add to the FB-List
          * @return response of the command execution as defined in IEC 61499
          */
         EMGMResponse addFB(CFunctionBlock *paFuncBlock);
 
-        typedef std::vector<CFunctionBlock *> TFunctionBlockList;
-
-        TFunctionBlockList &getFBList(){
-          return mFunctionBlocks;
-        }
+        /*!\brief Gets a function block from the container or recursively from its subcontainers
+         *
+         * @param paNameList iterator to the name hierarchy the requested function block, if retval is not 0 it will point to the the item which found the FB
+         * @return pointer to the requested function block, returns 0 if function block is not in the list
+         */
+        virtual CFunctionBlock *getFB(forte::core::TNameIdentifier::CIterator &paNameListIt);
 
         typedef std::vector<CFBContainer *> TFBContainerList;
 
-        TFBContainerList &getSubContainerList(){
-          return mSubContainers;
+        TFBContainerList &getChildren(){
+          return mChildren;
         }
 
         CFBContainer& getParent() const { return mParent;}
@@ -70,6 +64,7 @@ namespace forte {
         virtual CResource* getResource(){
           return mParent.getResource();
         }
+
         virtual const CResource* getResource() const {
           return const_cast<CFBContainer*>(this)->getResource();
         }
@@ -77,15 +72,27 @@ namespace forte {
         virtual CDevice* getDevice(){
           return mParent.getDevice();
         }
+
         virtual const CDevice* getDevice() const {
           return const_cast<CFBContainer*>(this)->getDevice();
         }
 
+        /*! \brief Get the full hierarchical name of this FB in its application
+         *
+         * Generates a dot separated name list of this FB excluding device and resource
+         *
+         * \return full hierarchical name
+         */
         virtual std::string getFullQualifiedApplicationInstanceName(const char sepChar) const;
 
-      protected:
-        CFBContainer(CStringDictionary::TStringId paContainerName, CFBContainer &paParent, size_t paNumFBs);
+        //! Change the execution state of all contained FBs and also recursively in all contained containers
+        virtual EMGMResponse changeExecutionState(EMGMCommandType paCommand);
 
+        virtual bool isFB() {
+          return false;
+        }
+
+      protected:
         /*!\brief Create a new FB instance of given type and name
          *
          * @param paNameListIt    iterator to the current position in the name list for the FB to be created (e.g., SubApp1.SubApp2.FBName, FBName2)
@@ -113,16 +120,20 @@ namespace forte {
          *
          */
         CFunctionBlock *getFB(CStringDictionary::TStringId paFBName);
-        TFunctionBlockList::iterator getFBIterator(CStringDictionary::TStringId paFBName);
-        bool fBIteratorIsValid(TFunctionBlockList::iterator iterator, CStringDictionary::TStringId paFBName);
 
-        CFBContainer *getFBContainer(CStringDictionary::TStringId paContainerName);
-        TFBContainerList::iterator getFBContainerIterator(CStringDictionary::TStringId paContainerName);
+        CFBContainer *getChild(CStringDictionary::TStringId paName);
 
-        //! Change the execution state of all contained FBs and also recursively in all contained containers
-        EMGMResponse changeContainedFBsExecutionState(EMGMCommandType paCommand);
+        TFBContainerList::iterator getChildrenIterator(CStringDictionary::TStringId paName);
 
       private:
+
+        /*!\brief Check if the given iterator points to a valid child with the provide name
+         *
+         */
+        bool isChild(TFBContainerList::iterator childIt, CStringDictionary::TStringId paName) {
+          return (childIt != mChildren.end() && (*childIt)->getInstanceNameId() == paName);
+        }
+
         /*!\brief Retrieve a FBContainer with given name. If it does not exist create it.
          *
          * @param paContainerName name of the container
@@ -130,11 +141,10 @@ namespace forte {
          */
         CFBContainer *findOrCreateContainer(CStringDictionary::TStringId paContainerName);
 
-        CStringDictionary::TStringId mContainerName; //!< name of the container
+        const CStringDictionary::TStringId mContInstanceName; //!< Instance name of the container
         CFBContainer &mParent; //!< the parent FBContainer this FBContainer is contained in. The parent of a device is the device itself!
 
-        TFunctionBlockList mFunctionBlocks; //!< The functionblocks hold in this container
-        TFBContainerList mSubContainers; //!< List of subcontainers (i.e, subapplications in this container)
+        TFBContainerList mChildren; //!< List of children (i.e, fbs or subapplications in this container)
     };
 
   } /* namespace core */

--- a/src/core/fmi/fmuInstance.cpp
+++ b/src/core/fmi/fmuInstance.cpp
@@ -92,8 +92,8 @@ bool fmuInstance::loadFBs(){
 
   CFunctionBlock* devMgr = CTypeLib::createFB(g_nStringIdMGR, g_nStringIdDEV_MGR, mResource);
   devMgr->getDataInput(g_nStringIdQI)->fromString("1");
-  devMgr->changeFBExecutionState(EMGMCommandType::Reset);
-  devMgr->changeFBExecutionState(EMGMCommandType::Start);
+  devMgr->changeExecutionState(EMGMCommandType::Reset);
+  devMgr->changeExecutionState(EMGMCommandType::Start);
   FMU_DEBUG_LOG(this, MODEL_GUID << " About to load FBs from file " << getBootFileLocation().getValue() << "\n--------------\n");
   CIEC_STRING val = "FORTE_BOOT_FILE=";
   val.append(mBootFileLocation.getValue());
@@ -285,11 +285,11 @@ void fmuInstance::fillInterfaceElementsArray(CFunctionBlock* paFB, bool isInput,
 
 void fmuInstance::startInstance(){
   resetInstance();
-  changeFBExecutionState(EMGMCommandType::Start);
+  changeExecutionState(EMGMCommandType::Start);
 }
 
 void fmuInstance::resetInstance(){
-  changeFBExecutionState(EMGMCommandType::Reset);
+  changeExecutionState(EMGMCommandType::Reset);
 }
 
 
@@ -299,5 +299,5 @@ void fmuInstance::stopInstance(){
   for(unsigned int i = 0; i < mNumberOfEcets; i++){
     mEcetSemaphore.inc();
   }
-  changeFBExecutionState(EMGMCommandType::Stop);
+  changeExecutionState(EMGMCommandType::Stop);
 }

--- a/src/core/forteinstance.cpp
+++ b/src/core/forteinstance.cpp
@@ -37,7 +37,7 @@ bool C4diacFORTEInstance::startupNewDevice(const std::string &paMGRID){
 
 void C4diacFORTEInstance::triggerDeviceShutdown() {
   if(mActiveDevice) {
-    mActiveDevice->changeFBExecutionState(EMGMCommandType::Kill);
+    mActiveDevice->changeExecutionState(EMGMCommandType::Kill);
   }
 }
 

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2023 ACIN, Profactor GmbH, nxtControl GmbH, fortiss GmbH,
+ * Copyright (c) 2005, 2024 ACIN, Profactor GmbH, nxtControl GmbH, fortiss GmbH,
  *                          Johannes Kepler University, Martin Erich Jobst,
  *                          Primetals Technologies Austria GmbH
  *
@@ -21,6 +21,7 @@
 #define _FUNCBLOC_H_
 
 #include <forte_config.h>
+#include "fbcontainer.h"
 #include "mgmcmd.h"
 #include "event.h"
 #include "dataconn.h"
@@ -103,7 +104,7 @@ struct SFBInterfaceSpec {
 
 /*!\ingroup CORE\brief Base class for all function blocks.
  */
-class CFunctionBlock {
+class CFunctionBlock : public forte::core::CFBContainer {
   public:
     constexpr static TDataIOID scmWithListDelimiter = cgInvalidPortId; //!< value identifying the end of a with list
     constexpr static TForteInt16 scmNoDataAssociated = static_cast<TForteInt16>(cgInvalidPortId); //!< value identifying the end of a with list
@@ -129,22 +130,6 @@ class CFunctionBlock {
     virtual bool initialize();
 
     virtual ~CFunctionBlock();
-
-    /*!\brief Get the resource the function block is contained in.
-     */
-    virtual CResource* getResource();
-    virtual const CResource* getResource() const {
-      return const_cast<CFunctionBlock *>(this)->getResource();
-    }
-
-    virtual CDevice* getDevice();
-    virtual const CDevice* getDevice() const {
-      return const_cast<CFunctionBlock *>(this)->getDevice();
-    }
-
-    forte::core::CFBContainer& getContainer() const {
-      return mContainer;
-    }
 
     /*!\brief Get the timer of the device where the FB is contained.
      */
@@ -324,30 +309,7 @@ class CFunctionBlock {
       return mInterfaceSpec;
     }
 
-    virtual EMGMResponse changeFBExecutionState(EMGMCommandType paCommand);
-
-    /*!\brief Get/set the instance name
-     */
-    CStringDictionary::TStringId getInstanceNameId() const {
-      return mFBInstanceName;
-    }
-    ;
-
-    /*! \brief Get the full hierarchical name of this FB in its application
-     *
-     * Generates a dot separated name list of this FB excluding device and resource
-     *
-     * \return full hierarchical name
-     */
-    std::string getFullQualifiedApplicationInstanceName(const char sepChar) const;
-
-    const char* getInstanceName() const {
-      return CStringDictionary::getInstance().get(mFBInstanceName);
-    }
-
-    void setInstanceNameId(const CStringDictionary::TStringId paInstanceNameId) {
-      mFBInstanceName = paInstanceNameId;
-    }
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
     /*!\brief Get information if the runable object is deletable by a management command.
      *
@@ -355,14 +317,14 @@ class CFunctionBlock {
     bool getDeletable() const {
       return mDeletable;
     }
-    ;
+
     /*!\brief Set attribute to enable/disable the runable object deletion by a management command.
      *
      */
     void setDeletable(const bool &paDelAble) {
       mDeletable = paDelAble;
     }
-    ;
+
     /*!\brief Return if the runable object is allowed to be deleted now.
      *
      * This is more complex then the simple deleteable flag as the current state has to be incorporated.
@@ -418,17 +380,16 @@ class CFunctionBlock {
       return const_cast<CFunctionBlock *>(this)->getDIO(paDIONum);
     }
 
-#ifdef FORTE_SUPPORT_MONITORING
-    TForteUInt32 &getEIMonitorData(TEventID paEIID);
-
-    TForteUInt32 &getEOMonitorData(TEventID paEOID);
-
     /*!\brief get any internal FB referenced by the iterator to the name list
      *
      * This allows that also adapters and the internals of a CFB can be monitored.
      */
-    virtual CFunctionBlock *getFB(forte::core::TNameIdentifier::CIterator &paNameListIt);
+    CFunctionBlock *getFB(forte::core::TNameIdentifier::CIterator &paNameListIt) override;
 
+#ifdef FORTE_SUPPORT_MONITORING
+    TForteUInt32 &getEIMonitorData(TEventID paEIID);
+
+    TForteUInt32 &getEOMonitorData(TEventID paEOID);
 #endif //FORTE_SUPPORT_MONITORING
     
     virtual int toString(char* paValue, size_t paBufferSize) const;
@@ -587,15 +548,6 @@ class CFunctionBlock {
       return nullptr;
     }
 
-    /*!\brief helper function for changeing the FB execution state for FBs with internal FBs
-     *
-     * @param paCommand the reqeusted state change (i.e., start, stop, kill, reset)
-     * @param paAmountOfInternalFBs number of internal FBs contained in this FB
-     * @param paInternalFBs  array with the internal FBs of this FB
-     * @return success status of the requested state change
-     */
-    EMGMResponse changeFBExecutionStateHelper(const EMGMCommandType paCommand, const size_t paAmountOfInternalFBs, TFunctionBlockPtr *const paInternalFBs);
-
     /*!\brief Get the size of a data point
      *
      * @param paDataTypeIds pointer to the data type ids. If the datatype
@@ -636,8 +588,6 @@ class CFunctionBlock {
 
     static void destroyAdapter(CAdapter *adapter);
 
-    static EMGMResponse changeInternalFBExecutionState(const EMGMCommandType paCommand, const size_t paAmountOfInternalFBs, TFunctionBlockPtr *const paInternalFBs);
-
     const SFBInterfaceSpec *mInterfaceSpec; //!< Pointer to the interface specification
 
 #ifdef FORTE_SUPPORT_MONITORING
@@ -645,6 +595,9 @@ class CFunctionBlock {
     void freeEventMonitoringData();
 #endif
   private:
+    bool isFB() override {
+       return true;
+    }
 
     /*!\brief Function providing the functionality of the FB (e.g. execute ECC for basic FBs).
      *
@@ -679,8 +632,6 @@ class CFunctionBlock {
     void configureGenericDI(TPortId paDIPortId, const CIEC_ANY *paRefValue);
     void configureGenericDIO(TPortId paDIOPortId, const CIEC_ANY *paRefValue);
 
-    forte::core::CFBContainer &mContainer; //!< The container of this function block.
-
 #ifdef FORTE_SUPPORT_MONITORING
     TForteUInt32 *mEOMonitorCount;
     TForteUInt32 *mEIMonitorCount;
@@ -690,8 +641,6 @@ class CFunctionBlock {
     void traceInputEvent(TEventID paEIID);
     void traceOutputEvent(TEventID paEOID);
 #endif
-    //! the instance name of the object
-    CStringDictionary::TStringId mFBInstanceName;
 
     /*!\brief Current state of the runnable object.
      *

--- a/src/core/monitoring.cpp
+++ b/src/core/monitoring.cpp
@@ -66,13 +66,7 @@ EMGMResponse CMonitoringHandler::executeMonitoringCommand(SManagementCMD &paComm
 
 CFunctionBlock* CMonitoringHandler::getFB(forte::core::TNameIdentifier &paNameList){
   forte::core::TNameIdentifier::CIterator runner(paNameList.begin());
-
-  CFunctionBlock *fb = mResource.getContainedFB(runner);
-  if((nullptr != fb) && (!runner.isLastEntry())){
-    ++runner;
-    fb = fb->getFB(runner);
-  }
-  return fb;
+  return mResource.getFB(runner);
 }
 
 EMGMResponse CMonitoringHandler::addWatch(forte::core::TNameIdentifier &paNameList){
@@ -150,8 +144,8 @@ EMGMResponse CMonitoringHandler::readWatches(std::string &paResponse){
   paResponse.clear();
   if(&mResource == &mResource.getParent()){
     //we are in the device
-    for(CFBContainer::TFunctionBlockList::iterator itRunner = mResource.getFBList().begin();
-        itRunner != mResource.getFBList().end();
+    for(CFBContainer::TFBContainerList::iterator itRunner = mResource.getChildren().begin();
+        itRunner != mResource.getChildren().end();
         ++itRunner){
       static_cast<CResource*>(*itRunner)->getMonitoringHandler().readResourceWatches(paResponse);
     }

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -38,11 +38,8 @@ class CInterface2InternalDataConnection;
 /*! \ingroup CORE\brief Base class for all resources handling the reconfiguration management within this
  * resource and the background execution of event chains.
  *
- * CResource is inherited from CFBContainer in order to make the implementation of getResource easier. Furthermore
- * also the forwarding of management commands is less effort.
- * TODO think if CFBContainer inheritance should be public or private
  */
-class CResource : public CFunctionBlock, public forte::core::CFBContainer{
+class CResource : public CFunctionBlock{
 
   public:
     /*! \brief The main constructor for a resource.
@@ -95,7 +92,7 @@ class CResource : public CFunctionBlock, public forte::core::CFBContainer{
       return mResourceEventExecution;
     };
 
-    EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
     /*!\brief Write a parameter value to a given FB-input
      *
@@ -122,6 +119,10 @@ class CResource : public CFunctionBlock, public forte::core::CFBContainer{
       return tracePlatformContext;
     }
 #endif
+
+    bool isFB() override {
+       return false;
+    }
 
   protected:
     CResource(const SFBInterfaceSpec *paInterfaceSpec, CStringDictionary::TStringId paInstanceNameId);

--- a/src/modules/IEC61131-3/Comparison/tests/F_EQ_TIME_tester.cpp
+++ b/src/modules/IEC61131-3/Comparison/tests/F_EQ_TIME_tester.cpp
@@ -24,7 +24,7 @@ F_EQ_TIME_tester::F_EQ_TIME_tester(CResource *mTestResource) :
         mIn_IN1_Conn(mTestee, g_nStringIdIN1, &mIN1),
         mIn_IN2_Conn(mTestee, g_nStringIdIN2, &mIN2),
         mOut_OUT_Conn(mTestee, g_nStringIdOUT, &mOut_OUT){
-  mTestee.changeFBExecutionState(EMGMCommandType::Start);
+  mTestee.changeExecutionState(EMGMCommandType::Start);
 }
 
 void F_EQ_TIME_tester::executeAllTests(){

--- a/src/modules/IEC61131-3/Comparison/tests/F_GT_TIME_tester.cpp
+++ b/src/modules/IEC61131-3/Comparison/tests/F_GT_TIME_tester.cpp
@@ -24,7 +24,7 @@ F_GT_TIME_tester::F_GT_TIME_tester(CResource *mTestResource) :
         mIn_IN1_Conn(mTestee, g_nStringIdIN1, &mIN1),
         mIn_IN2_Conn(mTestee, g_nStringIdIN2, &mIN2),
         mOut_OUT_Conn(mTestee, g_nStringIdOUT, &mOut_OUT){
-  mTestee.changeFBExecutionState(EMGMCommandType::Start);
+  mTestee.changeExecutionState(EMGMCommandType::Start);
 }
 
 void F_GT_TIME_tester::executeAllTests(){

--- a/src/modules/rt_events/RT_E_CYCLE.cpp
+++ b/src/modules/rt_events/RT_E_CYCLE.cpp
@@ -78,9 +78,9 @@ void FORTE_RT_E_CYCLE::executeEvent(TEventID paEIID, CEventChainExecutionThread 
   }
 }
 
-EMGMResponse FORTE_RT_E_CYCLE::changeFBExecutionState(EMGMCommandType paCommand){
+EMGMResponse FORTE_RT_E_CYCLE::changeExecutionState(EMGMCommandType paCommand){
   mECEO.changeExecutionState(paCommand);
-  EMGMResponse eRetVal = CFunctionBlock::changeFBExecutionState(paCommand);
+  EMGMResponse eRetVal = CFunctionBlock::changeExecutionState(paCommand);
   if((EMGMResponse::Ready == eRetVal) && ((EMGMCommandType::Stop == paCommand) || (EMGMCommandType::Kill == paCommand)) && mActive) {
     getTimer().unregisterTimedFB(this);
     mActive = false;

--- a/src/modules/rt_events/RT_E_CYCLE.h
+++ b/src/modules/rt_events/RT_E_CYCLE.h
@@ -57,7 +57,7 @@ private:
 public:
   FORTE_RT_E_CYCLE(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
 
-  EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+  EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
   CIEC_TIME var_DT;
   CIEC_TIME var_Deadline;

--- a/src/modules/rt_events/RT_E_DELAY.cpp
+++ b/src/modules/rt_events/RT_E_DELAY.cpp
@@ -98,9 +98,9 @@ void FORTE_RT_E_DELAY::executeEvent(TEventID paEIID, CEventChainExecutionThread 
   }
 }
 
-EMGMResponse FORTE_RT_E_DELAY::changeFBExecutionState(EMGMCommandType paCommand){
+EMGMResponse FORTE_RT_E_DELAY::changeExecutionState(EMGMCommandType paCommand){
   mECEO.changeExecutionState(paCommand);
-  EMGMResponse eRetVal = CFunctionBlock::changeFBExecutionState(paCommand);
+  EMGMResponse eRetVal = CFunctionBlock::changeExecutionState(paCommand);
   if((EMGMResponse::Ready == eRetVal) && ((EMGMCommandType::Stop == paCommand) || (EMGMCommandType::Kill == paCommand)) && mActive) {
     getTimer().unregisterTimedFB(this);
     mActive = false;

--- a/src/modules/rt_events/RT_E_DELAY.h
+++ b/src/modules/rt_events/RT_E_DELAY.h
@@ -61,7 +61,7 @@ private:
 public:
   FORTE_RT_E_DELAY(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
 
-  EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+  EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
   CIEC_BOOL var_QI;
   CIEC_TIME var_DT;

--- a/src/modules/utils/GetInstancePathAndName_fbt.cpp
+++ b/src/modules/utils/GetInstancePathAndName_fbt.cpp
@@ -140,7 +140,7 @@ CIEC_ANY *FORTE_GetInstancePathAndName::getVarInternal(size_t) {
 }
 
 void FORTE_GetInstancePathAndName::alg_REQ(void) {
-  var_Path = CIEC_STRING(getContainer().getFullQualifiedApplicationInstanceName(var_Sep.operator TForteChar()));
+  var_Path = CIEC_STRING(getParent().getFullQualifiedApplicationInstanceName(var_Sep.operator TForteChar()));
   var_Name = CIEC_STRING(getInstanceName(), strlen(getInstanceName()));
 }
 

--- a/src/modules/utils/STEST_END_fbt.cpp
+++ b/src/modules/utils/STEST_END_fbt.cpp
@@ -39,7 +39,7 @@ FORTE_STEST_END::FORTE_STEST_END(const CStringDictionary::TStringId paInstanceNa
 void FORTE_STEST_END::executeEvent(TEventID paEIID, CEventChainExecutionThread *const) {
   if(scmEventREQID == paEIID){
     CThread::sleepThread(250); //avoid killing the device before it was properly started (DEV_MGR still was initializing the ipCommlayer when it was killed)
-    getDevice()->changeFBExecutionState(EMGMCommandType::Kill);
+    getDevice()->changeExecutionState(EMGMCommandType::Kill);
   }
 }
 

--- a/src/stdfblib/events/E_RESTART.cpp
+++ b/src/stdfblib/events/E_RESTART.cpp
@@ -44,7 +44,7 @@ void FORTE_E_RESTART::executeEvent(TEventID paEIID, CEventChainExecutionThread *
     sendOutputEvent(mEventToSend, paECET);
     if(scmEventSTOPID == mEventToSend) {
       //stop event is sent put the FB finally into the stopped state
-      CFunctionBlock::changeFBExecutionState(EMGMCommandType::Stop);
+      CFunctionBlock::changeExecutionState(EMGMCommandType::Stop);
       // release semaphore to indicate that the stop event was sent now
       mSuspendSemaphore.inc();
     }
@@ -84,8 +84,8 @@ CDataConnection *FORTE_E_RESTART::getDOConUnchecked(TPortId) {
   return nullptr;
 }
 
-EMGMResponse FORTE_E_RESTART::changeFBExecutionState(EMGMCommandType paCommand){
-  EMGMResponse eRetVal = CFunctionBlock::changeFBExecutionState(paCommand);
+EMGMResponse FORTE_E_RESTART::changeExecutionState(EMGMCommandType paCommand){
+  EMGMResponse eRetVal = CFunctionBlock::changeExecutionState(paCommand);
   if(EMGMResponse::Ready == eRetVal){
     switch(paCommand){
       case EMGMCommandType::Start:
@@ -94,7 +94,7 @@ EMGMResponse FORTE_E_RESTART::changeFBExecutionState(EMGMCommandType paCommand){
         break;
       case EMGMCommandType::Stop:
         mEventToSend = scmEventSTOPID;
-        CFunctionBlock::changeFBExecutionState(EMGMCommandType::Start);   //keep FB in running state until stop event is delivered.
+        CFunctionBlock::changeExecutionState(EMGMCommandType::Start);   //keep FB in running state until stop event is delivered.
         getDevice()->getDeviceExecution().startNewEventChain(this);
         // wait until semaphore is released, after STOP eventExecution was completed
         mSuspendSemaphore.waitIndefinitely();

--- a/src/stdfblib/events/E_RESTART.h
+++ b/src/stdfblib/events/E_RESTART.h
@@ -53,6 +53,6 @@ public:
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
 
-    EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 };
 

--- a/src/stdfblib/events/E_RTimeOut_fbt.cpp
+++ b/src/stdfblib/events/E_RTimeOut_fbt.cpp
@@ -34,7 +34,7 @@ const SFBInterfaceSpec FORTE_E_RTimeOut::scmFBInterfaceSpec = {
 
 FORTE_E_RTimeOut::FORTE_E_RTimeOut(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
     CCompositeFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId, scmFBNData),
-    var_TimeOutSocket(g_nStringIdTimeOutSocket, getContainer(), false) {
+    var_TimeOutSocket(g_nStringIdTimeOutSocket, *this, false) {
 };
 
 bool FORTE_E_RTimeOut::initialize() {

--- a/src/stdfblib/events/E_TimeOut_fbt.cpp
+++ b/src/stdfblib/events/E_TimeOut_fbt.cpp
@@ -35,7 +35,7 @@ const SFBInterfaceSpec FORTE_E_TimeOut::scmFBInterfaceSpec = {
 FORTE_E_TimeOut::FORTE_E_TimeOut(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
     CEventSourceFB(paContainer, &scmFBInterfaceSpec, paInstanceNameId),
     mActive(false),
-    var_TimeOutSocket(g_nStringIdTimeOutSocket, getContainer(), false) {
+    var_TimeOutSocket(g_nStringIdTimeOutSocket, *this, false) {
 };
 
 bool FORTE_E_TimeOut::initialize() {
@@ -99,8 +99,8 @@ CDataConnection *FORTE_E_TimeOut::getDOConUnchecked(TPortId) {
   return nullptr;
 }
 
-EMGMResponse FORTE_E_TimeOut::changeFBExecutionState(EMGMCommandType paCommand){
-  EMGMResponse eRetVal = CFunctionBlock::changeFBExecutionState(paCommand);
+EMGMResponse FORTE_E_TimeOut::changeExecutionState(EMGMCommandType paCommand){
+  EMGMResponse eRetVal = CFunctionBlock::changeExecutionState(paCommand);
   if((EMGMResponse::Ready == eRetVal) && ((EMGMCommandType::Stop == paCommand) || (EMGMCommandType::Kill == paCommand))){
     if(mActive){
       getTimer().unregisterTimedFB(this);

--- a/src/stdfblib/events/E_TimeOut_fbt.h
+++ b/src/stdfblib/events/E_TimeOut_fbt.h
@@ -52,6 +52,6 @@ class FORTE_E_TimeOut final : public CEventSourceFB {
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
 
-    EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 };
 

--- a/src/stdfblib/ita/DEV_MGR.cpp
+++ b/src/stdfblib/ita/DEV_MGR.cpp
@@ -63,7 +63,7 @@ void DEV_MGR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const pa
       //this is the first time init is called try to load a boot file
       ForteBootFileLoader loader(*this);
       if(loader.needsExit()){
-        getDevice()->changeFBExecutionState(EMGMCommandType::Kill);
+        getDevice()->changeExecutionState(EMGMCommandType::Kill);
         return;
       }
       if(loader.isOpen() && LOAD_RESULT_OK == loader.loadBootFile()){

--- a/src/stdfblib/ita/EMB_RES.cpp
+++ b/src/stdfblib/ita/EMB_RES.cpp
@@ -29,7 +29,7 @@ const SFBInterfaceSpec EMB_RES::scmFBInterfaceSpec = {
 };
 
 EMB_RES::EMB_RES(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paDevice) :
-    CResource(paDevice, nullptr, paInstanceNameId){
+    CResource(paDevice, &scmFBInterfaceSpec, paInstanceNameId){
 }
 
 bool EMB_RES::initialize() {

--- a/src/stdfblib/ita/FakeTimeDev.cpp
+++ b/src/stdfblib/ita/FakeTimeDev.cpp
@@ -60,7 +60,7 @@ FakeTimeDev::~FakeTimeDev() = default;
 
 int FakeTimeDev::startDevice(){
   CDevice::startDevice();
-  MGR.changeFBExecutionState(EMGMCommandType::Start);
+  MGR.changeExecutionState(EMGMCommandType::Start);
   return 0;
 }
 
@@ -68,10 +68,10 @@ void FakeTimeDev::awaitShutdown() {
   MGR.joinResourceThread();
 }
 
-EMGMResponse FakeTimeDev::changeFBExecutionState(EMGMCommandType paCommand){
-  EMGMResponse eRetVal = CDevice::changeFBExecutionState(paCommand);
+EMGMResponse FakeTimeDev::changeExecutionState(EMGMCommandType paCommand){
+  EMGMResponse eRetVal = CDevice::changeExecutionState(paCommand);
   if((EMGMResponse::Ready == eRetVal) && (EMGMCommandType::Kill == paCommand)){
-    MGR.changeFBExecutionState(EMGMCommandType::Kill);
+    MGR.changeExecutionState(EMGMCommandType::Kill);
   }
   return eRetVal;
 }

--- a/src/stdfblib/ita/FakeTimeDev.h
+++ b/src/stdfblib/ita/FakeTimeDev.h
@@ -34,7 +34,7 @@ class FakeTimeDev : public CDevice{
 
     void awaitShutdown() override;
 
-    EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
     EMGMResponse writeValue(forte::core::TNameIdentifier &paNameList, const std::string & paValue, bool paForce = false) override;
 

--- a/src/stdfblib/ita/OPCUA_DEV.cpp
+++ b/src/stdfblib/ita/OPCUA_DEV.cpp
@@ -15,7 +15,7 @@
 
 OPCUA_DEV::OPCUA_DEV(const std::string &paMGRID) :
   RMT_DEV(paMGRID), mOPCUAMgr(*this){
-  changeFBExecutionState(EMGMCommandType::Reset);
+  changeExecutionState(EMGMCommandType::Reset);
 }
 
 OPCUA_DEV::~OPCUA_DEV() {

--- a/src/stdfblib/ita/RMT_DEV.cpp
+++ b/src/stdfblib/ita/RMT_DEV.cpp
@@ -55,7 +55,7 @@ RMT_DEV::~RMT_DEV() = default;
 
 int RMT_DEV::startDevice(){
   CDevice::startDevice();
-  MGR.changeFBExecutionState(EMGMCommandType::Start);
+  MGR.changeExecutionState(EMGMCommandType::Start);
   return 0;
 }
 
@@ -63,10 +63,10 @@ void RMT_DEV::awaitShutdown() {
   MGR.joinResourceThread();
 }
 
-EMGMResponse RMT_DEV::changeFBExecutionState(EMGMCommandType paCommand){
-  EMGMResponse eRetVal = CDevice::changeFBExecutionState(paCommand);
+EMGMResponse RMT_DEV::changeExecutionState(EMGMCommandType paCommand){
+  EMGMResponse eRetVal = CDevice::changeExecutionState(paCommand);
   if((EMGMResponse::Ready == eRetVal) && (EMGMCommandType::Kill == paCommand)){
-    MGR.changeFBExecutionState(EMGMCommandType::Kill);
+    MGR.changeExecutionState(EMGMCommandType::Kill);
   }
   return eRetVal;
 }

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -37,7 +37,7 @@
 
     void awaitShutdown() override;
 
-    EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
     void setMGR_ID(const std::string& paVal);
 

--- a/src/stdfblib/ita/RMT_RES.cpp
+++ b/src/stdfblib/ita/RMT_RES.cpp
@@ -58,7 +58,7 @@ bool RMT_RES::initialize() {
 
   command.mFirstParam.clear();
   command.mFirstParam.pushBack(g_nStringIdSTART);
-  command.mFirstParam.pushBack(g_nStringIdwARM);
+  command.mFirstParam.pushBack(g_nStringIdWARM);
   command.mSecondParam.clear();
   command.mSecondParam.pushBack(g_nStringIdMGR_FF);
   command.mSecondParam.pushBack(g_nStringIdS);

--- a/src/stdfblib/timedfb.cpp
+++ b/src/stdfblib/timedfb.cpp
@@ -97,8 +97,8 @@ CDataConnection *CTimedFB::getDOConUnchecked(const TPortId) {
   return nullptr;
 }
 
-EMGMResponse CTimedFB::changeFBExecutionState(EMGMCommandType paCommand){
-  EMGMResponse eRetVal = CFunctionBlock::changeFBExecutionState(paCommand);
+EMGMResponse CTimedFB::changeExecutionState(EMGMCommandType paCommand){
+  EMGMResponse eRetVal = CFunctionBlock::changeExecutionState(paCommand);
   if((EMGMResponse::Ready == eRetVal) && ((EMGMCommandType::Stop == paCommand) || (EMGMCommandType::Kill == paCommand)) && mActive) {
     getTimer().unregisterTimedFB(this);
     mActive = false;

--- a/src/stdfblib/timedfb.h
+++ b/src/stdfblib/timedfb.h
@@ -61,7 +61,7 @@ public:
   CDataConnection **getDIConUnchecked(TPortId) override;
   CDataConnection *getDOConUnchecked(TPortId) override;
 
-  EMGMResponse changeFBExecutionState(EMGMCommandType paCommand) override;
+  EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 };
 
 #endif /*TIMEDFB_H_*/

--- a/tests/core/fbtests/fbtesterglobalfixture.cpp
+++ b/tests/core/fbtests/fbtesterglobalfixture.cpp
@@ -23,7 +23,7 @@ CFBTestDataGlobalFixture::CFBTestDataGlobalFixture(){
   //setup is done in the setup so that boost_test can throw exceptions
   smTestDev = std::make_unique<CTesterDevice>();
   //mimick the behavior provided by typelib
-  smTestDev->changeFBExecutionState(EMGMCommandType::Reset);
+  smTestDev->changeExecutionState(EMGMCommandType::Reset);
 
   smTestRes = (CResource *)CTypeLib::createFB(g_nStringIdEMB_RES, g_nStringIdEMB_RES, *smTestDev);
 
@@ -35,7 +35,7 @@ CFBTestDataGlobalFixture::CFBTestDataGlobalFixture(){
 
 
 CFBTestDataGlobalFixture::~CFBTestDataGlobalFixture(){
-  smTestDev->changeFBExecutionState(EMGMCommandType::Stop);
+  smTestDev->changeExecutionState(EMGMCommandType::Stop);
   smTestDev.reset();
   //we don't need to delete the res here as the res is deletes in the destructor of the device
 }

--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -58,8 +58,8 @@ bool CFBTestFixtureBase::initialize() {
   if(!CFunctionBlock::initialize()) {
     return false;
   }
-  changeFBExecutionState(EMGMCommandType::Reset);
-  changeFBExecutionState(EMGMCommandType::Start);
+  changeExecutionState(EMGMCommandType::Reset);
+  changeExecutionState(EMGMCommandType::Start);
   //assure that we are in running state
   BOOST_REQUIRE_EQUAL(CFunctionBlock::E_FBStates::Running, getState());
   BOOST_REQUIRE(nullptr != mFBUnderTest);
@@ -102,8 +102,8 @@ CFBTestFixtureBase::~CFBTestFixtureBase(){
 void CFBTestFixtureBase::performFBResetTests() {
   const SFBInterfaceSpec* interfaceSpec = mFBUnderTest->getFBInterfaceSpec();
 
-  BOOST_CHECK_EQUAL(EMGMResponse::Ready, mFBUnderTest->changeFBExecutionState(EMGMCommandType::Stop));
-  BOOST_CHECK_EQUAL(EMGMResponse::Ready, mFBUnderTest->changeFBExecutionState(EMGMCommandType::Reset));
+  BOOST_CHECK_EQUAL(EMGMResponse::Ready, mFBUnderTest->changeExecutionState(EMGMCommandType::Stop));
+  BOOST_CHECK_EQUAL(EMGMResponse::Ready, mFBUnderTest->changeExecutionState(EMGMCommandType::Reset));
 
   CFunctionBlock *freshInstance = CTypeLib::createFB(mTypeId, mTypeId, *getResource());
   BOOST_REQUIRE(freshInstance != nullptr);
@@ -121,13 +121,13 @@ void CFBTestFixtureBase::performFBResetTests() {
 
   BOOST_CHECK(CTypeLib::deleteFB(freshInstance));
 
-  BOOST_CHECK_EQUAL(EMGMResponse::Ready, mFBUnderTest->changeFBExecutionState(EMGMCommandType::Start));
+  BOOST_CHECK_EQUAL(EMGMResponse::Ready, mFBUnderTest->changeExecutionState(EMGMCommandType::Start));
 }
 
 void CFBTestFixtureBase::performFBDeleteTests() {
   BOOST_CHECK(!mFBUnderTest->isCurrentlyDeleteable());
 
-  BOOST_CHECK_EQUAL(EMGMResponse::Ready, mFBUnderTest->changeFBExecutionState(EMGMCommandType::Stop));
+  BOOST_CHECK_EQUAL(EMGMResponse::Ready, mFBUnderTest->changeExecutionState(EMGMCommandType::Stop));
 
   BOOST_CHECK(mFBUnderTest->isCurrentlyDeleteable());
 
@@ -145,7 +145,7 @@ void CFBTestFixtureBase::setup(const char* paConfigString){
   setupTestInterface();
   performDataInterfaceTests();
 
-  mFBUnderTest->changeFBExecutionState(EMGMCommandType::Start);
+  mFBUnderTest->changeExecutionState(EMGMCommandType::Start);
 
   createEventOutputConnections();
   createDataInputConnections();

--- a/tests/core/mgmstatemachinetest.cpp
+++ b/tests/core/mgmstatemachinetest.cpp
@@ -27,7 +27,7 @@ class CFunctionBlockMock : public CFunctionBlock{
         return false;
       }
       //mimick the behavior provided by typelib
-      changeFBExecutionState(EMGMCommandType::Reset);
+      changeExecutionState(EMGMCommandType::Reset);
       return true;
     }
 
@@ -77,21 +77,21 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
 
     BOOST_CHECK(testee.isCurrentlyDeleteable());
 
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Stop));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Stop));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Idle, testee.getState());
 
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Kill));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Kill));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Idle, testee.getState());
 
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Reset));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Reset));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Idle, testee.getState());
 
-    BOOST_CHECK_EQUAL(EMGMResponse::Ready, testee.changeFBExecutionState(EMGMCommandType::Start));
+    BOOST_CHECK_EQUAL(EMGMResponse::Ready, testee.changeExecutionState(EMGMCommandType::Start));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Running, testee.getState());
   }
 
   void putTesteeIntoRun(CFunctionBlock &paTestee){
-    paTestee.changeFBExecutionState(EMGMCommandType::Start);
+    paTestee.changeExecutionState(EMGMCommandType::Start);
   }
 
   BOOST_AUTO_TEST_CASE(runningTest){
@@ -104,15 +104,15 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Running, testee.getState());
 
     //we should not be able to reset it
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Reset));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Reset));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Running, testee.getState());
 
     //we should not be able to start it
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Start));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Start));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Running, testee.getState());
 
     //we should be able to stop it
-    BOOST_CHECK_EQUAL(EMGMResponse::Ready, testee.changeFBExecutionState(EMGMCommandType::Stop));
+    BOOST_CHECK_EQUAL(EMGMResponse::Ready, testee.changeExecutionState(EMGMCommandType::Stop));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Stopped, testee.getState());
 
     //we shold be able to kill it, use a new testee to have a clean running state
@@ -120,13 +120,13 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
     BOOST_ASSERT(killTestee.initialize());
     putTesteeIntoRun(killTestee);
 
-    BOOST_CHECK_EQUAL(EMGMResponse::Ready, killTestee.changeFBExecutionState(EMGMCommandType::Kill));
+    BOOST_CHECK_EQUAL(EMGMResponse::Ready, killTestee.changeExecutionState(EMGMCommandType::Kill));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Killed, killTestee.getState());
   }
 
   void putTesteeIntoStopped(CFunctionBlock &paTestee){
     putTesteeIntoRun(paTestee);
-    paTestee.changeFBExecutionState(EMGMCommandType::Stop);
+    paTestee.changeExecutionState(EMGMCommandType::Stop);
   }
 
   BOOST_AUTO_TEST_CASE(stoppedTest){
@@ -137,15 +137,15 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
     BOOST_CHECK(testee.isCurrentlyDeleteable());
 
     //we should not be able to kill it
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Kill));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Kill));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Stopped, testee.getState());
 
     //we should not be able to stop it
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Stop));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Stop));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Stopped, testee.getState());
 
     //we should be able to start it
-    BOOST_CHECK_EQUAL(EMGMResponse::Ready, testee.changeFBExecutionState(EMGMCommandType::Start));
+    BOOST_CHECK_EQUAL(EMGMResponse::Ready, testee.changeExecutionState(EMGMCommandType::Start));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Running, testee.getState());
 
     //we should be able to reset it, use new testeee for a clean stopped state
@@ -153,14 +153,14 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
     BOOST_ASSERT(resetTestee.initialize());
     putTesteeIntoStopped(resetTestee);
 
-    BOOST_CHECK_EQUAL(EMGMResponse::Ready, resetTestee.changeFBExecutionState(EMGMCommandType::Reset));
+    BOOST_CHECK_EQUAL(EMGMResponse::Ready, resetTestee.changeExecutionState(EMGMCommandType::Reset));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Idle, resetTestee.getState());
 
   }
 
   void putTesteeIntoKilled(CFunctionBlock &paTestee){
     putTesteeIntoRun(paTestee);
-    paTestee.changeFBExecutionState(EMGMCommandType::Kill);
+    paTestee.changeExecutionState(EMGMCommandType::Kill);
   }
 
   BOOST_AUTO_TEST_CASE(killedTest){
@@ -171,19 +171,19 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
     BOOST_CHECK(testee.isCurrentlyDeleteable());
 
     //we should not be able to kill it
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Kill));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Kill));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Killed, testee.getState());
 
     //we should not be able to stop it
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Stop));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Stop));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Killed, testee.getState());
 
     //we should not be able to start it
-    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeFBExecutionState(EMGMCommandType::Start));
+    BOOST_CHECK_EQUAL(EMGMResponse::InvalidState, testee.changeExecutionState(EMGMCommandType::Start));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Killed, testee.getState());
 
     //we should be able to reset it
-    BOOST_CHECK_EQUAL(EMGMResponse::Ready, testee.changeFBExecutionState(EMGMCommandType::Reset));
+    BOOST_CHECK_EQUAL(EMGMResponse::Ready, testee.changeExecutionState(EMGMCommandType::Reset));
     BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Idle, testee.getState());
   }
 
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
       auto type = static_cast<EMGMCommandType>(i);
       if ((type != EMGMCommandType::Start) && (type != EMGMCommandType::Stop) && (type != EMGMCommandType::Kill) &&
           (type != EMGMCommandType::Reset)) {
-        BOOST_CHECK_EQUAL(EMGMResponse::InvalidOperation, paTestee.changeFBExecutionState(type));
+        BOOST_CHECK_EQUAL(EMGMResponse::InvalidOperation, paTestee.changeExecutionState(type));
         BOOST_CHECK_EQUAL(paState, paTestee.getState());
       }
     }
@@ -206,16 +206,16 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
     testAllOtherCommands(testee, CFunctionBlock::E_FBStates::Idle);
 
     //test for running
-    testee.changeFBExecutionState(EMGMCommandType::Start);
+    testee.changeExecutionState(EMGMCommandType::Start);
     testAllOtherCommands(testee, CFunctionBlock::E_FBStates::Running);
 
     //test for stopped
-    testee.changeFBExecutionState(EMGMCommandType::Stop);
+    testee.changeExecutionState(EMGMCommandType::Stop);
     testAllOtherCommands(testee, CFunctionBlock::E_FBStates::Stopped);
 
     //test for killed
-    testee.changeFBExecutionState(EMGMCommandType::Start);
-    testee.changeFBExecutionState(EMGMCommandType::Kill);
+    testee.changeExecutionState(EMGMCommandType::Start);
+    testee.changeExecutionState(EMGMCommandType::Kill);
     testAllOtherCommands(testee, CFunctionBlock::E_FBStates::Killed);
   }
 

--- a/tests/core/trace/ctfTracerTest.cpp
+++ b/tests/core/trace/ctfTracerTest.cpp
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(sequential_events_test) {
     while(resource->getResourceEventExecution()->isProcessingEvents()){
       std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
-    device.changeFBExecutionState(EMGMCommandType::Stop);
+    device.changeExecutionState(EMGMCommandType::Stop);
     resource->getResourceEventExecution()->joinEventChainExecutionThread();
   }
 


### PR DESCRIPTION
As basic and simple fbs can have FBs as children and to reduce a lot of code complexity in the FBContainer all FBs are now FBContainers.