### PR TITLE
Reset data inputs pointers in Adapter before interface is destroyed

### DIFF
--- a/src/core/adapter.cpp
+++ b/src/core/adapter.cpp
@@ -34,10 +34,12 @@ bool CAdapter::initialize() {
     return false;
   }
   setupEventEntryList();
+  mLocalDIs = mDIs;
   return true;
 }
 
 CAdapter::~CAdapter(){
+  mDIs = mLocalDIs;
   if (mIsPlug) {
     if (mAdapterConn != nullptr) {
       delete mAdapterConn;


### PR DESCRIPTION
Starting the PR mostly to see if the solution is the best. 

The context is the following:
- 2 FB with an compatible adapter each
- When the Adapter is created,  `CGenFunctionBlock<T>::setupFBInterface`  does its Voldermort-level-memory-magic, storing the data inputs and data outupts into member variables `mDIs` and `mDOs`
- Whent the connecction between the adapters is created, `mDIs = paPeer->mDOs;` is done in each FB, meaning each FB has the pointer from the other, which is reseted to `mLocalDIs` when disconnected.

Two problems: 
1. `mLocalDIs`  is set with `mDIs` in the constructor, but `mDIs` is set only afterwards in `initialize`, therefore this PE contrins the change in this `initialize` to store the updated value of `mDIs`
2. `disconnect`  (which resets `mDIs` with `mLocalDIs`) is called after the destructor of the Adapter, specifically  from `CAdapterConnection::performDisconnect` in its destructor. That means whent he destructor of the Adapter is called, `mDIs` still has the `mDOs` value of the connected FB, and when the interface is destroyed in `CGenFunctionBlock<T>::freeFBInterfaceData` really bad things happen. 
I tried calling `disconnect` in the destructor of the Adapter, but the call later to `performDisconnect` is not happy (probably because the FB was destroyed alreayd, but not sure) 

With the changes in the first commit of the PR, I don't get a crash. I'm surprised this was not detected before, so I'm not sure I'm doing something wrong. I used the  ReferenceExamples from the Examples repository. There `Ex2a_05_Adapter` and `Ex3a_05_Adapter` have this issue. The particular case I see is that the Adapter has both Data Inputs and Data Ouputs, which is not the case for example of the `ATimeout`, but I didn't test too deep to see if this affects the context in which the crash occurs.

In my opinion, the adapter should perform the disconnection in its destructor, and the `CAdapterConnection::performDisconnect` should not exist