### PR TITLE
Remove dynamic internal variable setup

### DIFF
--- a/src/core/basicfb.h
+++ b/src/core/basicfb.h
@@ -61,9 +61,7 @@ class CBasicFB : public CFunctionBlock {
      * @param paVarIntNum number of the internal variable starting with 0
      * @return pointer to the internal variable
      */
-    virtual CIEC_ANY* getVarInternal(size_t paVarIntNum) {
-      return mInternals[paVarIntNum];
-    }
+    virtual CIEC_ANY* getVarInternal(size_t paVarIntNum) = 0;
 
     const CIEC_ANY* getVarInternal(size_t paVarIntNum) const {
       return const_cast<CBasicFB *>(this)->getVarInternal(paVarIntNum);
@@ -71,10 +69,6 @@ class CBasicFB : public CFunctionBlock {
 
     CIEC_STATE mECCState; //! the current state of the ecc. start value is 0 = initial state id
     const SInternalVarsInformation *const cmVarInternals; //!< struct holding the information on the internal vars.
-
-    static size_t calculateBasicFBVarsDataSize(const SInternalVarsInformation &paVarInternals);
-
-    void *mBasicFBVarsData;
   private:
     /*!\brief Get the pointer to a internal variable of the basic FB.
      *
@@ -84,8 +78,6 @@ class CBasicFB : public CFunctionBlock {
     CIEC_ANY* getInternalVar(CStringDictionary::TStringId paInternalName);
 
     void setInitialValues() override;
-
-    CIEC_ANY **mInternals; //!< A list of pointers to the internal variables.
 
 #ifdef FORTE_FMU
         friend class fmuInstance;

--- a/src/core/datatypes/forte_array_fixed.h
+++ b/src/core/datatypes/forte_array_fixed.h
@@ -19,7 +19,8 @@
 
 #include "forte_array_common.h"
 #include <array>
-#include <devlog.h>
+#include <algorithm>
+#include "devlog.h"
 
 #include "forte_ulint.h"
 

--- a/tests/core/funcbloctests.cpp
+++ b/tests/core/funcbloctests.cpp
@@ -47,7 +47,15 @@ BOOST_AUTO_TEST_CASE(FB_TO_STRING_BUFFER_SIZE_TEST_WITH_INRENAL_VAR){
         }
 
         CIEC_ANY *getVarInternal(size_t paVarIntNum) override {
-            return CBasicFB::getVarInternal(paVarIntNum);
+          switch (paVarIntNum) {
+            case 0:
+              return &var_QU;
+            case 1:
+              return &var_QD;
+            case 2:
+              return &var_CV;
+          }
+          return nullptr;
         }
 
         CStringDictionary::TStringId getFBTypeId() const override {
@@ -83,6 +91,11 @@ BOOST_AUTO_TEST_CASE(FB_TO_STRING_BUFFER_SIZE_TEST_WITH_INRENAL_VAR){
         CDataConnection *getDOConUnchecked(TPortId) override {
                 return nullptr;
         }
+
+      private:
+        CIEC_BOOL var_QU;
+        CIEC_BOOL var_QD;
+        CIEC_UINT var_CV;
 };
 
     CStringDictionary::TStringId varInternalNames[] = {g_nStringIdQU, g_nStringIdQD, g_nStringIdCV};

--- a/tests/core/internalvartests.cpp
+++ b/tests/core/internalvartests.cpp
@@ -35,11 +35,20 @@ class CInternalVarTestFB : public CBasicFB{
 
   public:
     CInternalVarTestFB(const SInternalVarsInformation *paVarInternals) :
-      CBasicFB(CFBContainerMock::smDefaultFBContMock, &gcEmptyInterface, CStringDictionary::scmInvalidStringId, paVarInternals) {
+      CBasicFB(CFBContainerMock::smDefaultFBContMock, &gcEmptyInterface, CStringDictionary::scmInvalidStringId, paVarInternals),
+      var_QU(false_BOOL), var_QD(false_BOOL), var_CV(0_UINT) {
     }
 
     CIEC_ANY *getVarInternal(size_t paVarIntNum) override {
-      return CBasicFB::getVarInternal(paVarIntNum);
+      switch (paVarIntNum) {
+        case 0:
+          return &var_QU;
+        case 1:
+          return &var_QD;
+        case 2:
+          return &var_CV;
+      }
+      return nullptr;
     }
 
     CStringDictionary::TStringId getFBTypeId() const override {
@@ -75,6 +84,11 @@ class CInternalVarTestFB : public CBasicFB{
     CDataConnection *getDOConUnchecked(TPortId) override {
       return nullptr;
     }
+
+  private:
+    CIEC_BOOL var_QU;
+    CIEC_BOOL var_QD;
+    CIEC_UINT var_CV;
 };
 
 BOOST_AUTO_TEST_SUITE(internal_vars)


### PR DESCRIPTION
Remove obsolete dynamic setup of internal variables in basic function blocks.

Also add a missing include in fixed array.