### PR TITLE
Add dynamic internal variable setup to Lua BFB

### DIFF
--- a/src/core/lua/luabfb.cpp
+++ b/src/core/lua/luabfb.cpp
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 fortiss GmbH, Johannes Kepler University Linz
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz
+ *                          Martin Erich Jobst
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +11,7 @@
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
  *   Alois Zoitl  - upgraded to new FB memory layout
+ *   Martin Jobst - add dynamic internal variable setup from CBasicFB
  *******************************************************************************/
 
 #include "luabfb.h"
@@ -62,12 +65,38 @@ CLuaBFB::CLuaBFB(CStringDictionary::TStringId paInstanceNameId, const CLuaBFBTyp
   luaEngine->store(this);
 }
 
-CLuaBFB::~CLuaBFB() = default;
-
 bool CLuaBFB::initialize() {
   //before calling super we need to configure the interface of the FB
   setupFBInterface(getFBInterfaceSpec());
+  createVarInternals();
   return CGenFunctionBlock<CBasicFB>::initialize();
+}
+
+CLuaBFB::~CLuaBFB() {
+  if(mInternals) {
+    for(TPortId i = 0; i < cmVarInternals->mNumIntVars; ++i) {
+      if(CIEC_ANY* value = mInternals[i]; nullptr != value) {
+        std::destroy_at(value);
+      }
+    }
+  }
+  operator delete(mInternalVarsData);
+  mInternalVarsData = nullptr;
+}
+
+void CLuaBFB::createVarInternals() {
+  if(cmVarInternals && cmVarInternals->mNumIntVars) {
+    size_t internalVarsDataSize = calculateInternalVarsDataSize(*cmVarInternals);
+    mInternalVarsData = internalVarsDataSize ? operator new(internalVarsDataSize) : nullptr;
+
+    auto *internalVarsData = reinterpret_cast<TForteByte *>(mInternalVarsData);
+    mInternals = reinterpret_cast<CIEC_ANY**>(internalVarsData);
+    internalVarsData += cmVarInternals->mNumIntVars * sizeof(CIEC_ANY *);
+    const CStringDictionary::TStringId *pnDataIds = cmVarInternals->mIntVarsDataTypeNames;
+    for(TPortId i = 0; i < cmVarInternals->mNumIntVars; ++i) {
+      mInternals[i] = createDataPoint(pnDataIds, internalVarsData);
+    }
+  }
 }
 
 void CLuaBFB::executeEvent(TEventID paEIID, CEventChainExecutionThread *paECET) {
@@ -125,3 +154,17 @@ void CLuaBFB::writeOutputData(TEventID paEO) {
     }
   }
 }
+
+size_t CLuaBFB::calculateInternalVarsDataSize(const SInternalVarsInformation &paVarInternals) {
+  size_t result = 0;
+  const CStringDictionary::TStringId *pnDataIds;
+
+  result += paVarInternals.mNumIntVars * sizeof(CIEC_ANY *);
+  pnDataIds = paVarInternals.mIntVarsDataTypeNames;
+  for (TPortId i = 0; i < paVarInternals.mNumIntVars; ++i) {
+    result += getDataPointSize(pnDataIds);
+  }
+
+  return result;
+}
+

--- a/src/core/lua/luabfb.h
+++ b/src/core/lua/luabfb.h
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 fortiss GmbH, Johannes Kepler University Linz
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz
+ *                          Martin Erich Jobst
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +11,7 @@
  * Contributors:
  *   Martin Jobst - initial API and implementation and/or initial documentation
  *   Alois Zoitl  - upgraded to new FB memory layout
+ *   Martin Jobst - add dynamic internal variable setup from CBasicFB
  *******************************************************************************/
 
 #ifndef SRC_CORE_LUABFB_H_
@@ -45,7 +48,7 @@ class CLuaBFB : public CGenFunctionBlock<CBasicFB> {
 
     CIEC_ANY* getVariable(TForteUInt32 paId);
 
-    int recalculateID(int paEIID) {
+    TEventID recalculateID(TEventID paEIID) {
       return CLuaBFB::scmLuaFBAdpFlag | ((((paEIID >> 8) - 1) << 16) & 0xFF0000) | (paEIID & 0x00FF);
     }
 
@@ -74,8 +77,19 @@ class CLuaBFB : public CGenFunctionBlock<CBasicFB> {
     friend int CLuaFB_call(lua_State *paLuaState);
 
   private:
-    virtual void readInputData(TEventID paEIID);
-    virtual void writeOutputData(TEventID paEO);
+    void readInputData(TEventID paEIID) override;
+    void writeOutputData(TEventID paEO) override;
+
+    void createVarInternals();
+
+    static size_t calculateInternalVarsDataSize(const SInternalVarsInformation &paVarInternals);
+
+    CIEC_ANY* getVarInternal(size_t paVarIntNum) override {
+      return mInternals[paVarIntNum];
+    }
+
+    CIEC_ANY **mInternals; //!< A list of pointers to the internal variables.
+    void *mInternalVarsData;
 };
 
 #endif /* SRC_CORE_LUABFB_H_ */


### PR DESCRIPTION
This adds the dynamic internal variable setup, which was removed from `CBasicFB` in https://github.com/eclipse-4diac/4diac-forte/pull/199, to the Lua BFB.