### PR TITLE
Unregister Local Comm Layer to use GroupId #275

### DIFF
--- a/src/core/cominfra/localcomlayer.h
+++ b/src/core/cominfra/localcomlayer.h
@@ -73,12 +73,12 @@ namespace forte {
 
           public:
 
-            CLocalCommGroup* registerPubl(const CStringDictionary::TStringId paID, CLocalComLayer *paLayer);
-            CLocalCommGroup* registerPubl(const CStringDictionary::TStringId paID, CLocalComLayer *paLayer, CIEC_ANY **paDataPins, TPortId paNumDataPins);
-            void unregisterPubl(CLocalCommGroup *paGroup, CLocalComLayer *paLayer);
+            bool registerPubl(const CStringDictionary::TStringId paGroupID, CLocalComLayer *paLayer);
+            bool registerPubl(const CStringDictionary::TStringId paGroupID, CLocalComLayer *paLayer, CIEC_ANY **paDataPins, TPortId paNumDataPins);
+            void unregisterPubl(const CStringDictionary::TStringId paGroupID, CLocalComLayer *paLayer);
 
-            CLocalCommGroup* registerSubl(const CStringDictionary::TStringId paID, CLocalComLayer *paLayer);
-            void unregisterSubl(CLocalCommGroup *paGroup, CLocalComLayer *paLayer);
+            bool registerSubl(const CStringDictionary::TStringId paGroupID, CLocalComLayer *paLayer);
+            void unregisterSubl(const CStringDictionary::TStringId paGroupID, CLocalComLayer *paLayer);
 
             CLocalCommGroup* getComGroup(const CStringDictionary::TStringId paGroupID);
 
@@ -90,7 +90,7 @@ namespace forte {
             TLocalCommGroupList::iterator getLocalCommGroupIterator(CStringDictionary::TStringId paID);
 
             CLocalCommGroup* findOrCreateLocalCommGroup(CStringDictionary::TStringId paID, CIEC_ANY **paDataPins, TPortId paNumDataPins);
-            void removeCommGroup(CLocalCommGroup &paGroup);
+            void checkForGroupRemoval(TLocalCommGroupList::iterator comGroupIt);
 
             bool isGroupIteratorForGroup(TLocalCommGroupList::iterator iter, CStringDictionary::TStringId paID){
               return (iter != mLocalCommGroups.end() && iter->mGroupName == paID);
@@ -120,7 +120,6 @@ namespace forte {
           return smLocalCommGroupsManager;
         }
 
-        CLocalCommGroup *mLocalCommGroup;
         CStringDictionary::TStringId mGroupID;
 
       private:

--- a/src/core/cominfra/structmembercomlayer.cpp
+++ b/src/core/cominfra/structmembercomlayer.cpp
@@ -149,18 +149,19 @@ EComResponse CStructMemberLocalComLayer::openConnection(char *paLayerParameter){
     return e_InitInvalidId;
   }
 
-  switch (mFb->getComServiceType()){
+  switch(mFb->getComServiceType()){
     case e_Server:
     case e_Client:
       break;
     case e_Publisher: {
-      CIEC_ANY *dummySDs[] = {dummy};
-      mLocalCommGroup = getLocalCommGroupsManager().registerPubl(groupNameID, this, dummySDs, 1);
+      CIEC_ANY *dummySDs[] = { dummy };
+      if(!getLocalCommGroupsManager().registerPubl(groupNameID, this, dummySDs, 1)) {
+        return e_InitInvalidId;
       }
+    }
       break;
     case e_Subscriber:
       break;
   }
-  
-  return (nullptr != mLocalCommGroup) ? e_InitOk : e_InitInvalidId;
+  return e_InitOk;
 }


### PR DESCRIPTION
The local comm layer was using a pointer to a vector entry for deregistration. This pointer was not valid when other groups where created or deleted in the mean-time. This fix correctly uses the group identifier as it is already done on registration and sending of data.

Fixes: https://github.com/eclipse-4diac/4diac-forte/issues/275