### PR TITLE
fix and move ldsMe to its own class

### DIFF
--- a/src/com/opc_ua/CMakeLists.txt
+++ b/src/com/opc_ua/CMakeLists.txt
@@ -91,6 +91,8 @@ if (FORTE_COM_OPC_UA)
 
     add_subdirectory(FBs)    
     add_subdirectory(types)
+    add_subdirectory(detail)
+
     
     if(FORTE_COM_OPC_UA_ENCRYPTION)
       SET(FORTE_COM_OPC_UA_ENCRYPTION_INCLUDE_DIR "" CACHE STRING "ABSOLUTE path to encryption headers")

--- a/src/com/opc_ua/detail/CMakeLists.txt
+++ b/src/com/opc_ua/detail/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+if(FORTE_COM_OPC_UA_MULTICAST)
+  forte_add_sourcefile_hcpp(lds_me_handler)
+endif(FORTE_COM_OPC_UA_MULTICAST)

--- a/src/com/opc_ua/detail/lds_me_handler.cpp
+++ b/src/com/opc_ua/detail/lds_me_handler.cpp
@@ -1,0 +1,100 @@
+
+#include "lds_me_handler.h"
+
+#include "devlog.h"
+
+using namespace forte::com::opc_ua::detail;
+
+LdsMeHandler::ClientWithLds::ClientWithLds(const UA_String& paDiscoveryUrl) {
+  mClient = UA_Client_new();
+  UA_ClientConfig_setDefault(UA_Client_getConfig(mClient));
+  UA_String_copy(&paDiscoveryUrl, &mDiscoveryUrl);
+}
+
+LdsMeHandler::ClientWithLds::ClientWithLds(LdsMeHandler::ClientWithLds&& other) {
+  *this = std::move(other);
+}
+
+LdsMeHandler::ClientWithLds& LdsMeHandler::ClientWithLds::operator=(LdsMeHandler::ClientWithLds&& other ) {
+  mDiscoveryUrl = other.mDiscoveryUrl;
+  UA_String_init(&other.mDiscoveryUrl);
+  mClient = other.mClient;
+  other.mClient = nullptr;
+  return *this;
+} 
+
+LdsMeHandler::ClientWithLds::~ClientWithLds() {
+  if(mClient){
+    UA_Client_disconnect(mClient);
+    UA_Client_delete(mClient);
+  }
+  if(mDiscoveryUrl.data){
+    UA_String_clear(&mDiscoveryUrl);
+  }
+}
+
+LdsMeHandler::LdsMeHandler(UA_Server& paUaServer) : mUaServer{paUaServer}  {
+  UA_Server_setServerOnNetworkCallback(&mUaServer, serverOnNetworkCallback, this);
+}      
+
+void LdsMeHandler::configureServer(UA_ServerConfig& paUaServerConfig, const std::string& paServerName) {
+  // hostname will be added by mdns library
+  UA_String_clear(&paUaServerConfig.mdnsConfig.mdnsServerName);
+  paUaServerConfig.mdnsConfig.mdnsServerName = UA_String_fromChars(paServerName.c_str());
+  // Enable the mDNS announce and response functionality
+  paUaServerConfig.mdnsEnabled = true;
+}
+
+void LdsMeHandler::serverOnNetworkCallback(const UA_ServerOnNetwork* paServerOnNetwork, UA_Boolean paIsServerAnnounce, UA_Boolean paIsTxtReceived, void* paData) { 
+
+  auto handler = static_cast<LdsMeHandler*>(paData);
+
+  if(!paIsTxtReceived) {
+    return; // we wait until the corresponding TXT record is announced.
+  }
+
+  DEVLOG_DEBUG("[OPC UA LDS ME]: mDNS %s '%.*s' with url '%.*s'\n", paIsServerAnnounce ? "announce" : "remove", paServerOnNetwork->serverName.length,
+      paServerOnNetwork->serverName.data, paServerOnNetwork->discoveryUrl.length, paServerOnNetwork->discoveryUrl.data);
+
+  // check if server is LDS, and then register
+  UA_String ldsStr = UA_String_fromChars("LDS");
+  for(unsigned int i = 0; i < paServerOnNetwork->serverCapabilitiesSize; i++) {
+    if(UA_String_equal(&paServerOnNetwork->serverCapabilities[i], &ldsStr)) {
+      if(paIsServerAnnounce) {
+        handler->registerWithLds(paServerOnNetwork->discoveryUrl);
+      } else {
+        handler->removeLdsRegister(paServerOnNetwork->discoveryUrl);
+      }
+      break;
+    }
+  }
+  UA_String_clear(&ldsStr);
+}
+
+void LdsMeHandler::registerWithLds(const UA_String& paDiscoveryUrl) {
+  // check if already registered with the given LDS
+  for(const auto& clientWithLds : mRegisteredWithLds) {
+    if(UA_String_equal(&paDiscoveryUrl, &clientWithLds.mDiscoveryUrl)) {
+      return;
+    }
+  }
+
+  ClientWithLds clienWithLDS(paDiscoveryUrl);
+  UA_StatusCode retVal = UA_Server_addPeriodicServerRegisterCallback(&mUaServer, clienWithLDS.mClient, reinterpret_cast<const char*>(clienWithLDS.mDiscoveryUrl.data), 10 * 60 * 1000, 500, nullptr);
+  if( UA_STATUSCODE_GOOD != retVal) {
+    DEVLOG_ERROR("[OPC UA LDSME]: Could not register with LDS. Error: %s\n", UA_StatusCode_name(retVal));
+    return;
+  }
+  mRegisteredWithLds.emplace_back(std::move(clienWithLDS));
+  DEVLOG_INFO("[OPC UA LDSME]: Registered to LDS '%.*s'\n", paDiscoveryUrl.length, paDiscoveryUrl.data);
+}
+
+void LdsMeHandler::removeLdsRegister(const UA_String& paDiscoveryUrl) {
+  for(auto iter = mRegisteredWithLds.begin(); iter != mRegisteredWithLds.end(); iter++) {
+    if(UA_String_equal(&paDiscoveryUrl, &iter->mDiscoveryUrl)) {
+      DEVLOG_INFO("[OPC UA LDSME]: Unregistered from LDS '%.*s'\n", paDiscoveryUrl.length, paDiscoveryUrl.data);
+      mRegisteredWithLds.erase(iter);
+      break;
+    }
+  }
+}

--- a/src/com/opc_ua/detail/lds_me_handler.cpp
+++ b/src/com/opc_ua/detail/lds_me_handler.cpp
@@ -5,40 +5,18 @@
 
 using namespace forte::com::opc_ua::detail;
 
-LdsMeHandler::ClientWithLds::ClientWithLds(const UA_String& paDiscoveryUrl) {
-  mClient = UA_Client_new();
-  UA_ClientConfig_setDefault(UA_Client_getConfig(mClient));
-  UA_String_copy(&paDiscoveryUrl, &mDiscoveryUrl);
-}
-
-LdsMeHandler::ClientWithLds::ClientWithLds(LdsMeHandler::ClientWithLds&& other) {
-  *this = std::move(other);
-}
-
-LdsMeHandler::ClientWithLds& LdsMeHandler::ClientWithLds::operator=(LdsMeHandler::ClientWithLds&& other ) {
-  mDiscoveryUrl = other.mDiscoveryUrl;
-  UA_String_init(&other.mDiscoveryUrl);
-  mClient = other.mClient;
-  other.mClient = nullptr;
-  return *this;
-} 
-
-LdsMeHandler::ClientWithLds::~ClientWithLds() {
-  if(mClient){
-    UA_Client_disconnect(mClient);
-    UA_Client_delete(mClient);
-  }
-  if(mDiscoveryUrl.data){
-    UA_String_clear(&mDiscoveryUrl);
-  }
-}
-
 LdsMeHandler::LdsMeHandler(UA_Server& paUaServer) : mUaServer{paUaServer}  {
   UA_Server_setServerOnNetworkCallback(&mUaServer, serverOnNetworkCallback, this);
-}      
+}
+
+LdsMeHandler::~LdsMeHandler() {
+  for(const auto& registeredServer : mRegisteredServers){
+    deregisterDiscoveryServer(registeredServer.mString);
+  }
+  UA_Server_setServerOnNetworkCallback(&mUaServer, nullptr, nullptr);
+}
 
 void LdsMeHandler::configureServer(UA_ServerConfig& paUaServerConfig, const std::string& paServerName) {
-  // hostname will be added by mdns library
   UA_String_clear(&paUaServerConfig.mdnsConfig.mdnsServerName);
   paUaServerConfig.mdnsConfig.mdnsServerName = UA_String_fromChars(paServerName.c_str());
   // Enable the mDNS announce and response functionality
@@ -47,8 +25,6 @@ void LdsMeHandler::configureServer(UA_ServerConfig& paUaServerConfig, const std:
 
 void LdsMeHandler::serverOnNetworkCallback(const UA_ServerOnNetwork* paServerOnNetwork, UA_Boolean paIsServerAnnounce, UA_Boolean paIsTxtReceived, void* paData) { 
 
-  auto handler = static_cast<LdsMeHandler*>(paData);
-
   if(!paIsTxtReceived) {
     return; // we wait until the corresponding TXT record is announced.
   }
@@ -56,45 +32,69 @@ void LdsMeHandler::serverOnNetworkCallback(const UA_ServerOnNetwork* paServerOnN
   DEVLOG_DEBUG("[OPC UA LDS ME]: mDNS %s '%.*s' with url '%.*s'\n", paIsServerAnnounce ? "announce" : "remove", paServerOnNetwork->serverName.length,
       paServerOnNetwork->serverName.data, paServerOnNetwork->discoveryUrl.length, paServerOnNetwork->discoveryUrl.data);
 
-  // check if server is LDS, and then register
-  UA_String ldsStr = UA_String_fromChars("LDS");
+  // check if server is LDS
+  bool isServerLDS = false;
+
+  UA_StringRAII ldsStr("LDS");
   for(unsigned int i = 0; i < paServerOnNetwork->serverCapabilitiesSize; i++) {
-    if(UA_String_equal(&paServerOnNetwork->serverCapabilities[i], &ldsStr)) {
-      if(paIsServerAnnounce) {
-        handler->registerWithLds(paServerOnNetwork->discoveryUrl);
-      } else {
-        handler->removeLdsRegister(paServerOnNetwork->discoveryUrl);
-      }
+    if(UA_String_equal(&paServerOnNetwork->serverCapabilities[i], &ldsStr.mString)) {
+      isServerLDS = true;
       break;
     }
   }
-  UA_String_clear(&ldsStr);
-}
 
-void LdsMeHandler::registerWithLds(const UA_String& paDiscoveryUrl) {
-  // check if already registered with the given LDS
-  for(const auto& clientWithLds : mRegisteredWithLds) {
-    if(UA_String_equal(&paDiscoveryUrl, &clientWithLds.mDiscoveryUrl)) {
-      return;
-    }
-  }
-
-  ClientWithLds clienWithLDS(paDiscoveryUrl);
-  UA_StatusCode retVal = UA_Server_addPeriodicServerRegisterCallback(&mUaServer, clienWithLDS.mClient, reinterpret_cast<const char*>(clienWithLDS.mDiscoveryUrl.data), 10 * 60 * 1000, 500, nullptr);
-  if( UA_STATUSCODE_GOOD != retVal) {
-    DEVLOG_ERROR("[OPC UA LDSME]: Could not register with LDS. Error: %s\n", UA_StatusCode_name(retVal));
+  // skip non-LDS servers
+  if(!isServerLDS) {
     return;
   }
-  mRegisteredWithLds.emplace_back(std::move(clienWithLDS));
-  DEVLOG_INFO("[OPC UA LDSME]: Registered to LDS '%.*s'\n", paDiscoveryUrl.length, paDiscoveryUrl.data);
-}
 
-void LdsMeHandler::removeLdsRegister(const UA_String& paDiscoveryUrl) {
-  for(auto iter = mRegisteredWithLds.begin(); iter != mRegisteredWithLds.end(); iter++) {
-    if(UA_String_equal(&paDiscoveryUrl, &iter->mDiscoveryUrl)) {
-      DEVLOG_INFO("[OPC UA LDSME]: Unregistered from LDS '%.*s'\n", paDiscoveryUrl.length, paDiscoveryUrl.data);
-      mRegisteredWithLds.erase(iter);
+  auto handler = static_cast<LdsMeHandler*>(paData);
+
+  auto foundDiscoveryUrl = handler->mRegisteredServers.end();
+  for(auto iter = handler->mRegisteredServers.begin(); iter != handler->mRegisteredServers.end(); iter++) {
+    if(UA_String_equal(&paServerOnNetwork->discoveryUrl, &iter->mString)) {
+      foundDiscoveryUrl = iter;
       break;
     }
   }
+
+  // if a new server is being announced
+  if(paIsServerAnnounce && foundDiscoveryUrl == handler->mRegisteredServers.end()) {
+    if(handler->registerDiscoveryServer(paServerOnNetwork->discoveryUrl)){
+        handler->mRegisteredServers.emplace_back(paServerOnNetwork->discoveryUrl);
+    }
+  // if a known server is being un-announced
+  } else if(!paIsServerAnnounce && foundDiscoveryUrl != handler->mRegisteredServers.end()) {
+    handler->deregisterDiscoveryServer(foundDiscoveryUrl->mString);
+    handler->mRegisteredServers.erase(foundDiscoveryUrl);
+  }
+}
+
+bool LdsMeHandler::registerDiscoveryServer(const UA_String& paDiscoveryUrl) {
+  
+  UA_ClientConfig clientConfig;
+  memset(&clientConfig, 0, sizeof(UA_ClientConfig));
+  UA_ClientConfig_setDefault(&clientConfig);
+  auto retVal = UA_Server_registerDiscovery(&mUaServer, &clientConfig, paDiscoveryUrl, UA_STRING_NULL);
+  if( UA_STATUSCODE_GOOD != retVal) {
+    DEVLOG_ERROR("[OPC UA LDSME]: Could not register with LDS. Error: %s\n", UA_StatusCode_name(retVal));
+    return false;
+  }
+  DEVLOG_INFO("[OPC UA LDSME]: Registered to LDS '%.*s'\n", paDiscoveryUrl.length, paDiscoveryUrl.data);
+  return true;
+}
+
+void LdsMeHandler::deregisterDiscoveryServer(const UA_String& paDiscoveryUrl) {
+  UA_ClientConfig clientConfig;
+  memset(&clientConfig, 0, sizeof(UA_ClientConfig));
+  UA_ClientConfig_setDefault(&clientConfig);
+
+  auto retVal = UA_Server_deregisterDiscovery(&mUaServer, &clientConfig, paDiscoveryUrl);
+  // if unregister fails, we don't do anything else
+  if( UA_STATUSCODE_GOOD != retVal) {
+    DEVLOG_ERROR("[OPC UA LDSME]: Could not deregister with LDS. Error: %s\n", UA_StatusCode_name(retVal));
+    return;
+  }
+
+  DEVLOG_INFO("[OPC UA LDSME]: Unregistered from LDS '%.*s'\n", paDiscoveryUrl.length, paDiscoveryUrl.data);
 }

--- a/src/com/opc_ua/detail/lds_me_handler.h
+++ b/src/com/opc_ua/detail/lds_me_handler.h
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Jose Cabral
+ *      - initial integration of the OPC-UA protocol
+ *******************************************************************************/
+
+#ifndef SRC_COM_OPC_UA_DETAIL_LDSMEHANDLER_H_
+#define SRC_COM_OPC_UA_DETAIL_LDSMEHANDLER_H_
+
+#include <open62541.h>
+
+#include <vector>
+#include <string>
+
+namespace forte::com::opc_ua::detail {
+
+class LdsMeHandler {
+  public:
+    LdsMeHandler(UA_Server& paUaServer);
+    static void configureServer(UA_ServerConfig& paUaServerConfig, const std::string& paServerName);
+  
+  private:
+    void registerWithLds(const UA_String& paDiscoveryUrl);
+    void removeLdsRegister(const UA_String& paDiscoveryUrl);
+
+    static void serverOnNetworkCallback(const UA_ServerOnNetwork* paServerOnNetwork, UA_Boolean paIsServerAnnounce, UA_Boolean paIsTxtReceived, void* paData);
+
+    UA_Server& mUaServer;
+
+    class ClientWithLds {
+      public:
+        ClientWithLds(const UA_String& paDiscoveryUrl);
+        ~ClientWithLds();
+
+        ClientWithLds(ClientWithLds&& other);
+        ClientWithLds& operator=(ClientWithLds&& other);
+
+        ClientWithLds(ClientWithLds&) = delete;
+        ClientWithLds& operator=(ClientWithLds&) = delete;
+
+        UA_String mDiscoveryUrl;
+        UA_Client *mClient;
+    };
+
+    /**
+     * List of LDS servers where this instance is already registered.
+     */
+    std::vector<ClientWithLds> mRegisteredWithLds;
+};
+}
+
+#endif // SRC_COM_OPC_UA_DETAIL_LDSMEHANDLER_H_

--- a/src/com/opc_ua/detail/lds_me_handler.h
+++ b/src/com/opc_ua/detail/lds_me_handler.h
@@ -17,14 +17,32 @@
 
 #include <open62541.h>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace forte::com::opc_ua::detail {
 
+/**
+ * @brief Handles all things related to LDS-ME
+ * 
+ * Configures the server to accept LDS-ME messages and handles them accordingly.
+ */
 class LdsMeHandler {
   public:
+
+    /**
+     * @brief Constructor
+     * 
+     * @param paUaServer OpcUa server to handle
+     */
     LdsMeHandler(UA_Server& paUaServer);
+
+    /**
+     * @brief Sets the proper values to the server configuration so it accepts LDS-ME messages
+     * 
+     * @param paUaServerConfig configuration to be set
+     * @param paServerName server name to be used when registering to the discovery server 
+     */
     static void configureServer(UA_ServerConfig& paUaServerConfig, const std::string& paServerName);
   
   private:
@@ -35,6 +53,11 @@ class LdsMeHandler {
 
     UA_Server& mUaServer;
 
+    /**
+     * @brief For each discovery server, this class handles the opcua client connectig to it
+     * and the memory for the string holding the discovery url.
+     * 
+     */
     class ClientWithLds {
       public:
         ClientWithLds(const UA_String& paDiscoveryUrl);
@@ -50,9 +73,7 @@ class LdsMeHandler {
         UA_Client *mClient;
     };
 
-    /**
-     * List of LDS servers where this instance is already registered.
-     */
+    /// List of discovery servers where this instance is already registered
     std::vector<ClientWithLds> mRegisteredWithLds;
 };
 }

--- a/src/com/opc_ua/detail/lds_me_handler.h
+++ b/src/com/opc_ua/detail/lds_me_handler.h
@@ -19,7 +19,6 @@
 
 #include <string>
 #include <vector>
-#include <optional>
 
 namespace forte::com::opc_ua::detail {
 

--- a/src/com/opc_ua/opcua_local_handler.cpp
+++ b/src/com/opc_ua/opcua_local_handler.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2023 Florian Froschermeier <florian.froschermeier@tum.de>,
+ * Copyright (c) 2015, 2024 Florian Froschermeier <florian.froschermeier@tum.de>,
  *                          fortiss GmbH, Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -57,12 +57,6 @@ COPC_UA_Local_Handler::~COPC_UA_Local_Handler() {
     UA_NodeId_delete(const_cast<UA_NodeId*>(iter->mNodeId));
   }
   mNodesReferences.clear();
-
-#ifdef FORTE_COM_OPC_UA_MULTICAST
-  for(CSinglyLinkedList<UA_String*>::Iterator iter = mRegisteredWithLds.begin(); iter != mRegisteredWithLds.end(); ++iter) {
-    UA_String_delete(*iter);
-  }
-#endif //FORTE_COM_OPC_UA_MULTICAST
 }
 
 void COPC_UA_Local_Handler::enableHandler() {
@@ -91,11 +85,10 @@ void COPC_UA_Local_Handler::run() {
     configureUAServer(serverStrings, *uaServerConfig);
 
     if(initializeNodesets(*mUaServer)) {
-#ifdef FORTE_COM_OPC_UA_MULTICAST
-      UA_Server_setServerOnNetworkCallback(mUaServer, serverOnNetworkCallback, this);
-#endif //FORTE_COM_OPC_UA_MULTICAST
-
       UA_StatusCode retVal = UA_Server_run_startup(mUaServer);
+#ifdef FORTE_COM_OPC_UA_MULTICAST
+      mLdsMeHandler = std::make_unique<forte::com::opc_ua::detail::LdsMeHandler>(*mUaServer);
+#endif //FORTE_COM_OPC_UA_MULTICAST
       if(UA_STATUSCODE_GOOD == retVal) {
         mServerStarted.inc();
         while(isAlive()) {
@@ -166,10 +159,7 @@ void COPC_UA_Local_Handler::generateServerStrings(TForteUInt16 paUAServerPort, U
 
 void COPC_UA_Local_Handler::configureUAServer(UA_ServerStrings &paServerStrings, UA_ServerConfig &paUaServerConfig) const {
 #ifdef FORTE_COM_OPC_UA_MULTICAST
-  paUaServerConfig.applicationDescription.applicationType = UA_APPLICATIONTYPE_DISCOVERYSERVER;
-  // hostname will be added by mdns library
-  UA_String_clear(&paUaServerConfig.mdnsConfig.mdnsServerName);
-  paUaServerConfig.mdnsConfig.mdnsServerName = UA_String_fromChars(paServerStrings.mMdnsServerName.c_str());
+  forte::com::opc_ua::detail::LdsMeHandler::configureServer(paUaServerConfig, paServerStrings.mMdnsServerName);
 #endif //FORTE_COM_OPC_UA_MULTICAST
 
   UA_Array_delete(paUaServerConfig.serverUrls, paUaServerConfig.serverUrlsSize, &UA_TYPES[UA_TYPES_STRING]);
@@ -280,85 +270,7 @@ void COPC_UA_Local_Handler::getNodesReferencedByAction(const CActionInfo &paActi
   }
 }
 
-#ifdef FORTE_COM_OPC_UA_MULTICAST
 
-const UA_String* COPC_UA_Local_Handler::getDiscoveryUrl() const {
-
-  UA_ServerConfig *mServerConfig = UA_Server_getConfig(mUaServer); //change mServerConfig to serverConfig when only master branch is present
-  if(0 == mServerConfig->networkLayersSize) {
-    return 0;
-  }
-  return &mServerConfig->networkLayers[0].discoveryUrl;
-}
-
-void COPC_UA_Local_Handler::serverOnNetworkCallback(const UA_ServerOnNetwork *paServerOnNetwork, UA_Boolean paIsServerAnnounce, UA_Boolean paIsTxtReceived,
-    void *paData) { //NOSONAR
-  COPC_UA_Local_Handler *handler = static_cast<COPC_UA_Local_Handler*>(paData);
-
-  const UA_String *ownDiscoverUrl = handler->getDiscoveryUrl();
-
-  if(!ownDiscoverUrl || UA_String_equal(&paServerOnNetwork->discoveryUrl, ownDiscoverUrl)) {
-    // skip self
-    return;
-  }
-
-  if(!paIsTxtReceived) {
-    return; // we wait until the corresponding TXT record is announced.
-  }
-
-  DEVLOG_DEBUG("[OPC UA LOCAL]: mDNS %s '%.*s' with url '%.*s'\n", paIsServerAnnounce ? "announce" : "remove", paServerOnNetwork->serverName.length,
-      paServerOnNetwork->serverName.data, paServerOnNetwork->discoveryUrl.length, paServerOnNetwork->discoveryUrl.data);
-
-  // check if server is LDS, and then register
-  UA_String ldsStr = UA_String_fromChars("LDS");
-  for(unsigned int i = 0; i < paServerOnNetwork->serverCapabilitiesSize; i++) {
-    if(UA_String_equal(&paServerOnNetwork->serverCapabilities[i], &ldsStr)) {
-      if(paIsServerAnnounce) {
-        handler->registerWithLds(&paServerOnNetwork->discoveryUrl);
-      } else {
-        handler->removeLdsRegister(&paServerOnNetwork->discoveryUrl);
-      }
-      break;
-    }
-  }
-  UA_String_clear(&ldsStr);
-}
-
-void COPC_UA_Local_Handler::registerWithLds(const UA_String *paDiscoveryUrl) {
-  // check if already registered with the given LDS
-  for(CSinglyLinkedList<UA_String*>::Iterator iter = mRegisteredWithLds.begin(); iter != mRegisteredWithLds.end(); ++iter) {
-    if(UA_String_equal(paDiscoveryUrl, *iter)) {
-      return;
-    }
-  }
-
-  // will be freed when removed from list
-  UA_String *discoveryUrlChar = 0;
-  UA_String_copy(paDiscoveryUrl, discoveryUrlChar);
-
-  mRegisteredWithLds.pushFront(discoveryUrlChar);
-  DEVLOG_INFO("[OPC UA LOCAL]: Registering with LDS '%.*s'\n", paDiscoveryUrl->length, paDiscoveryUrl->data);
-  UA_StatusCode retVal = UA_Server_addPeriodicServerRegisterCallback(mUaServer, 0, reinterpret_cast<const char*>(discoveryUrlChar->data), 10 * 60 * 1000, 500, 0);
-  if( UA_STATUSCODE_GOOD != retVal) {
-    DEVLOG_ERROR("[OPC UA LOCAL]: Could not register with LDS. Error: %s\n", UA_StatusCode_name(retVal));
-  }
-}
-
-void COPC_UA_Local_Handler::removeLdsRegister(const UA_String *paDiscoveryUrl) {
-  UA_String *toDelete = 0;
-  for(CSinglyLinkedList<UA_String*>::Iterator iter = mRegisteredWithLds.begin(); iter != mRegisteredWithLds.end(); ++iter) {
-    if(UA_String_equal(paDiscoveryUrl, *iter)) {
-      toDelete = *iter;
-      break;
-    }
-  }
-  if(toDelete) {
-    mRegisteredWithLds.erase(toDelete);
-    UA_String_delete(toDelete);
-  }
-}
-
-#endif //FORTE_COM_OPC_UA_MULTICAST
 
 UA_StatusCode COPC_UA_Local_Handler::initializeAction(CActionInfo &paActionInfo) {
   enableHandler();

--- a/src/com/opc_ua/opcua_local_handler.h
+++ b/src/com/opc_ua/opcua_local_handler.h
@@ -31,9 +31,6 @@
 #include "../../core/fortelist.h"
 #include "opcua_handler_abstract.h"
 #include "opcua_helper.h"
-#ifdef FORTE_COM_OPC_UA_MULTICAST
-#include "detail/lds_me_handler.h"
-#endif //FORTE_COM_OPC_UA_MULTICAST
 #include <string>
 
 /**
@@ -697,12 +694,6 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      * Default description for variable nodes
      */
     static const char *const mDefaultDescriptionForVariableNodes;
-
-#ifdef FORTE_COM_OPC_UA_MULTICAST
-    // pointer because the class has not default constructor
-    std::unique_ptr<forte::com::opc_ua::detail::LdsMeHandler> mLdsMeHandler; 
-#endif //FORTE_COM_OPC_UA_MULTICAST
-
 };
 
 #endif /* SRC_MODULES_OPC_UA_OPCUALOCALHANDLER_H_ */

--- a/src/com/opc_ua/opcua_local_handler.h
+++ b/src/com/opc_ua/opcua_local_handler.h
@@ -31,6 +31,9 @@
 #include "../../core/fortelist.h"
 #include "opcua_handler_abstract.h"
 #include "opcua_helper.h"
+#ifdef FORTE_COM_OPC_UA_MULTICAST
+#include "detail/lds_me_handler.h"
+#endif //FORTE_COM_OPC_UA_MULTICAST
 #include <string>
 
 /**
@@ -696,19 +699,8 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
     static const char *const mDefaultDescriptionForVariableNodes;
 
 #ifdef FORTE_COM_OPC_UA_MULTICAST
-# ifndef UA_ENABLE_DISCOVERY_MULTICAST
-#  error open62541 needs to be built with UA_ENABLE_DISCOVERY=ON and UA_ENABLE_DISCOVERY_MULTICAST=ON
-# else // UA_ENABLE_DISCOVERY_MULTICAST
-    /**
-     * List of LDS servers where this instance is already registered.
-     */
-    CSinglyLinkedList<UA_String*> mRegisteredWithLds;
-
-    const UA_String* getDiscoveryUrl() const;
-    void registerWithLds(const UA_String *paDiscoveryUrl);
-    void removeLdsRegister(const UA_String *paDiscoveryUrl);
-    static void serverOnNetworkCallback(const UA_ServerOnNetwork *paServerOnNetwork, UA_Boolean paIsServerAnnounce, UA_Boolean paIsTxtReceived, void *paData);
-# endif //UA_ENABLE_DISCOVERY_MULTICAST
+    // pointer because the class has not default constructor
+    std::unique_ptr<forte::com::opc_ua::detail::LdsMeHandler> mLdsMeHandler; 
 #endif //FORTE_COM_OPC_UA_MULTICAST
 
 };


### PR DESCRIPTION
This PR takes the fix from #75 which seems to have gone stale and moves all the logic related to the LDS-ME to its own class to have all encapsulated and make the LocalHandler lighter.

Pointers and deletions where also removed when possible and/or properly encapsulated for better memory managment.