### PR TITLE
Increase address char array in modbuslayer.h

### DIFF
--- a/src/com/modbus/modbuslayer.h
+++ b/src/com/modbus/modbuslayer.h
@@ -39,7 +39,7 @@ namespace forte {
 
       private:
         struct STcpParams {
-          char mIp[15];
+          char mIp[16];
           unsigned int mPort;
         };
         struct SRtuParams {


### PR DESCRIPTION
15 characters for the IP + 1 for the null terminator