### PR TITLE
Update compiler flags to remove "no deprecated warnig" declarations.

### DIFF
--- a/buildsupport/toolchains/toolchain-esp32-DualOut.cmake
+++ b/buildsupport/toolchains/toolchain-esp32-DualOut.cmake
@@ -4,8 +4,8 @@ SET(FORTE_ARCHITECTURE "FreeRTOSLwIP")
 
 
 
-set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions ")
+set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
 
 
 

--- a/buildsupport/toolchains/toolchain-esp32-Hutschienenmoped.cmake
+++ b/buildsupport/toolchains/toolchain-esp32-Hutschienenmoped.cmake
@@ -4,8 +4,8 @@ SET(FORTE_ARCHITECTURE "FreeRTOSLwIP")
 
 
 
-set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions -Wno-deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions -Wno-deprecated-declarations")
+set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
 
 
 

--- a/buildsupport/toolchains/toolchain-esp32-basic.cmake
+++ b/buildsupport/toolchains/toolchain-esp32-basic.cmake
@@ -4,8 +4,8 @@ SET(FORTE_ARCHITECTURE "FreeRTOSLwIP")
 
 
 
-set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions ")
+set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
 
 
 

--- a/buildsupport/toolchains/toolchain-esp32-datapanel.cmake
+++ b/buildsupport/toolchains/toolchain-esp32-datapanel.cmake
@@ -4,8 +4,8 @@ SET(FORTE_ARCHITECTURE "FreeRTOSLwIP")
 
 
 
-set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions -Wno-deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions -Wno-deprecated-declarations")
+set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
 
 
 

--- a/buildsupport/toolchains/toolchain-esp32s3-HutschienenmopedXL.cmake
+++ b/buildsupport/toolchains/toolchain-esp32s3-HutschienenmopedXL.cmake
@@ -4,8 +4,8 @@ SET(FORTE_ARCHITECTURE "FreeRTOSLwIP")
 
 
 
-set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions -Wno-deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions -Wno-deprecated-declarations")
+set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions")
 
 
 


### PR DESCRIPTION
Changed compiler flags to **exclude** "deprecated declarations" for C and C++ files in multiple toolchain configurations.
