### PR TITLE
Fix OPC UA namespace index for Structs

### DIFF
--- a/src/com/opc_ua/opcua_objectstruct_helper.cpp
+++ b/src/com/opc_ua/opcua_objectstruct_helper.cpp
@@ -159,6 +159,10 @@ forte::com_infra::EComResponse COPC_UA_ObjectStruct_Helper::createObjectNode(CAc
     if( (UA_STATUSCODE_GOOD != mHandler->initializeAction(*mCreateNodeActionInfo)) || (UA_STATUSCODE_GOOD != mHandler->executeAction(*mCreateNodeActionInfo)) ) {
       return response;
     }
+  } else {
+    if(paActionInfo.getNodePairInfo().begin()->getNodeId() != nullptr) {
+      mOpcuaObjectNamespaceIndex = paActionInfo.getNodePairInfo().begin()->getNodeId()->namespaceIndex;
+    }
   }
   return initializeMemberAction(paActionInfo, browsePath, paIsPublisher);
 }


### PR DESCRIPTION
Assign correct namespace for Publish/Subscribe FBs that want to write/read already existing OPC UA Objects