### PR TITLE
clean and fix internal tracer

### DIFF
--- a/src/core/trace/flexibleTracer.cpp
+++ b/src/core/trace/flexibleTracer.cpp
@@ -16,14 +16,14 @@
 
 #include "flexibleTracer.h"
 
-void CFlexibleTracer::setTracer(std::string paTracerName) {
-  CFlexibleTracer::mCurrentTracer = std::move(paTracerName);
+void CFlexibleTracer::setTracer(AvailableTracers paTracerType) {
+  CFlexibleTracer::mCurrentTracer = paTracerType;
 }
 
 CFlexibleTracer::CFlexibleTracer(CStringDictionary::TStringId instanceName, size_t bufferSize) {
-  if(mCurrentTracer == ""){
+  if(mCurrentTracer == AvailableTracers::BareCtf){
     mTracer.emplace<BarectfPlatformFORTE>(instanceName, bufferSize);
-  } else {
+  } else if (mCurrentTracer == AvailableTracers::Internal) {
     mTracer.emplace<CInternalTracer>(instanceName, bufferSize);
   }
 }

--- a/src/core/trace/flexibleTracer.h
+++ b/src/core/trace/flexibleTracer.h
@@ -31,6 +31,11 @@
 class CFlexibleTracer final {
 public: 
 
+    enum class AvailableTracers {
+      BareCtf,
+      Internal
+    };
+
     CFlexibleTracer(CStringDictionary::TStringId instanceName, size_t bufferSize);
 
     ~CFlexibleTracer() = default;
@@ -61,13 +66,13 @@ public:
 
     /**
      * @brief Select the tracer to use
-     * @param paTracerName An empty string to use the BarectfPlatformFORTE, any other string for the CInternalTracer
+     * @param paTracerType the type of tracer to be used
      */
-    static void setTracer(std::string paTracerName);
+    static void setTracer(AvailableTracers paTracerType);
 
 private:
 
-  static inline std::string mCurrentTracer;
+  static inline AvailableTracers mCurrentTracer{AvailableTracers::BareCtf};
 
   std::variant<std::monostate, BarectfPlatformFORTE, CInternalTracer> mTracer{};
 };

--- a/src/core/trace/internalTracer.cpp
+++ b/src/core/trace/internalTracer.cpp
@@ -28,7 +28,7 @@ void CInternalTracer::fillStringsVector(const char *const *const paIn, const uin
 {
   for (uint32_t i = 0; i < paLen; i++)
   {
-    paOut.emplace_back(paIn[i]);
+    paOut[i] = paIn[i];
   }
 }
 

--- a/src/core/trace/internalTracer.h
+++ b/src/core/trace/internalTracer.h
@@ -57,6 +57,15 @@ public:
     void traceOutputData(const char * const paTypeName, const char * const paInstanceName, const uint64_t paDataId, 
       const char * const paValue);
 
+    /**
+     * @brief Fills the given vector with the array of const char* information. The vector must already contain the
+     * expected amount of elements to be inserted, defined by paLen. This help performance by allocating the vector
+     * with a size that won't change while filling it 
+     * 
+     * @param paIn the input of texts that will be inserted into the vector
+     * @param paLen the length of paIn 
+     * @param paOut output where to store the passed texts
+     */
     void fillStringsVector(const char * const * const paIn, const uint32_t paLen, std::vector<std::string>& paOut);
 
     bool isEnabled();


### PR DESCRIPTION
Fix filling vector of data when internally tracing and cleanup the selection of the tracer to be used.