### PR TITLE
Fix rounding for real to integer conversions

### DIFF
--- a/src/core/datatypes/forte_lreal.cpp
+++ b/src/core/datatypes/forte_lreal.cpp
@@ -108,33 +108,10 @@ void CIEC_LREAL::castLRealData(const CIEC_LREAL &paSrcValue, CIEC_ANY &paDestVal
       // bit string will cast to the binary representation of the real value
       paDestValue.setValue(paSrcValue);
       break;
-    case CIEC_ANY::e_BOOL: //bool works better when treated as signed so that negative numbers will be treated as true to
-    case CIEC_ANY::e_SINT:
-    case CIEC_ANY::e_INT:
-    case CIEC_ANY::e_DINT:
-    case CIEC_ANY::e_LINT: {
-      CIEC_LREAL::TValueType doubleValue = static_cast<CIEC_LREAL::TValueType>(paSrcValue);
-      if(0 < doubleValue){
-        doubleValue += 0.5;
-      }
-      if(0 > doubleValue){
-        doubleValue -= 0.5;
-      }
-      *((CIEC_ANY::TLargestIntValueType *) paDestValue.getDataPtr()) = static_cast<CIEC_ANY::TLargestIntValueType>(doubleValue);
-    }
-      break;
     default: {
-      //TODO maybe we should check for destination id to be in valid range (i.e., any_bit, any_unsigned_int, and time)
-      //should not be necessary because of connect function, but who knows.
       CIEC_LREAL::TValueType doubleValue = static_cast<CIEC_LREAL::TValueType>(paSrcValue);
-      if(0 < doubleValue){
-        doubleValue += 0.5;
-      }
-      if(0 > doubleValue){
-        doubleValue -= 0.5;
-      }
-      *((CIEC_ANY::TLargestUIntValueType *) paDestValue.getDataPtr()) = static_cast<CIEC_ANY::TLargestUIntValueType>(doubleValue);
-    }
+      *(reinterpret_cast<CIEC_ANY::TLargestUIntValueType*>(paDestValue.getDataPtr())) = static_cast<CIEC_ANY::TLargestUIntValueType>(std::llrint(doubleValue));
       break;
+    }
   }
 }

--- a/src/core/datatypes/forte_real.cpp
+++ b/src/core/datatypes/forte_real.cpp
@@ -108,33 +108,10 @@ void CIEC_REAL::castRealData(const CIEC_REAL &paSrcValue, CIEC_ANY &paDestValue)
       // bit string will cast to the binary representation of the real value
       paDestValue.setValue(paSrcValue);
       break;
-    case CIEC_ANY::e_BOOL:    //bool works better when treated as signed so that negative numbers will be treated as true to
-    case CIEC_ANY::e_SINT:
-    case CIEC_ANY::e_INT:
-    case CIEC_ANY::e_DINT:
-    case CIEC_ANY::e_LINT: {
-      CIEC_REAL::TValueType floatValue = static_cast<CIEC_REAL::TValueType>(paSrcValue);
-      if(0 < floatValue){
-        floatValue += 0.5F;
-      }
-      if(0 > floatValue){
-        floatValue -= 0.5F;
-      }
-      *((CIEC_ANY::TLargestIntValueType *) paDestValue.getDataPtr()) = static_cast<CIEC_ANY::TLargestIntValueType>(floatValue);
-    }
-      break;
     default: {
-      //TODO maybe we should check for destination id to be in valid range (i.e., any_bit, any_unsigned_int, and time)
-      //should not be necessary because of connect function, but who knows.
       CIEC_REAL::TValueType floatValue = static_cast<CIEC_REAL::TValueType>(paSrcValue);
-      if(0 < floatValue){
-        floatValue += 0.5F;
-      }
-      if(0 > floatValue){
-        floatValue -= 0.5F;
-      }
-      *(reinterpret_cast<CIEC_ANY::TLargestUIntValueType*>(paDestValue.getDataPtr())) = static_cast<CIEC_ANY::TLargestUIntValueType>(floatValue);
-    }
+      *(reinterpret_cast<CIEC_ANY::TLargestUIntValueType*>(paDestValue.getDataPtr())) = static_cast<CIEC_ANY::TLargestUIntValueType>(std::llrint(floatValue));
       break;
+    }
   }
 }

--- a/tests/core/datatypes/convert/convert_functionstests.cpp
+++ b/tests/core/datatypes/convert/convert_functionstests.cpp
@@ -284,49 +284,151 @@ BOOST_AUTO_TEST_SUITE(convert_functions)
   }
 
   BOOST_AUTO_TEST_CASE(CONVERT_REAL_TO_XINT) {
-    CIEC_REAL roundUpReal(50.5f);
-    CIEC_REAL roundDownReal(50.4f);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(1.6_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(-1.6_REAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(1.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(-1.5_REAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(1.4_REAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(-1.4_REAL)) == -1);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(2.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(-2.5_REAL)) == -2);
 
-    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_REAL_TO_SINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(roundDownReal)) == 50);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(1.6_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(-1.6_REAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(1.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(-1.5_REAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(1.4_REAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(-1.4_REAL)) == -1);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(2.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_REAL_TO_INT(-2.5_REAL)) == -2);
 
-    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(roundDownReal)) == 50);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(1.6_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(-1.6_REAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(1.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(-1.5_REAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(1.4_REAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(-1.4_REAL)) == -1);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(2.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_REAL_TO_DINT(-2.5_REAL)) == -2);
+
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(1.6_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(-1.6_REAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(1.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(-1.5_REAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(1.4_REAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(-1.4_REAL)) == -1);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(2.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_REAL_TO_LINT(-2.5_REAL)) == -2);
+
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(1.6_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(-1.6_REAL)) == CIEC_USINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(1.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(-1.5_REAL)) == CIEC_USINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(1.4_REAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(-1.4_REAL)) == CIEC_USINT::TValueType(-1));
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(2.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_REAL_TO_USINT(-2.5_REAL)) == CIEC_USINT::TValueType(-2));
+
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(1.6_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(-1.6_REAL)) == CIEC_UINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(1.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(-1.5_REAL)) == CIEC_UINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(1.4_REAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(-1.4_REAL)) == CIEC_UINT::TValueType(-1));
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(2.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_REAL_TO_UINT(-2.5_REAL)) == CIEC_UINT::TValueType(-2));
+
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(1.6_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(-1.6_REAL)) == CIEC_UDINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(1.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(-1.5_REAL)) == CIEC_UDINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(1.4_REAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(-1.4_REAL)) == CIEC_UDINT::TValueType(-1));
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(2.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_REAL_TO_UDINT(-2.5_REAL)) == CIEC_UDINT::TValueType(-2));
+
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(1.6_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(-1.6_REAL)) == CIEC_ULINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(1.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(-1.5_REAL)) == CIEC_ULINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(1.4_REAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(-1.4_REAL)) == CIEC_ULINT::TValueType(-1));
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(2.5_REAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_REAL_TO_ULINT(-2.5_REAL)) == CIEC_ULINT::TValueType(-2));
   }
 
   BOOST_AUTO_TEST_CASE(CONVERT_LREAL_TO_XINT) {
-    CIEC_LREAL roundUpReal(50.5f);
-    CIEC_LREAL roundDownReal(50.4f);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(1.6_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(-1.6_LREAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(1.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(-1.5_LREAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(1.4_LREAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(-1.4_LREAL)) == -1);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(2.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(-2.5_LREAL)) == -2);
 
-    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_SINT::TValueType>(func_LREAL_TO_SINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(roundDownReal)) == 50);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(1.6_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(-1.6_LREAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(1.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(-1.5_LREAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(1.4_LREAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(-1.4_LREAL)) == -1);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(2.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_INT::TValueType>(func_LREAL_TO_INT(-2.5_LREAL)) == -2);
 
-    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(roundDownReal)) == 50);
-    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(roundUpReal)) == 51);
-    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(roundDownReal)) == 50);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(1.6_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(-1.6_LREAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(1.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(-1.5_LREAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(1.4_LREAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(-1.4_LREAL)) == -1);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(2.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_DINT::TValueType>(func_LREAL_TO_DINT(-2.5_LREAL)) == -2);
+
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(1.6_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(-1.6_LREAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(1.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(-1.5_LREAL)) == -2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(1.4_LREAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(-1.4_LREAL)) == -1);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(2.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(func_LREAL_TO_LINT(-2.5_LREAL)) == -2);
+
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(1.6_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(-1.6_LREAL)) == CIEC_USINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(1.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(-1.5_LREAL)) == CIEC_USINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(1.4_LREAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(-1.4_LREAL)) == CIEC_USINT::TValueType(-1));
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(2.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_USINT::TValueType>(func_LREAL_TO_USINT(-2.5_LREAL)) == CIEC_USINT::TValueType(-2));
+
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(1.6_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(-1.6_LREAL)) == CIEC_UINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(1.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(-1.5_LREAL)) == CIEC_UINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(1.4_LREAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(-1.4_LREAL)) == CIEC_UINT::TValueType(-1));
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(2.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UINT::TValueType>(func_LREAL_TO_UINT(-2.5_LREAL)) == CIEC_UINT::TValueType(-2));
+
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(1.6_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(-1.6_LREAL)) == CIEC_UDINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(1.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(-1.5_LREAL)) == CIEC_UDINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(1.4_LREAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(-1.4_LREAL)) == CIEC_UDINT::TValueType(-1));
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(2.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_UDINT::TValueType>(func_LREAL_TO_UDINT(-2.5_LREAL)) == CIEC_UDINT::TValueType(-2));
+
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(1.6_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(-1.6_LREAL)) == CIEC_ULINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(1.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(-1.5_LREAL)) == CIEC_ULINT::TValueType(-2));
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(1.4_LREAL)) == 1);
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(-1.4_LREAL)) == CIEC_ULINT::TValueType(-1));
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(2.5_LREAL)) == 2);
+    BOOST_TEST(static_cast<CIEC_ULINT::TValueType>(func_LREAL_TO_ULINT(-2.5_LREAL)) == CIEC_ULINT::TValueType(-2));
   }
 
   BOOST_AUTO_TEST_CASE(CONVERT_TIME_TO_S_LINT) {


### PR DESCRIPTION
Fix rounding for real to integer conversions to use the current rounding mode, which rounds towards the nearest even integer by default according to IEEE 754 (IEC 60559) and in conformance with IEC 61131-3.