### PR TITLE
Allow multiple ecet to be compiled

### DIFF
--- a/buildsupport/forte.cmake
+++ b/buildsupport/forte.cmake
@@ -152,7 +152,7 @@ FUNCTION(forte_replace_sourcefile_cpp)
 ENDFUNCTION(forte_replace_sourcefile_cpp)
 
 # Add a new possible timer to be created. Pass an extra variable to be used as 
-# name for the timer handler. If not passed, the default empty string will be used
+# name for the timer handler. If not passed, the default string will be used
 FUNCTION(forte_add_timerhandler CLASSNAME FILENAME) 
     set_property(GLOBAL APPEND PROPERTY FORTE_TIMERHANDLER_CLASS ${CLASSNAME})
     set_property(GLOBAL APPEND PROPERTY FORTE_TIMERHANDLER_FILENAME "${FILENAME}.h")
@@ -241,6 +241,12 @@ MACRO(forte_add_handler CLASSNAME FILENAME)
     set_property(GLOBAL APPEND PROPERTY FORTE_HANDLER_CLASS ${CLASSNAME})
     set_property(GLOBAL APPEND PROPERTY FORTE_HANDLER_FILENAME "${FILENAME}.h")
 ENDMACRO(forte_add_handler)
+
+MACRO(forte_add_ecet CLASSNAME FILENAME ECET_NAME)
+    set_property(GLOBAL APPEND PROPERTY FORTE_ECET_CLASS ${CLASSNAME})
+    set_property(GLOBAL APPEND PROPERTY FORTE_ECET_FILENAME "${FILENAME}.h")
+    set_property(GLOBAL APPEND PROPERTY FORTE_ECET_NAME "${ECET_NAME}")
+ENDMACRO(forte_add_ecet)
 
 MACRO(forte_add_startup_hook FUNCTION_NAME)
     set_property(GLOBAL APPEND PROPERTY FORTE_STARTUP_HOOK_FUNCTIONS ${FUNCTION_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,6 +160,42 @@ forte_replacefile_if_changed(${CMAKE_BINARY_DIR}/arch/timerHandlerFactory_new.cp
 file(REMOVE ${CMAKE_BINARY_DIR}/arch/timerHandlerFactory_new.cpp)
 
 #############################################################################
+# Configure ECETs
+#############################################################################
+
+GET_PROPERTY(ECET_CLASS GLOBAL PROPERTY FORTE_ECET_CLASS)
+GET_PROPERTY(ECET_FILENAME GLOBAL PROPERTY FORTE_ECET_FILENAME)
+GET_PROPERTY(ECET_NAME GLOBAL PROPERTY FORTE_ECET_NAME)
+
+LIST(LENGTH ECET_CLASS ECET_CLASS_LEN)
+math(EXPR ECET_CLASS_LEN  ${ECET_CLASS_LEN}-1)
+
+SET(ECET_INCLUDE "")
+SET(ECET_CREATE "")
+SET(ECET_ENUM "")
+
+
+FOREACH(POS RANGE ${ECET_CLASS_LEN})
+  LIST(GET ECET_CLASS      ${POS} CLASS) 
+  LIST(GET ECET_FILENAME   ${POS} FILENAME)
+  LIST(GET ECET_NAME   ${POS} NAME_)
+
+  SET(ECET_INCLUDE  "${ECET_INCLUDE}#include \"${FILENAME}\"\n")
+
+  SET(ECET_ENUM  "${ECET_ENUM}\n    ${NAME_},")
+
+  SET(ECET_CREATE "${ECET_CREATE}  if(ecetToCreate == AvailableEcets::${NAME_}) return new ${CLASS}();\n")
+  math(EXPR ECET_ID           ${ECET_ID}+1)
+ENDFOREACH(POS)
+
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/core/ecetFactory.cpp.in ${CMAKE_BINARY_DIR}/core/ecetFactory_new.cpp)
+forte_replacefile_if_changed(${CMAKE_BINARY_DIR}/core/ecetFactory_new.cpp ${CMAKE_BINARY_DIR}/core/ecetFactory.cpp)
+file(REMOVE ${CMAKE_BINARY_DIR}/core/ecetFactory_new.cpp)
+
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/core/ecetFactory.h.in ${CMAKE_BINARY_DIR}/core/ecetFactory_new.h)
+forte_replacefile_if_changed(${CMAKE_BINARY_DIR}/core/ecetFactory_new.h ${CMAKE_BINARY_DIR}/core/ecetFactory.h)
+file(REMOVE ${CMAKE_BINARY_DIR}/core/ecetFactory_new.h)
+#############################################################################
 # Configure startuphook
 #############################################################################
 GET_PROPERTY(STARTUP_HOOK_FUNCTIONS GLOBAL PROPERTY FORTE_STARTUP_HOOK_FUNCTIONS)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -37,7 +37,18 @@ forte_add_sourcefile_hcpp(adapterconn adapter anyadapter iec61131_functions)
 forte_add_sourcefile_h(forte_st_iterator.h)
 forte_add_sourcefile_h(forte_st_util.h)
 
+forte_add_ecet(CEventChainExecutionThread ecet "standard")
+
+forte_add_sourcefile_with_path_cpp(${CMAKE_BINARY_DIR}/core/ecetFactory.cpp) # created file
+
 forte_add_sourcefile_with_path_cpp(${CMAKE_BINARY_DIR}/core/deviceExecutionHandlers.cpp) # created file
+
+set(FORTE_USE_FAKE_ECET FALSE CACHE BOOL "Compile the fake ecet used for testing")
+mark_as_advanced(FORTE_USE_FAKE_ECET)
+if(FORTE_USE_FAKE_ECET)
+  forte_add_sourcefile_hcpp(ecetFake)
+  forte_add_ecet(CFakeEventExecutionThread "core/ecetFake" "fake")
+endif(FORTE_USE_FAKE_ECET)
 
 if(FORTE_DYNAMIC_TYPE_LOAD)
   forte_add_subdirectory(lua)

--- a/src/core/ecet.cpp
+++ b/src/core/ecet.cpp
@@ -22,7 +22,7 @@
 #include "../arch/devlog.h"
 
 CEventChainExecutionThread::CEventChainExecutionThread() :
-    CThread(), mSuspendSemaphore(false), mProcessingEvents(false){
+    CThread(){
   clear();
 }
 

--- a/src/core/ecet.h
+++ b/src/core/ecet.h
@@ -34,7 +34,7 @@ class CEventChainExecutionThread : public CThread{
      *
      * \param paEventToAdd event of the EC to start
      */
-    void startEventChain(TEventEntry paEventToAdd);
+    virtual void startEventChain(TEventEntry paEventToAdd);
 
     /*!\brief Add an new event entry to the event chain
      *
@@ -64,14 +64,16 @@ class CEventChainExecutionThread : public CThread{
       mSuspendSemaphore.inc();
     }
 
-    static CEventChainExecutionThread* createEcet();
-
   protected:
     /*! \brief List of input events to deliver.
      *
      * This list stores the necessary information for all events to deliver that occurred within this event chain.
      */
     forte::core::util::CRingBuffer<TEventEntry, cgEventChainEventListSize> mEventList;
+
+    void selfSuspend(){
+      mSuspendSemaphore.waitIndefinitely();
+    }
 
     void mainRun();
 
@@ -104,10 +106,6 @@ class CEventChainExecutionThread : public CThread{
     //! Transfer elements stored in the external event list to the main event list
     void transferExternalEvents();
 
-    void selfSuspend(){
-      mSuspendSemaphore.waitIndefinitely();
-    }
-
     /*! \brief List of external events that occurred during one FB's execution
      *
      * This list stores external events that may have occurred during the execution of a FB or during when the
@@ -129,7 +127,7 @@ class CEventChainExecutionThread : public CThread{
      * Currently this flag is only needed for the FB tester.
      * TODO consider surrounding the usage points of this flag with #defines such that it is only used for testing.
      */
-    bool mProcessingEvents;
+    bool mProcessingEvents{false};
 };
 
 #endif /*ECET_H_*/

--- a/src/core/ecetFactory.cpp.in
+++ b/src/core/ecetFactory.cpp.in
@@ -10,8 +10,21 @@
  *    Jose Cabral - initial API and implementation and/or initial documentation
  *******************************************************************************/
 
-#include "ecet.h"
+#include "ecetFactory.h"
 
-CEventChainExecutionThread* CEventChainExecutionThread::createEcet(){
-  return new CEventChainExecutionThread();
+${ECET_INCLUDE}
+
+namespace EcetFactory {
+
+AvailableEcets ecetToCreate{AvailableEcets::standard};
+
+void setEcetToCreate(AvailableEcets paEcet){
+  ecetToCreate = paEcet;
+}
+
+CEventChainExecutionThread* createEcet(){
+${ECET_CREATE}
+  return nullptr;
+}
+
 }

--- a/src/core/ecetFactory.h.in
+++ b/src/core/ecetFactory.h.in
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2018 - fortiss GmbH
- *
+ * Copyright (c) 2018 fortiss GmbH
+ * Copyright (c) 2024 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,11 +8,17 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    Jose Cabral - initial implementation and rework communication infrastructure
+ *    Jose Cabral - initial API and implementation and/or initial documentation
  *******************************************************************************/
 
-#include "fmuEcet.h"
+class CEventChainExecutionThread; 
 
-CEventChainExecutionThread* CEventChainExecutionThread::createEcet(){
-  return new CFMUEventChainExecutionThread();
-}
+namespace EcetFactory {
+
+  enum class AvailableEcets {${ECET_ENUM}
+  };
+
+  CEventChainExecutionThread* createEcet();
+
+  void setEcetToCreate(AvailableEcets paEcet);
+};

--- a/src/core/ecetFake.cpp
+++ b/src/core/ecetFake.cpp
@@ -29,7 +29,7 @@ void CFakeEventExecutionThread::triggerNextEvent(){
   if(!mProcessEventCallback.has_value()){
     return;
   }
-  mNewEventChainCallback.value()(*event);
+  mProcessEventCallback.value()(*event);
 }
 
 void CFakeEventExecutionThread::setCallbackForEventTriggering(std::optional<HandleEvent> paCallback) {

--- a/src/core/ecetFake.cpp
+++ b/src/core/ecetFake.cpp
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2018 - fortiss GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Jose Cabral - initial implementation and rework communication infrastructure
+ *******************************************************************************/
+
+#include "ecetFake.h"
+#include "funcbloc.h"
+
+CFakeEventExecutionThread::CFakeEventExecutionThread() :
+    CEventChainExecutionThread(){
+  setDefaultCallbackForNewEventChain();
+  setDefaultCallbackForEventTrigger();
+}
+
+void CFakeEventExecutionThread::triggerNextEvent(){
+  auto event = mEventList.pop();
+  if(nullptr == event){
+    return;
+  }
+
+  if(!mProcessEventCallback.has_value()){
+    return;
+  }
+  mNewEventChainCallback.value()(*event);
+}
+
+void CFakeEventExecutionThread::setCallbackForEventTriggering(std::optional<HandleEvent> paCallback) {
+  mProcessEventCallback = paCallback;
+}
+
+void CFakeEventExecutionThread::setDefaultCallbackForEventTrigger() {
+  mProcessEventCallback = [this](TEventEntry paEvent){
+    paEvent.mFB->receiveInputEvent(paEvent.mPortId, this);
+  };
+}
+
+void CFakeEventExecutionThread::startEventChain(TEventEntry paEvent) {
+  if(!mNewEventChainCallback.has_value()){
+    return;
+  }
+  mNewEventChainCallback.value()(paEvent);
+}
+
+void CFakeEventExecutionThread::setCallbackForNewEventChain(std::optional<HandleEvent> paCallback) {
+  mNewEventChainCallback = paCallback;
+}
+
+void CFakeEventExecutionThread::setDefaultCallbackForNewEventChain(){
+  mNewEventChainCallback = [this](TEventEntry paEvent){
+    CEventChainExecutionThread::startEventChain(paEvent);
+  };
+}
+
+void CFakeEventExecutionThread::removeExternalControl() {
+  setDefaultCallbackForNewEventChain();
+  setDefaultCallbackForEventTrigger();
+  mIsControlledFromOutside = false;      
+  resumeSelfSuspend();
+}
+
+void CFakeEventExecutionThread::insertFront(TEventEntry paEvent){
+  // the ring buffer does not have a way to insert in the front,
+  // so we create a new one and push the event first there and then the rest
+  // and then copy the events back to the original list
+  decltype(mEventList) temp;
+  temp.push(paEvent);
+  while(!mEventList.isEmpty()){
+    temp.push(*mEventList.pop());
+  }
+
+  while(!temp.isEmpty()){
+    mEventList.push(*temp.pop());
+  }
+}
+
+void CFakeEventExecutionThread::removeFromBack(size_t paNumberOfItemsToRemove){
+  std::vector<TEventEntry> temp;
+  while(!mEventList.isEmpty()){
+    temp.push_back(*mEventList.pop());
+  }
+
+  while(paNumberOfItemsToRemove-- != 0){
+    temp.pop_back();
+  }
+
+  for(auto& event : temp){
+    mEventList.push(event);
+  }
+}
+
+std::optional<TEventEntry> CFakeEventExecutionThread::getNextEvent(){
+  auto nextEvent = mEventList.pop(); // get a copy, but need to pop for it
+  if(nextEvent == nullptr){
+    return std::nullopt;
+  }
+
+  insertFront(*nextEvent);
+  return *nextEvent;
+}
+
+// we don't need the complexities of a separate thread, so 
+// the funtion just set to sleep when is controlled from outside
+void CFakeEventExecutionThread::run(){
+  while(isAlive()){
+    if(mIsControlledFromOutside){
+      selfSuspend();
+    } 
+    CEventChainExecutionThread::mainRun();
+  }
+}

--- a/src/core/ecetFake.h
+++ b/src/core/ecetFake.h
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2024 
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Jose Cabral - initial implementation and rework communication infrastructure
+ *******************************************************************************/
+#ifndef _CORE_FAKE_ECET_H_
+#define _CORE_FAKE_ECET_H_
+
+#include "ecet.h"
+
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+#include <set>
+#include <optional>
+
+/**
+ * @brief An ecet which can be fully controlled from outside the class 
+ * 
+ */
+class CFakeEventExecutionThread : public CEventChainExecutionThread{
+  public:
+
+    /**
+     * @brief Callback type for processing events 
+     */
+    typedef std::function<void(TEventEntry)> HandleEvent;
+
+
+    CFakeEventExecutionThread();
+    ~CFakeEventExecutionThread() override = default;
+
+    /**
+     * @brief Triggers the next event in the list if there's any
+     * 
+     * How the event trigger is handled can be configured via a callback. 
+     */
+    void triggerNextEvent();
+
+    /**
+     * @brief Set the callback that will be called for each event that is triggered.
+     * If set to std::nullopt, the event is supressed
+     * 
+     * @param paCallback Callback to be used
+     */
+    void setCallbackForEventTriggering(std::optional<HandleEvent> paCallback = std::nullopt);
+    
+    /**
+     * @brief Set the callback for event trigger to the default one, 
+     * which calls receiveInputEvent on the Function Block 
+     */
+    void setDefaultCallbackForEventTrigger();
+    
+    /**
+     * @brief Starts a new chain event. If a callback was set, it is called. * Initially,
+     * the callback is set to call the same function in the parent ecet
+     * 
+     * @param paEventToAdd event starting the chain 
+     */
+    void startEventChain(TEventEntry paEventToAdd) override;
+
+    /**
+     * @brief Set a new callback that will be called when a new event chain would be started. If set
+     * to std::nullopt, the new event chain is supressed
+     * 
+     * @param paCallback function to be called when a new chain of event starts
+     */
+    void setCallbackForNewEventChain(std::optional<HandleEvent> paCallback = std::nullopt);
+
+    /**
+     * @brief Set the callback for new event chains to the default one which calls the parent startEventChain
+     */
+    void setDefaultCallbackForNewEventChain();
+
+    /**
+     * @brief Let the ecet run freely and not controlled from outside anymore
+     */
+    void removeExternalControl();
+
+    /**
+     * @brief Insert a new event at the front of the list of events
+     * 
+     * @param paEvent event to be inserted
+     */
+    void insertFront(TEventEntry paEvent);
+
+    /**
+     * @brief Remove events from the back of the list of events
+     * 
+     * @param paNumberOfItemsToRemove number of events to remove from the back of the list
+     */
+    void removeFromBack(size_t paNumberOfItemsToRemove);
+
+    /**
+     * @brief Get a copy of next event to be triggered if any
+     * 
+     * @return The next event to be triggered, std::nullopt if there isn't any 
+     */
+    std::optional<TEventEntry> getNextEvent();
+
+private:
+
+    void run() override;
+    bool mIsControlledFromOutside{true};
+    std::optional<HandleEvent> mNewEventChainCallback;
+    std::optional<HandleEvent> mProcessEventCallback;
+};
+
+#endif /*_CORE_FAKE_ECET_H_*/

--- a/src/core/fmi/CMakeLists.txt
+++ b/src/core/fmi/CMakeLists.txt
@@ -35,15 +35,14 @@ if(FORTE_ENABLE_FMU)
 
   forte_add_subdirectory(comm)
 
-  forte_add_timerhandler(fmiTimerHandler fmiTimerHandler )
+  forte_add_timerhandler(fmiTimerHandler fmiTimerHandler "fmi")
+
+  forte_add_ecet(CFMUEventChainExecutionThread fmuEcet "fmi")
 
   forte_add_sourcefile_cpp(fmiInterface.cpp)
   forte_add_sourcefile_hcpp(fmuValueContainer fmuInstance processinterface fmuEcet fmiTimerHandler)
   forte_set_process_interface("FORTE FMU" IX QX IW QW)
-  forte_add_sourcefile_cpp(fmuEcetFactory.cpp)
   forte_add_sourcefile_hcpp(../../arch/utils/timespec_utils)
-
-else(FORTE_ENABLE_FMU)
-  forte_add_sourcefile_cpp(../ecetFactory.cpp)
+   
 endif(FORTE_ENABLE_FMU)
 

--- a/src/core/fmi/fmuEcet.h
+++ b/src/core/fmi/fmuEcet.h
@@ -29,7 +29,7 @@ class CFMUEventChainExecutionThread : public CEventChainExecutionThread{
     }
 
     bool hasMoreEvents(){
-      return (mEventListEnd != mEventListStart);
+      return !mEventList.isEmpty();
     }
 
     bool isInWaitingStepState(){

--- a/src/core/fmi/processinterface.h
+++ b/src/core/fmi/processinterface.h
@@ -27,7 +27,7 @@ class CFMUProcessInterface : public CProcessInterfaceBase{
 
     ~CFMUProcessInterface() override;
 
-    void executeEvent(TEventID ) override {};
+    void executeEvent(TEventID, CEventChainExecutionThread *const) override {};
 
   protected:
     bool initialise(bool paIsInput, CEventChainExecutionThread *const paECET);

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -29,7 +29,7 @@
 #include "if2indco.h"
 #include "utils/criticalregion.h"
 #include "utils/fixedcapvector.h"
-#include "ecet.h"
+#include "core/ecetFactory.h"
 
 #ifdef FORTE_DYNAMIC_TYPE_LOAD
 #include "lua/luaengine.h"
@@ -44,7 +44,7 @@ using namespace std::string_literals;
 
 CResource::CResource(forte::core::CFBContainer &paDevice, const SFBInterfaceSpec& paInterfaceSpec, const CStringDictionary::TStringId paInstanceNameId) :
     CFunctionBlock(paDevice, paInterfaceSpec, paInstanceNameId),
-    mResourceEventExecution(CEventChainExecutionThread::createEcet()), mResIf2InConnections(nullptr)
+    mResourceEventExecution(EcetFactory::createEcet()), mResIf2InConnections(nullptr)
 #ifdef FORTE_SUPPORT_MONITORING
 , mMonitoringHandler(*this)
 #endif

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -17,6 +17,7 @@
 
 #include <utility>
 
+#include "ecet.h"
 #include "fbcontainer.h"
 #include "funcbloc.h"
 #include "forte_sync.h"


### PR DESCRIPTION
Move the construction of the ecet outside of the class and allow to have multiple ones. I added a `fake ecet` which basically doesn't execute any event unless it's told to do so using public functions. Triggering of events and newEventChains can be hijacked to have full control of the list of events. Adding and removing events from the list is also possible. 

Performance-wise there's no change, since the previous version was also calling a function returning a pointer to a Ecet.

I introduced many `fake` thinks in the past weeks, so I'll move them into their own folder to clearly separate what belongs to testing/simulation stuff. But I'll do that in a separate PR.