### PR TITLE
Fix error with String Node Ids in Object Struct Helper

### DIFF
--- a/src/com/opc_ua/opcua_objectstruct_helper.h
+++ b/src/com/opc_ua/opcua_objectstruct_helper.h
@@ -140,11 +140,6 @@ class COPC_UA_ObjectStruct_Helper {
     std::shared_ptr<CActionInfo> mCreateNodeActionInfo;
 
     /**
-     * String NodeIds of OPCUA Struct Type Member Nodes 
-    */
-    std::vector<UA_NodeId> mStructTypeMemberNodes;
-
-    /**
      * ActionInfos of Struct members 
     */
     std::vector<std::shared_ptr<CActionInfo>> mStructMemberActionInfos;


### PR DESCRIPTION
The changes of #201 lead to a use-after-scope issue when creating Struct Types with String Node Ids in OPC UA, so additional changes are needed. In more detail, the `memberBrowsePathStr` variable in the `addOPCUAStructTypeComponent` method used a reference on a local buffer. I allocated memory to avoid this issue.