### PR TITLE
Build errors on develop branch when enabling LUA (#583610)

### DIFF
--- a/src/core/lua/CMakeLists.txt
+++ b/src/core/lua/CMakeLists.txt
@@ -33,7 +33,7 @@ elseif("${FORTE_USE_LUATYPES}" STREQUAL "Lua")
     find_package(Lua REQUIRED)
   endif(NOT DEFINED LUA_FOUND)
 
-  forte_add_include_directories(${LUA_INCLUDE_DIR})
+  forte_add_include_directories(${LUA_INCLUDE_DIRS})
   forte_add_link_library(${LUA_LIBRARIES})
 
 endif("${FORTE_USE_LUATYPES}" STREQUAL "LuaJIT")

--- a/src/core/lua/luaadapter.cpp
+++ b/src/core/lua/luaadapter.cpp
@@ -24,7 +24,6 @@ CLuaAdapter::~CLuaAdapter() = default;
 
 bool CLuaAdapter::initialize() {
   //before calling super we need to configure the interface of the FB
-  setupFBInterface(getFBInterfaceSpec());
   return CAdapter::initialize();
 }
 

--- a/src/core/lua/luaadapter.cpp
+++ b/src/core/lua/luaadapter.cpp
@@ -22,12 +22,6 @@ CLuaAdapter::CLuaAdapter(CStringDictionary::TStringId paInstanceNameId, const CL
 
 CLuaAdapter::~CLuaAdapter() = default;
 
-bool CLuaAdapter::initialize() {
-  //before calling super we need to configure the interface of the FB
-  return CAdapter::initialize();
-}
-
-
 void CLuaAdapter::readInputData(TEventID paEIID) {
   if(nullptr != getFBInterfaceSpec().mEIWithIndexes && scmNoDataAssociated != getFBInterfaceSpec().mEIWithIndexes[paEIID]) {
     const TDataIOID *eiWithStart = &(getFBInterfaceSpec().mEIWith[getFBInterfaceSpec().mEIWithIndexes[paEIID]]);

--- a/src/core/lua/luaadapter.h
+++ b/src/core/lua/luaadapter.h
@@ -22,9 +22,6 @@ class CLuaAdapter : public CAdapter {
     CLuaAdapter(CStringDictionary::TStringId paInstanceNameId, const CLuaAdapterTypeEntry* paTypeEntry, bool paIsPlug, forte::core::CFBContainer &paContainer);
     ~CLuaAdapter() override;
 
-
-    bool initialize() override;
-
     CStringDictionary::TStringId getFBTypeId() const override {
       return mTypeEntry->getTypeNameId();
     }

--- a/src/core/lua/luaadaptertypeentry.h
+++ b/src/core/lua/luaadaptertypeentry.h
@@ -42,12 +42,12 @@ public:
 
   CAdapter* createAdapterInstance(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer, bool paIsPlug) override;
 
-  const SFBInterfaceSpec* getSocketInterfaceSpec() const {
-    return &mSocketInterfaceSpec;
+  const SFBInterfaceSpec & getSocketInterfaceSpec() const {
+    return mSocketInterfaceSpec;
   }
 
-  const SFBInterfaceSpec* getPlugInterfaceSpec() const {
-      return &mPlugInterfaceSpec;
+  const SFBInterfaceSpec & getPlugInterfaceSpec() const {
+      return mPlugInterfaceSpec;
   }
 };
 

--- a/src/core/lua/luabfb.cpp
+++ b/src/core/lua/luabfb.cpp
@@ -57,7 +57,7 @@ const char CLuaBFB::LUA_NAME[] = "FORTE_CLuaFB";
 const luaL_Reg CLuaBFB::LUA_FUNCS[] = { { "__index", CLuaFB_index }, { "__newindex", CLuaFB_newindex }, { "__call", CLuaFB_call }, { nullptr, nullptr } };
 
 CLuaBFB::CLuaBFB(CStringDictionary::TStringId paInstanceNameId, const CLuaBFBTypeEntry* paTypeEntry, forte::core::CFBContainer &paContainer) :
-    CGenFunctionBlock<CBasicFB>(paContainer, paTypeEntry->getInterfaceSpec(), paInstanceNameId, paTypeEntry->getInternalVarsInformation()),
+    CGenFunctionBlock<CBasicFB>(paContainer, paInstanceNameId, paTypeEntry->getInternalVarsInformation()),
         mTypeEntry(paTypeEntry) {
   CLuaEngine *luaEngine = getResource()->getLuaEngine();
   luaEngine->registerType<CLuaBFB>();
@@ -67,7 +67,6 @@ CLuaBFB::CLuaBFB(CStringDictionary::TStringId paInstanceNameId, const CLuaBFBTyp
 
 bool CLuaBFB::initialize() {
   //before calling super we need to configure the interface of the FB
-  setupFBInterface(getFBInterfaceSpec());
   createVarInternals();
   return CGenFunctionBlock<CBasicFB>::initialize();
 }

--- a/src/core/lua/luabfb.cpp
+++ b/src/core/lua/luabfb.cpp
@@ -57,7 +57,7 @@ const char CLuaBFB::LUA_NAME[] = "FORTE_CLuaFB";
 const luaL_Reg CLuaBFB::LUA_FUNCS[] = { { "__index", CLuaFB_index }, { "__newindex", CLuaFB_newindex }, { "__call", CLuaFB_call }, { nullptr, nullptr } };
 
 CLuaBFB::CLuaBFB(CStringDictionary::TStringId paInstanceNameId, const CLuaBFBTypeEntry* paTypeEntry, forte::core::CFBContainer &paContainer) :
-    CGenFunctionBlock<CBasicFB>(paContainer, paInstanceNameId, paTypeEntry->getInternalVarsInformation()),
+    CGenFunctionBlock<CBasicFB>(paContainer, paTypeEntry->getInterfaceSpec(), paInstanceNameId, paTypeEntry->getInternalVarsInformation()),
         mTypeEntry(paTypeEntry) {
   CLuaEngine *luaEngine = getResource()->getLuaEngine();
   luaEngine->registerType<CLuaBFB>();

--- a/src/core/lua/luabfb.h
+++ b/src/core/lua/luabfb.h
@@ -61,8 +61,7 @@ class CLuaBFB : public CGenFunctionBlock<CBasicFB> {
 
     bool initialize() override;
 
-    bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override {
-      paInterfaceSpec = mInterfaceSpec;
+    bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &) override {
       return true;
     }
 

--- a/src/core/lua/luabfb.h
+++ b/src/core/lua/luabfb.h
@@ -62,7 +62,7 @@ class CLuaBFB : public CGenFunctionBlock<CBasicFB> {
     bool initialize() override;
 
     bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override {
-      paInterfaceSpec = *mInterfaceSpec;
+      paInterfaceSpec = mInterfaceSpec;
       return true;
     }
 

--- a/src/core/lua/luabfbtypeentry.h
+++ b/src/core/lua/luabfbtypeentry.h
@@ -40,8 +40,8 @@ public:
 
   CFunctionBlock* createFBInstance(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) override;
 
-  const SFBInterfaceSpec* getInterfaceSpec() const {
-    return &m_interfaceSpec;
+  const SFBInterfaceSpec& getInterfaceSpec() const {
+    return m_interfaceSpec;
   }
 
   const SInternalVarsInformation* getInternalVarsInformation() const {

--- a/src/core/lua/luacfb.cpp
+++ b/src/core/lua/luacfb.cpp
@@ -19,16 +19,10 @@
 #include "criticalregion.h"
 
 CLuaCFB::CLuaCFB(CStringDictionary::TStringId paInstanceNameId, const CLuaCFBTypeEntry* paTypeEntry, SCFB_FBNData &paFbnData, forte::core::CFBContainer &paContainer) :
-    CGenFunctionBlock<CCompositeFB>(paContainer, paInstanceNameId, paFbnData), mTypeEntry(paTypeEntry) {
+    CGenFunctionBlock<CCompositeFB>(paContainer, paTypeEntry->getInterfaceSpec(), paInstanceNameId, paFbnData), mTypeEntry(paTypeEntry) {
 }
 
 CLuaCFB::~CLuaCFB() = default;
-
-
-bool CLuaCFB::initialize() {
-  //before calling super we need to configure the interface of the FB
-  return CGenFunctionBlock<CCompositeFB>::initialize();
-}
 
 bool CLuaCFB::createInternalFBs(){
   const SCFB_FBNData &fbnData = getFBNData();

--- a/src/core/lua/luacfb.cpp
+++ b/src/core/lua/luacfb.cpp
@@ -19,7 +19,7 @@
 #include "criticalregion.h"
 
 CLuaCFB::CLuaCFB(CStringDictionary::TStringId paInstanceNameId, const CLuaCFBTypeEntry* paTypeEntry, SCFB_FBNData &paFbnData, forte::core::CFBContainer &paContainer) :
-    CGenFunctionBlock<CCompositeFB>(paContainer, paTypeEntry->getInterfaceSpec(), paInstanceNameId, paFbnData), mTypeEntry(paTypeEntry) {
+    CGenFunctionBlock<CCompositeFB>(paContainer, paInstanceNameId, paFbnData), mTypeEntry(paTypeEntry) {
 }
 
 CLuaCFB::~CLuaCFB() = default;
@@ -27,7 +27,6 @@ CLuaCFB::~CLuaCFB() = default;
 
 bool CLuaCFB::initialize() {
   //before calling super we need to configure the interface of the FB
-  setupFBInterface(getFBInterfaceSpec());
   return CGenFunctionBlock<CCompositeFB>::initialize();
 }
 

--- a/src/core/lua/luacfb.h
+++ b/src/core/lua/luacfb.h
@@ -30,10 +30,7 @@ class CLuaCFB : public CGenFunctionBlock<CCompositeFB> {
       return mTypeEntry->getTypeNameId();
     }
 
-    bool initialize() override;
-
-    bool createInterfaceSpec(const char *, SFBInterfaceSpec &paInterfaceSpec) override {
-      paInterfaceSpec = mInterfaceSpec;
+    bool createInterfaceSpec(const char *, SFBInterfaceSpec &) override {
       return true;
     }
 

--- a/src/core/lua/luacfb.h
+++ b/src/core/lua/luacfb.h
@@ -33,7 +33,7 @@ class CLuaCFB : public CGenFunctionBlock<CCompositeFB> {
     bool initialize() override;
 
     bool createInterfaceSpec(const char *, SFBInterfaceSpec &paInterfaceSpec) override {
-      paInterfaceSpec = *mInterfaceSpec;
+      paInterfaceSpec = mInterfaceSpec;
       return true;
     }
 

--- a/src/core/lua/luacfbtypeentry.h
+++ b/src/core/lua/luacfbtypeentry.h
@@ -41,8 +41,8 @@ public:
 
   CFunctionBlock* createFBInstance(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) override;
 
-  const SFBInterfaceSpec* getInterfaceSpec() const {
-    return &m_interfaceSpec;
+  const SFBInterfaceSpec& getInterfaceSpec() const {
+    return m_interfaceSpec;
   }
 
   SCFB_FBNData& getFbnSpec(){


### PR DESCRIPTION
Build errors on develop branch when enabling LUA (#583610)
    
Fixed typo in src/core/lua/CMakeLists.txt.
Completed changes about mInterfaceSpec into a reference in src/core/lua folder.
    
Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=583610.
With these changes forte builds and runs with LUA enabled, but still does not work.
