### PR TITLE
Add open62541 and mqtt as separate actions into the github workflows

### DIFF
--- a/.github/actions/mqtt/action.yml
+++ b/.github/actions/mqtt/action.yml
@@ -1,0 +1,52 @@
+name: Clone and compile paho-mqtt
+author: Jose Cabral
+Description: "Clone paho-mqtt and build a release static library with SSL disabled"
+
+inputs:
+  git_version:
+    type: string
+    Decription: Version of paho-mqtt to clone
+    required: True
+  
+  c_compiler:
+    type: string
+    Description: C compiler to use, passed as CMAKE_C_COMPILER to CMake
+    required: True
+
+outputs:
+  mqtt-include:
+    value: ${{ steps.vars.outputs.mqtt-include }}
+    description: The include directory
+  mqtt-lib-dir:
+    value: ${{ steps.vars.outputs.mqtt-lib-dir }}
+    description: The library directory
+
+runs:
+  using: "composite"
+  steps:
+    - name: Clone paho-mqtt
+      shell: bash
+      run: |
+        git clone https://github.com/eclipse/paho.mqtt.c.git -b ${{ inputs.git_version }}
+      
+    - name: Build paho-mqtt
+      shell: bash
+      run: |
+        cd paho.mqtt.c
+
+        cmake \
+        -B static \
+        -DCMAKE_C_COMPILER=${{ inputs.c_compiler }} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DPAHO_BUILD_STATIC=ON \
+        -DPAHO_BUILD_SHARED=OFF \
+        -DPAHO_WITH_SSL=OFF
+        
+        cmake --build static --config Release
+
+    - name: Output variables
+      id: vars
+      shell: bash
+      run: |
+        echo "mqtt-include=${{ github.workspace }}/paho.mqtt.c/src" >> "$GITHUB_OUTPUT"
+        echo "mqtt-lib-dir=${{ github.workspace }}/paho.mqtt.c/static/src" >> "$GITHUB_OUTPUT"

--- a/.github/actions/mqtt/action.yml
+++ b/.github/actions/mqtt/action.yml
@@ -13,6 +13,11 @@ inputs:
     Description: C compiler to use, passed as CMAKE_C_COMPILER to CMake
     required: True
 
+  platform:
+    type: string
+    Description: The platform where this job is running. "windows-latest" or anything else are valid values
+    required: True
+
 outputs:
   mqtt-include:
     value: ${{ steps.vars.outputs.mqtt-include }}
@@ -20,6 +25,9 @@ outputs:
   mqtt-lib-dir:
     value: ${{ steps.vars.outputs.mqtt-lib-dir }}
     description: The library directory
+  mqtt-lib:
+    value: ${{ steps.vars.outputs.mqtt-lib }}
+    description: The library to link to
 
 runs:
   using: "composite"
@@ -49,4 +57,5 @@ runs:
       shell: bash
       run: |
         echo "mqtt-include=${{ github.workspace }}/paho.mqtt.c/src" >> "$GITHUB_OUTPUT"
-        echo "mqtt-lib-dir=${{ github.workspace }}/paho.mqtt.c/static/src" >> "$GITHUB_OUTPUT"
+        echo "mqtt-lib-dir=${{ github.workspace }}/paho.mqtt.c/static/src/${{ inputs.platform == 'windows-latest' && 'Release' || '' }}" >> "$GITHUB_OUTPUT"
+        echo "mqtt-lib=${{ inputs.platform == 'windows-latest' && 'paho-mqtt3a-static.lib' || 'libpaho-mqtt3a.a' }}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/opc_ua/action.yml
+++ b/.github/actions/opc_ua/action.yml
@@ -1,0 +1,64 @@
+name: Clone and compile open62541
+author: Jose Cabral
+Description: "Clone open62541 and build a release static library with discovery multicast and events"
+
+inputs:
+  git_version:
+    type: string
+    Decription: Version of open62541 to clone
+    required: True
+  
+  cpp_compiler:
+    type: string
+    Description: C++ compiler to use, passed as CMAKE_CXX_COMPILER to CMake
+    required: True
+    
+  c_compiler:
+    type: string
+    Description: C compiler to use, passed as CMAKE_C_COMPILER to CMake
+    required: True
+
+outputs:
+  opc_ua-include:
+    value: ${{ steps.vars.outputs.opc_ua-include }}
+    description: The include directory
+  opc_ua-lib-dir:
+    value: ${{ steps.vars.outputs.opc_ua-lib-dir }}
+    description: The library directory
+
+runs:
+  using: "composite"
+  steps:
+    - name: Clone open62541
+      shell: bash
+      run: |
+        git clone https://github.com/open62541/open62541 -b ${{ inputs.git_version }}
+        
+        cd open62541
+        git submodule update --recursive --init
+      
+    - name: Build open62541
+      shell: bash
+      run: |
+        cd open62541
+
+        cmake \
+          -B static \
+          -DCMAKE_CXX_COMPILER=${{ inputs.cpp_compiler }} \
+          -DCMAKE_C_COMPILER=${{ inputs.c_compiler }} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DUA_ENABLE_AMALGAMATION=ON \
+          -DUA_ENABLE_DISCOVERY=ON \
+          -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
+          -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
+          -DUA_FORCE_WERROR=OFF \
+          -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
+
+        cmake --build static
+
+    - name: Output variables
+      id: vars
+      shell: bash
+      run: |
+        echo "opc_ua-include=${{ github.workspace }}/open62541/static" >> "$GITHUB_OUTPUT"
+        echo "opc_ua-lib-dir=${{ github.workspace }}/open62541/static/bin" >> "$GITHUB_OUTPUT"

--- a/.github/actions/opc_ua/action.yml
+++ b/.github/actions/opc_ua/action.yml
@@ -8,14 +8,14 @@ inputs:
     Decription: Version of open62541 to clone
     required: True
   
-  cpp_compiler:
-    type: string
-    Description: C++ compiler to use, passed as CMAKE_CXX_COMPILER to CMake
-    required: True
-    
   c_compiler:
     type: string
     Description: C compiler to use, passed as CMAKE_C_COMPILER to CMake
+    required: True
+
+  platform:
+    type: string
+    Description: The platform where this job is running. "windows-latest" or anything else are valid values
     required: True
 
 outputs:
@@ -25,6 +25,9 @@ outputs:
   opc_ua-lib-dir:
     value: ${{ steps.vars.outputs.opc_ua-lib-dir }}
     description: The library directory
+  opc_ua-lib:
+    value: ${{ steps.vars.outputs.opc_ua-lib }}
+    description: The library to link to
 
 runs:
   using: "composite"
@@ -36,15 +39,14 @@ runs:
         
         cd open62541
         git submodule update --recursive --init
-      
+    
     - name: Build open62541
       shell: bash
       run: |
         cd open62541
 
         cmake \
-          -B static \
-          -DCMAKE_CXX_COMPILER=${{ inputs.cpp_compiler }} \
+          -B amalgamated \
           -DCMAKE_C_COMPILER=${{ inputs.c_compiler }} \
           -DCMAKE_BUILD_TYPE=Release \
           -DUA_ENABLE_AMALGAMATION=ON \
@@ -52,13 +54,16 @@ runs:
           -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_FORCE_WERROR=OFF \
-          -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF
+          -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
+          -DBUILD_SHARED_LIBS=ON
 
-        cmake --build static
+        cmake --build amalgamated
 
+      # When AMALGAMATED=ON open62541 builds only a shared library for some reason 
     - name: Output variables
       id: vars
       shell: bash
       run: |
-        echo "opc_ua-include=${{ github.workspace }}/open62541/static" >> "$GITHUB_OUTPUT"
-        echo "opc_ua-lib-dir=${{ github.workspace }}/open62541/static/bin" >> "$GITHUB_OUTPUT"
+        echo "opc_ua-include=${{ github.workspace }}/open62541/amalgamated" >> "$GITHUB_OUTPUT"
+        echo "opc_ua-lib-dir=${{ github.workspace }}/open62541/amalgamated/bin/${{ inputs.platform == 'windows-latest' && matrix.build_type || '' }}" >> "$GITHUB_OUTPUT"
+        echo "opc_ua-lib=${{ inputs.platform == 'windows-latest' && 'open62541.dll' || 'libopen62541.so' }}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/opc_ua/action.yml
+++ b/.github/actions/opc_ua/action.yml
@@ -50,8 +50,6 @@ runs:
           -DCMAKE_C_COMPILER=${{ inputs.c_compiler }} \
           -DCMAKE_BUILD_TYPE=Release \
           -DUA_ENABLE_AMALGAMATION=ON \
-          -DUA_ENABLE_DISCOVERY=ON \
-          -DUA_ENABLE_DISCOVERY_MULTICAST=ON \
           -DUA_ENABLE_SUBSCRIPTIONS_EVENTS=ON \
           -DUA_FORCE_WERROR=OFF \
           -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
@@ -66,4 +64,4 @@ runs:
       run: |
         echo "opc_ua-include=${{ github.workspace }}/open62541/amalgamated" >> "$GITHUB_OUTPUT"
         echo "opc_ua-lib-dir=${{ github.workspace }}/open62541/amalgamated/bin/${{ inputs.platform == 'windows-latest' && matrix.build_type || '' }}" >> "$GITHUB_OUTPUT"
-        echo "opc_ua-lib=${{ inputs.platform == 'windows-latest' && 'open62541.dll' || 'libopen62541.so' }}" >> "$GITHUB_OUTPUT"
+        echo "opc_ua-lib=${{ github.workspace }}/open62541/amalgamated/bin/${{ inputs.platform == 'windows-latest' && matrix.build_type/'open62541.lib' || 'libopen62541.so' }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -65,6 +65,14 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: nuget install boost -Version 1.84.0
 
+    - name: clone and build open62541
+      id: open62541
+      uses: ./.github/actions/opc_ua
+      with:
+        git_version: v1.3.9
+        cpp_compiler: ${{ matrix.cpp_compiler }}
+        c_compiler: ${{ matrix.c_compiler }}
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
@@ -80,6 +88,10 @@ jobs:
         -DFORTE_COM_FBDK=ON
         -DFORTE_COM_HTTP=ON
         -DFORTE_COM_LOCAL=ON
+        -DFORTE_COM_OPC_UA=ON
+        -DFORTE_COM_OPC_UA_INCLUDE_DIR=${{ steps.open62541.outputs.opc_ua-include }}
+        -DFORTE_COM_OPC_UA_LIB_DIR=${{ steps.open62541.outputs.opc_ua-lib-dir }}/${{ matrix.os == 'windows-latest' && matrix.build_type || '' }}
+        -DFORTE_COM_OPC_UA_MULTICAST=ON
         -DFORTE_COM_RAW=ON
         -DFORTE_COM_SER=ON
         -DFORTE_COM_STRUCT_MEMBER=ON

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -73,6 +73,13 @@ jobs:
         cpp_compiler: ${{ matrix.cpp_compiler }}
         c_compiler: ${{ matrix.c_compiler }}
 
+    - name: clone and build paho-mqtt
+      id: paho-mqtt
+      uses: ./.github/actions/mqtt
+      with:
+        git_version: v1.3.13
+        c_compiler: ${{ matrix.c_compiler }}
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
@@ -92,6 +99,10 @@ jobs:
         -DFORTE_COM_OPC_UA_INCLUDE_DIR=${{ steps.open62541.outputs.opc_ua-include }}
         -DFORTE_COM_OPC_UA_LIB_DIR=${{ steps.open62541.outputs.opc_ua-lib-dir }}/${{ matrix.os == 'windows-latest' && matrix.build_type || '' }}
         -DFORTE_COM_OPC_UA_MULTICAST=ON
+        -DFORTE_COM_PAHOMQTT=ON
+        -DFORTE_COM_PAHOMQTT_INCLUDE_DIR=${{ steps.paho-mqtt.outputs.mqtt-include }}
+        -DFORTE_COM_PAHOMQTT_LIB_DIR=${{ steps.paho-mqtt.outputs.mqtt-lib-dir }}/${{ matrix.os == 'windows-latest' && 'Release' || '' }}
+        -DFORTE_COM_PAHOMQTT_LIB=${{ matrix.os == 'windows-latest' && 'paho-mqtt3a-static.lib' || 'libpaho-mqtt3a.a' }}
         -DFORTE_COM_RAW=ON
         -DFORTE_COM_SER=ON
         -DFORTE_COM_STRUCT_MEMBER=ON

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -100,7 +100,6 @@ jobs:
         -DFORTE_COM_OPC_UA_INCLUDE_DIR=${{ steps.open62541.outputs.opc_ua-include }}
         -DFORTE_COM_OPC_UA_LIB_DIR=${{ steps.open62541.outputs.opc_ua-lib-dir }}
         -DFORTE_COM_OPC_UA_LIB=${{ steps.open62541.outputs.opc_ua-lib }}
-        -DFORTE_COM_OPC_UA_MULTICAST=ON
         -DFORTE_COM_PAHOMQTT=ON
         -DFORTE_COM_PAHOMQTT_INCLUDE_DIR=${{ steps.paho-mqtt.outputs.mqtt-include }}
         -DFORTE_COM_PAHOMQTT_LIB_DIR=${{ steps.paho-mqtt.outputs.mqtt-lib-dir }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -69,9 +69,9 @@ jobs:
       id: open62541
       uses: ./.github/actions/opc_ua
       with:
-        git_version: v1.3.9
-        cpp_compiler: ${{ matrix.cpp_compiler }}
+        git_version: v1.4.5
         c_compiler: ${{ matrix.c_compiler }}
+        platform: ${{ matrix.os }}
 
     - name: clone and build paho-mqtt
       id: paho-mqtt
@@ -79,6 +79,7 @@ jobs:
       with:
         git_version: v1.3.13
         c_compiler: ${{ matrix.c_compiler }}
+        platform: ${{ matrix.os }}
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -97,12 +98,13 @@ jobs:
         -DFORTE_COM_LOCAL=ON
         -DFORTE_COM_OPC_UA=ON
         -DFORTE_COM_OPC_UA_INCLUDE_DIR=${{ steps.open62541.outputs.opc_ua-include }}
-        -DFORTE_COM_OPC_UA_LIB_DIR=${{ steps.open62541.outputs.opc_ua-lib-dir }}/${{ matrix.os == 'windows-latest' && matrix.build_type || '' }}
+        -DFORTE_COM_OPC_UA_LIB_DIR=${{ steps.open62541.outputs.opc_ua-lib-dir }}
+        -DFORTE_COM_OPC_UA_LIB=${{ steps.open62541.outputs.opc_ua-lib }}
         -DFORTE_COM_OPC_UA_MULTICAST=ON
         -DFORTE_COM_PAHOMQTT=ON
         -DFORTE_COM_PAHOMQTT_INCLUDE_DIR=${{ steps.paho-mqtt.outputs.mqtt-include }}
-        -DFORTE_COM_PAHOMQTT_LIB_DIR=${{ steps.paho-mqtt.outputs.mqtt-lib-dir }}/${{ matrix.os == 'windows-latest' && 'Release' || '' }}
-        -DFORTE_COM_PAHOMQTT_LIB=${{ matrix.os == 'windows-latest' && 'paho-mqtt3a-static.lib' || 'libpaho-mqtt3a.a' }}
+        -DFORTE_COM_PAHOMQTT_LIB_DIR=${{ steps.paho-mqtt.outputs.mqtt-lib-dir }}
+        -DFORTE_COM_PAHOMQTT_LIB=${{ steps.paho-mqtt.outputs.mqtt-lib }}
         -DFORTE_COM_RAW=ON
         -DFORTE_COM_SER=ON
         -DFORTE_COM_STRUCT_MEMBER=ON


### PR DESCRIPTION
Merge parts of #66 and #67 but without modbus (to separate PRs) and without SSL for MQTT (since it is failing for [linux](https://github.com/eclipse-4diac/4diac-forte/actions/runs/10888263604/job/30212353315))

The main idea is to separate certains steps into their own files to have it more organized