### PR TITLE
Refactor FBN parameters in CFBs

### DIFF
--- a/src/core/cfb.cpp
+++ b/src/core/cfb.cpp
@@ -47,7 +47,7 @@ bool CCompositeFB::initialize() {
   createEventConnections();
   createDataConnections();
   createAdapterConnections();
-  setParams();
+  setFBNetworkInitialValues();
 
   //remove adapter-references for CFB
   for(TPortId i = 0; i < getFBInterfaceSpec().mNumAdapters; i++){
@@ -123,7 +123,7 @@ EMGMResponse CCompositeFB::changeExecutionState(EMGMCommandType paCommand){
 
   //Update FB parameters that maybe got overwritten by default values of the FB
   if((EMGMCommandType::Reset == paCommand) && (E_FBStates::Idle == getState())){
-    setParams();
+    setFBNetworkInitialValues();
   }
   return nRetVal;
 }
@@ -295,7 +295,7 @@ void CCompositeFB::prepareIf2InDataCons(){
   }
 }
 
-void CCompositeFB::setParams() {
+void CCompositeFB::setFBNetworkInitialValues() {
   for(size_t i = 0; i < cmFBNData.mNumParams; ++i){
     const SCFB_FBParameter &currentParam(cmFBNData.mParams[i]);
     CFunctionBlock *child = getFunctionBlock(currentParam.mFBNum);

--- a/src/core/cfb.h
+++ b/src/core/cfb.h
@@ -153,7 +153,7 @@ class CCompositeFB: public CFunctionBlock {
     CDataConnection * getDataConn(CFunctionBlock *paSrcFB, CStringDictionary::TStringId paSrcNameId);
     void createAdapterConnections();
     void prepareIf2InDataCons();
-    void setParams();
+    virtual void setFBNetworkInitialValues();
 
     //!Acquire the functionblock for a given function block number this may be a contained fb, an adapter, or the composite itself.
     CFunctionBlock *getFunctionBlock(int paFBNum);


### PR DESCRIPTION
Make `setParams()` virtual in `CCompositeFB` and rename to `setFBNetworkInitialValues()`.