### PR TITLE
Fix query FB instances and connections commands

### DIFF
--- a/src/core/fbcontainer.cpp
+++ b/src/core/fbcontainer.cpp
@@ -66,10 +66,10 @@ std::string CFBContainer::getFullQualifiedApplicationInstanceName(const char sep
 EMGMResponse CFBContainer::createFB(forte::core::TNameIdentifier::CIterator &paNameListIt, CStringDictionary::TStringId paTypeName){
   if(paNameListIt.isLastEntry()){
     return createFB(*paNameListIt, paTypeName);
-  } else if(!isFB()) {
+  } else if(isDynamicContainer()) {
     //we have more than one name in the fb name list. Find or create the container and hand the create command to this container.
     CFBContainer *childCont = findOrCreateContainer(*paNameListIt);
-    if(childCont != nullptr && !childCont->isFB()){
+    if(childCont != nullptr && childCont->isDynamicContainer()){
       //remove the container from the name list
       ++paNameListIt;
       return childCont->createFB(paNameListIt, paTypeName);
@@ -101,8 +101,8 @@ EMGMResponse CFBContainer::deleteFB(forte::core::TNameIdentifier::CIterator &paN
   if(isChild(childIt, childName)){
     CFBContainer *child = *childIt;
     if(!paNameListIt.isLastEntry()){
-      //we have more than one name in the fb name list. Hand the process on to the child if it is not an FB
-      if(!child->isFB()){
+      //we have more than one name in the fb name list. Hand the process on to the child if it is a dynamic container
+      if(child->isDynamicContainer()){
         //remove the container from the name list
         ++paNameListIt;
         retval = child->deleteFB(paNameListIt);

--- a/src/core/fbcontainer.h
+++ b/src/core/fbcontainer.h
@@ -59,6 +59,10 @@ namespace forte {
           return mChildren;
         }
 
+        const TFBContainerList &getChildren() const {
+          return mChildren;
+        }
+
         CFBContainer& getParent() const { return mParent;}
 
         virtual CResource* getResource(){
@@ -90,6 +94,10 @@ namespace forte {
 
         virtual bool isFB() {
           return false;
+        }
+
+        virtual bool isDynamicContainer() {
+          return true;
         }
 
       protected:

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -599,6 +599,10 @@ class CFunctionBlock : public forte::core::CFBContainer {
        return true;
     }
 
+    bool isDynamicContainer() override {
+      return false;
+    }
+
     /*!\brief Function providing the functionality of the FB (e.g. execute ECC for basic FBs).
      *
      * \param paECET the event chain execution thread this FB was invoked from

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -120,8 +120,8 @@ class CResource : public CFunctionBlock{
     }
 #endif
 
-    bool isFB() override {
-       return false;
+    bool isDynamicContainer() override {
+      return true;
     }
 
   protected:
@@ -241,12 +241,10 @@ class CResource : public CFunctionBlock{
      * @param paValue the result of the query
      * @return response of the command execution as defined in IEC 61499
      */
-    EMGMResponse queryFBs(std::string& paValue);
-    void createFBResponseMessage(const CFunctionBlock& paFb, const char* fullName, std::string& paValue);
+    static EMGMResponse queryFBs(std::string &paValue, const CFBContainer &container, std::string prefix);
+    static void createFBResponseMessage(const CFunctionBlock &paFb, const std::string &fullName, std::string &paValue);
 
-    EMGMResponse querySubapps(std::string& paValue, CFBContainer& container, std::string prefix);
-
-    EMGMResponse queryConnections(std::string &paValue, CFBContainer& container);
+    EMGMResponse queryConnections(std::string &paValue, const CFBContainer& container);
     void createEOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
     void createDOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
     void createAOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);


### PR DESCRIPTION
A resource was previously added to the FB list of a device. With the recent changes to unify both FB and sub-contaier lists in the FB container, resources were no longer considered FB instances when querying FB instances or connections. This also meant the resource itself was no longer returned when querying the device.

This commit introduces a new virtual method isDynamicContainer() to distinguish between FBs and/or dynamic containers, respectively. The former are now all subclasses of CFunctionBlock and the latter support adding or removing children at runtime.

Closes #203 