### PR TITLE
Ensure generic FB constructors are public

### DIFF
--- a/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
@@ -34,9 +34,6 @@ GEN_ADD::GEN_ADD(const CStringDictionary::TStringId paInstanceNameId, forte::cor
     CGenFunctionBlock<CFunctionBlock>(paContainer, paInstanceNameId), mDInputs(0){
 }
 
-GEN_ADD::~GEN_ADD(){
-}
-
 void GEN_ADD::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
   switch (paEIID){
     case scmEventREQID:

--- a/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.h
+++ b/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.h
@@ -54,8 +54,9 @@ class GEN_ADD : public CGenFunctionBlock<CFunctionBlock> {
 
     bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
+  public:
     GEN_ADD(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-    ~GEN_ADD() override;
+    ~GEN_ADD() override = default;
 };
 
 #endif // _GEN_ADD_H_

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_AND.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_AND.cpp
@@ -27,8 +27,6 @@ GEN_AND::GEN_AND(const CStringDictionary::TStringId paInstanceNameId, forte::cor
     CGenBitBase(paInstanceNameId, paContainer){
 }
 
-GEN_AND::~GEN_AND() = default;
-
 void GEN_AND::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
   switch (paEIID) {
     case scmEventREQID:

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_AND.h
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_AND.h
@@ -27,8 +27,9 @@ class GEN_AND : public CGenBitBase {
   private:
     void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
+  public:
     GEN_AND(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-    ~GEN_AND() override;
+    ~GEN_AND() override = default;
 };
 
 #endif //_GEN_AND_H_

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_OR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_OR.cpp
@@ -27,8 +27,6 @@ GEN_OR::GEN_OR(const CStringDictionary::TStringId paInstanceNameId, forte::core:
     CGenBitBase(paInstanceNameId, paContainer){
 }
 
-GEN_OR::~GEN_OR() = default;
-
 void GEN_OR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
   switch (paEIID) {
     case scmEventREQID:

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_OR.h
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_OR.h
@@ -28,8 +28,9 @@ class GEN_OR : public CGenBitBase {
 
     void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
+  public:
     GEN_OR(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-    ~GEN_OR() override;
+    ~GEN_OR() override = default;
 };
 
 #endif //_GEN_OR_H_

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_XOR.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_XOR.cpp
@@ -27,8 +27,6 @@ GEN_XOR::GEN_XOR(const CStringDictionary::TStringId paInstanceNameId, forte::cor
     CGenBitBase(paInstanceNameId, paContainer){
 }
 
-GEN_XOR::~GEN_XOR() = default;
-
 void GEN_XOR::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
   switch (paEIID) {
     case scmEventREQID:

--- a/src/modules/IEC61131-3/BitwiseOperators/GEN_XOR.h
+++ b/src/modules/IEC61131-3/BitwiseOperators/GEN_XOR.h
@@ -28,8 +28,9 @@ class GEN_XOR : public CGenBitBase {
 
     void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
+  public:
     GEN_XOR(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-    ~GEN_XOR() override;
+    ~GEN_XOR() override = default;
 };
 
 #endif //_GEN_XOR_H_

--- a/src/modules/rt_events/RT_Bridge_fbt.h
+++ b/src/modules/rt_events/RT_Bridge_fbt.h
@@ -24,6 +24,7 @@ class FORTE_GEN_RT_Bridge final : public CGenFunctionBlock<CFunctionBlock>  {
 
   public:
     FORTE_GEN_RT_Bridge(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+    ~FORTE_GEN_RT_Bridge() override = default;
 
   private:
     static const TEventID scmEventRDID = 0;

--- a/src/modules/utils/GEN_ARRAY2ARRAY_fbt.h
+++ b/src/modules/utils/GEN_ARRAY2ARRAY_fbt.h
@@ -57,10 +57,9 @@ private:
 
   bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
+public:
   GEN_ARRAY2ARRAY(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
   ~GEN_ARRAY2ARRAY() override;
-
-public:
 
 };
 

--- a/src/modules/utils/GEN_ARRAY2VALUES_fbt.h
+++ b/src/modules/utils/GEN_ARRAY2VALUES_fbt.h
@@ -52,10 +52,10 @@ class GEN_ARRAY2VALUES : public CGenFunctionBlock<CFunctionBlock> {
 
     bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
+  public:
     GEN_ARRAY2VALUES(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
     ~GEN_ARRAY2VALUES() override;
 
-  public:
 };
 
 #endif //_GEN_ARRAY2VALUES_H_

--- a/src/modules/utils/GEN_F_MUX_fbt.h
+++ b/src/modules/utils/GEN_F_MUX_fbt.h
@@ -48,6 +48,7 @@ class GEN_F_MUX : public CGenFunctionBlock<CFunctionBlock> {
 
     bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
+  public:
     GEN_F_MUX(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
     ~GEN_F_MUX() override;
 };

--- a/src/modules/utils/GEN_VALUES2ARRAY_fbt.h
+++ b/src/modules/utils/GEN_VALUES2ARRAY_fbt.h
@@ -49,6 +49,7 @@ class GEN_VALUES2ARRAY : public CGenFunctionBlock<CFunctionBlock>{
 
     bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
+  public:
     GEN_VALUES2ARRAY(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
     ~GEN_VALUES2ARRAY() override;
 


### PR DESCRIPTION
Ensure generic FB constructors are public to be used as internal FBs.