### PR TITLE
Add debug device

### DIFF
--- a/src/core/ecetFake.cpp
+++ b/src/core/ecetFake.cpp
@@ -61,11 +61,6 @@ void CFakeEventExecutionThread::startEventChain(TEventEntry paEvent) {
 
 // remote methods
 void CFakeEventExecutionThread::insertFront(TEventEntry paEvent){
- // if remote is not enabled, we don't manually insert events
-  if(!mIsRemoteEnabled){
-    return;
-  }
-
   // the ring buffer does not have a way to insert in the front,
   // so we create a new one and push the event first there and then the rest
   // and then copy the events back to the original list
@@ -101,11 +96,6 @@ void CFakeEventExecutionThread::removeFromBack(size_t paNumberOfItemsToRemove){
 }
 
 std::optional<TEventEntry> CFakeEventExecutionThread::getNextEvent(){
- // if remote is not enabled, we don't manually access the events
-  if(!mIsRemoteEnabled){
-    return std::nullopt;
-  }
-
   auto nextEvent = mEventList.pop(); // get a copy, but need to pop for it
   if(nextEvent == nullptr){
     return std::nullopt;
@@ -115,8 +105,6 @@ std::optional<TEventEntry> CFakeEventExecutionThread::getNextEvent(){
   return *nextEvent;
 }
 
-// we don't need the complexities of a separate thread, so 
-// the funtion just set to sleep when is controlled from outside
 void CFakeEventExecutionThread::run(){
   while(isAlive()){
     if(mIsRemoteEnabled){

--- a/src/core/ecetFake.cpp
+++ b/src/core/ecetFake.cpp
@@ -16,57 +16,56 @@
 
 CFakeEventExecutionThread::CFakeEventExecutionThread() :
     CEventChainExecutionThread(){
-  setDefaultCallbackForNewEventChain();
-  setDefaultCallbackForEventTrigger();
+  mProcessEventCallback = [this](TEventEntry paEvent){
+    paEvent.mFB->receiveInputEvent(paEvent.mPortId, this);
+  };
+  removeExternalControl();
+}
+
+void CFakeEventExecutionThread::removeExternalControl() {
+  mIsRemoteEnabled = false;      
+  resumeSelfSuspend();
+}
+
+void CFakeEventExecutionThread::takeExternalControl() {
+  mIsRemoteEnabled = true;
+}
+
+void CFakeEventExecutionThread::setRemoteCallbackForEventTriggering(HandleEvent paCallback) {
+  mProcessEventCallback = paCallback;
 }
 
 void CFakeEventExecutionThread::triggerNextEvent(){
+  // if remote is not enabled, we don't manually trigger events
+  if(!mIsRemoteEnabled){
+    return;
+  }
+
+  // manually triggering events, is similar to the regular one but: 
+  // - no external events are handled 
+  // - if no events are available, the function returns instead of suspending itself
   auto event = mEventList.pop();
   if(nullptr == event){
     return;
   }
-
-  if(!mProcessEventCallback.has_value()){
-    return;
-  }
-  mProcessEventCallback.value()(*event);
-}
-
-void CFakeEventExecutionThread::setCallbackForEventTriggering(std::optional<HandleEvent> paCallback) {
-  mProcessEventCallback = paCallback;
-}
-
-void CFakeEventExecutionThread::setDefaultCallbackForEventTrigger() {
-  mProcessEventCallback = [this](TEventEntry paEvent){
-    paEvent.mFB->receiveInputEvent(paEvent.mPortId, this);
-  };
+  mProcessEventCallback(*event);
 }
 
 void CFakeEventExecutionThread::startEventChain(TEventEntry paEvent) {
-  if(!mNewEventChainCallback.has_value()){
+  // if remote is enabled, external events are inhibited
+  if(mIsRemoteEnabled){
     return;
   }
-  mNewEventChainCallback.value()(paEvent);
+  CEventChainExecutionThread::startEventChain(paEvent);
 }
 
-void CFakeEventExecutionThread::setCallbackForNewEventChain(std::optional<HandleEvent> paCallback) {
-  mNewEventChainCallback = paCallback;
-}
-
-void CFakeEventExecutionThread::setDefaultCallbackForNewEventChain(){
-  mNewEventChainCallback = [this](TEventEntry paEvent){
-    CEventChainExecutionThread::startEventChain(paEvent);
-  };
-}
-
-void CFakeEventExecutionThread::removeExternalControl() {
-  setDefaultCallbackForNewEventChain();
-  setDefaultCallbackForEventTrigger();
-  mIsControlledFromOutside = false;      
-  resumeSelfSuspend();
-}
-
+// remote methods
 void CFakeEventExecutionThread::insertFront(TEventEntry paEvent){
+ // if remote is not enabled, we don't manually insert events
+  if(!mIsRemoteEnabled){
+    return;
+  }
+
   // the ring buffer does not have a way to insert in the front,
   // so we create a new one and push the event first there and then the rest
   // and then copy the events back to the original list
@@ -82,6 +81,11 @@ void CFakeEventExecutionThread::insertFront(TEventEntry paEvent){
 }
 
 void CFakeEventExecutionThread::removeFromBack(size_t paNumberOfItemsToRemove){
+ // if remote is not enabled, we don't manually remove events
+  if(!mIsRemoteEnabled){
+    return;
+  }
+
   std::vector<TEventEntry> temp;
   while(!mEventList.isEmpty()){
     temp.push_back(*mEventList.pop());
@@ -97,6 +101,11 @@ void CFakeEventExecutionThread::removeFromBack(size_t paNumberOfItemsToRemove){
 }
 
 std::optional<TEventEntry> CFakeEventExecutionThread::getNextEvent(){
+ // if remote is not enabled, we don't manually access the events
+  if(!mIsRemoteEnabled){
+    return std::nullopt;
+  }
+
   auto nextEvent = mEventList.pop(); // get a copy, but need to pop for it
   if(nextEvent == nullptr){
     return std::nullopt;
@@ -110,9 +119,31 @@ std::optional<TEventEntry> CFakeEventExecutionThread::getNextEvent(){
 // the funtion just set to sleep when is controlled from outside
 void CFakeEventExecutionThread::run(){
   while(isAlive()){
-    if(mIsControlledFromOutside){
+    if(mIsRemoteEnabled){
       selfSuspend();
-    } 
+      if(mIsRemoteEnabled){
+        continue;
+      }
+    }
+    if(auto nextEvent = getNextEvent(); nextEvent.has_value() && mBreakpoints.count(nextEvent.value()) != 0){
+      takeExternalControl();
+      mBreakpointWasHit(nextEvent.value());
+      continue;
+    }
     CEventChainExecutionThread::mainRun();
   }
+}
+
+// Breakpoint methods
+
+void CFakeEventExecutionThread::addBreakpoint(TEventEntry paBreakpoint){
+  mBreakpoints.insert(paBreakpoint);
+}
+
+void CFakeEventExecutionThread::removeBreakpoint(TEventEntry paBreakpoint){
+  mBreakpoints.erase(paBreakpoint);
+}
+
+void CFakeEventExecutionThread::setBreakpointHitCallback(HandleEvent paCallback) {
+  mBreakpointWasHit = paCallback;
 }

--- a/src/core/ecetFake.h
+++ b/src/core/ecetFake.h
@@ -16,13 +16,26 @@
 #include "ecet.h"
 
 #include <functional>
-#include <mutex>
-#include <condition_variable>
-#include <set>
 #include <optional>
+#include <set>
 
 /**
- * @brief An ecet which can be fully controlled from outside the class 
+ * @brief An ecet which can be fully controlled from outside the class
+ * The ecet has two modes:
+ * - Normal: 
+ *    - The thread processing of events runs as usual
+ *    - External events are added to the queue of external events as usual
+ *    - manual methods are disabled: triggerNextEvent, insertFront, removeFromBack, getNextEvent
+ * 
+ * - Remote:
+ *   - The thread processing events is suspended. Events can be triggered only via triggerNextEvent
+ *   - External events are discarded
+ *   - manual methods are enabled: triggerNextEvent, insertFront, removeFromBack, getNextEvent
+ * 
+ * When a breakpoint is hit, the usual behaviour is to set all ecets from the device in remote mode, 
+ * but since this class does not have a reference to the device, a callback needs to be passed which will
+ * be called when a breakpoint is hit. 
+ * The caller should then take care of setting all ecets to remote mode.
  * 
  */
 class CFakeEventExecutionThread : public CEventChainExecutionThread{
@@ -38,6 +51,24 @@ class CFakeEventExecutionThread : public CEventChainExecutionThread{
     ~CFakeEventExecutionThread() override = default;
 
     /**
+     * @brief Let the ecet run freely and not controlled from outside anymore
+     */
+    void removeExternalControl();
+
+    /**
+     * @brief Enable control from outside the class. Events are triggered only when requested 
+     */
+    void takeExternalControl();
+
+    /**
+     * @brief Set the callback that will be called for each event that is triggered. By default the callback does nothing
+     * This ecet enters in remote mode, and the callback offers the change for extra work to be done by the caller.
+     * 
+     * @param paCallback Callback to be used
+     */
+    void setRemoteCallbackForEventTriggering(HandleEvent paCallback);
+
+    /**
      * @brief Triggers the next event in the list if there's any
      * 
      * How the event trigger is handled can be configured via a callback. 
@@ -45,44 +76,11 @@ class CFakeEventExecutionThread : public CEventChainExecutionThread{
     void triggerNextEvent();
 
     /**
-     * @brief Set the callback that will be called for each event that is triggered.
-     * If set to std::nullopt, the event is supressed
-     * 
-     * @param paCallback Callback to be used
-     */
-    void setCallbackForEventTriggering(std::optional<HandleEvent> paCallback = std::nullopt);
-    
-    /**
-     * @brief Set the callback for event trigger to the default one, 
-     * which calls receiveInputEvent on the Function Block 
-     */
-    void setDefaultCallbackForEventTrigger();
-    
-    /**
-     * @brief Starts a new chain event. If a callback was set, it is called. * Initially,
-     * the callback is set to call the same function in the parent ecet
+     * @brief Starts a new chain event. In remote mode, this doesn't do anything 
      * 
      * @param paEventToAdd event starting the chain 
      */
     void startEventChain(TEventEntry paEventToAdd) override;
-
-    /**
-     * @brief Set a new callback that will be called when a new event chain would be started. If set
-     * to std::nullopt, the new event chain is supressed
-     * 
-     * @param paCallback function to be called when a new chain of event starts
-     */
-    void setCallbackForNewEventChain(std::optional<HandleEvent> paCallback = std::nullopt);
-
-    /**
-     * @brief Set the callback for new event chains to the default one which calls the parent startEventChain
-     */
-    void setDefaultCallbackForNewEventChain();
-
-    /**
-     * @brief Let the ecet run freely and not controlled from outside anymore
-     */
-    void removeExternalControl();
 
     /**
      * @brief Insert a new event at the front of the list of events
@@ -105,12 +103,46 @@ class CFakeEventExecutionThread : public CEventChainExecutionThread{
      */
     std::optional<TEventEntry> getNextEvent();
 
+    /**
+     * @brief Add a new breakpoint. If the breakpoint already exists, nothing happens
+
+     * @param paBreakpoint breakpoint to add
+     */
+    void addBreakpoint(TEventEntry paBreakpoint);
+
+    /**
+     * @brief Remove breakpoint. If the breakpoint does not exist, nothing happen
+
+     * @param paBreakpoint breakpoint to remove
+     */
+    void removeBreakpoint(TEventEntry paBreakpoint);
+
+    /**
+     * @brief Set the callback that will be called when a breakpoint is hit.
+     * 
+     * @param paCallback Callback to be used
+     */
+    void setBreakpointHitCallback(HandleEvent paCallback);
+
 private:
 
     void run() override;
-    bool mIsControlledFromOutside{true};
-    std::optional<HandleEvent> mNewEventChainCallback;
-    std::optional<HandleEvent> mProcessEventCallback;
+    bool mIsRemoteEnabled{true};
+    HandleEvent mProcessEventCallback;
+    HandleEvent mBreakpointWasHit{[](TEventEntry){}};
+
+    struct EventEntryComparator {
+      bool operator() (const TEventEntry& paFirst, const TEventEntry& paSecond) const {
+        if(paFirst.mFB < paSecond.mFB){
+          return true;
+        } else if (paFirst.mFB > paSecond.mFB){
+          return false;
+        } 
+        return paFirst.mPortId < paSecond.mPortId;
+      }
+    };
+
+    std::set<TEventEntry, EventEntryComparator> mBreakpoints;
 };
 
 #endif /*_CORE_FAKE_ECET_H_*/

--- a/src/core/ecetFake.h
+++ b/src/core/ecetFake.h
@@ -25,12 +25,12 @@
  * - Normal: 
  *    - The thread processing of events runs as usual
  *    - External events are added to the queue of external events as usual
- *    - manual methods are disabled: triggerNextEvent, insertFront, removeFromBack, getNextEvent
+ *    - manual methods are disabled: triggerNextEvent, removeFromBack
  * 
  * - Remote:
  *   - The thread processing events is suspended. Events can be triggered only via triggerNextEvent
  *   - External events are discarded
- *   - manual methods are enabled: triggerNextEvent, insertFront, removeFromBack, getNextEvent
+ *   - manual methods are enabled: triggerNextEvent, removeFromBack
  * 
  * When a breakpoint is hit, the usual behaviour is to set all ecets from the device in remote mode, 
  * but since this class does not have a reference to the device, a callback needs to be passed which will

--- a/src/stdfblib/ita/CMakeLists.txt
+++ b/src/stdfblib/ita/CMakeLists.txt
@@ -39,3 +39,5 @@ forte_add_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 if(FORTE_SUPPORT_BOOT_FILE)
   forte_add_sourcefile_hcpp(ForteBootFileLoader)
 endif(FORTE_SUPPORT_BOOT_FILE)
+
+add_subdirectory(debug_device)

--- a/src/stdfblib/ita/OPCUA_DEV.h
+++ b/src/stdfblib/ita/OPCUA_DEV.h
@@ -21,7 +21,7 @@ public:
 
   OPCUA_MGR mOPCUAMgr;
 
-  OPCUA_DEV(const std::string &paMGRID = "opc.tcp://localhost:4840");
+  OPCUA_DEV(const std::string &paMGRID = "localhost:61499");
   virtual ~OPCUA_DEV();
 
   virtual int startDevice(void);

--- a/src/stdfblib/ita/OPCUA_MGR.h
+++ b/src/stdfblib/ita/OPCUA_MGR.h
@@ -13,22 +13,41 @@
 
 #pragma once
 
-#include "commfb.h"
 #include "opcua_local_handler.h"
-#include <vector>
+#include "core/mgmcmd.h"
 
-class OPCUA_DEV;
+#include <vector>
+#include <string>
+
+class CDevice;
 
 class OPCUA_MGR {
 public:
 
-  OPCUA_MGR(OPCUA_DEV& paUaDevice);
+  OPCUA_MGR(CDevice& paUaDevice);
   
   virtual ~OPCUA_MGR();
   
   EMGMResponse initialize();
   
   bool isInitialized();
+
+  static void initArgument(UA_Argument& paArgument, int paTypeId, char* paName, char* paDescription);
+
+  struct MethodInformation {
+    std::string mMethodName;
+    std::string mDisplayName;
+    std::string mDescription;
+    std::vector<UA_Argument> mInArguments;
+    std::vector<UA_Argument> mOutArguments;
+    UA_MethodCallback mCallback;
+    void* mNodeContext;
+  };
+
+  void addExtraMgmMethod(const MethodInformation& paMethod);
+
+  void addExtraResourceMethod(const MethodInformation& paMethod);
+
 private:
 
   static char smEmptyLocale[];
@@ -252,7 +271,7 @@ private:
 
   static const UA_UInt16 smNamespaces[];
 
-  OPCUA_DEV& mUaDevice;
+  CDevice& mUaDevice;
   
   COPC_UA_Local_Handler& mUaHandler;
 
@@ -265,6 +284,10 @@ private:
   UA_NodeId mResourceTypeId;
 
   std::map<std::string, UA_NodeId> resourceNodeMap;
+
+  std::vector<MethodInformation> mExtraMgmMethods;
+
+  std::vector<MethodInformation> mExtraResourceMethods;
   
   /**** OPCUA Methods ****/
   
@@ -516,9 +539,7 @@ private:
 
   EMGMResponse addMethodNode(UA_Server* paServer, char* paMethodName, UA_NodeId paParentNodeId, 
     UA_MethodAttributes paAttr, const UA_Argument *paInArgs, size_t paInArgSize, const UA_Argument *paOutArgs, 
-    size_t paOutArgSize, UA_MethodCallback paCallback);
-
-  void initArgument(UA_Argument& paArgument, int paTypeId, char* paName, char* paDescription);
+    size_t paOutArgSize, UA_MethodCallback paCallback, void* nodeContext = nullptr);
 
   UA_MethodAttributes createAttribute(char* paDisplayName, char* paDescription);
 
@@ -537,4 +558,6 @@ private:
   static std::string getInputValue(UA_String paInput);
 
   static void parseDestinationName(const std::string& paDestination, std::vector<std::string>& paTarget);
+
+  EMGMResponse addExtraMethods(UA_Server* paServer, UA_NodeId paParentNodeId, std::vector<MethodInformation>& paMethods);
 };

--- a/src/stdfblib/ita/debug_device/CMakeLists.txt
+++ b/src/stdfblib/ita/debug_device/CMakeLists.txt
@@ -1,0 +1,21 @@
+#*******************************************************************************
+# Copyright (c) 2025 Jose Cabral
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#    Jose Cabral
+# *    - initial API and implementation and/or initial documentation
+# *******************************************************************************/
+
+
+if (FORTE_COM_OPC_UA)
+  set(FORTE_DEBUG_DEVICE FALSE CACHE BOOL "Compile the debug Device")
+  if (FORTE_DEBUG_DEVICE)
+    forte_add_device(DebugDevice "stdfblib/ita/debug_device/DebugDevice" "DebugDevice")
+    forte_add_sourcefile_hcpp(DebugMGR DebugDevice)
+  endif()
+endif()

--- a/src/stdfblib/ita/debug_device/DebugDevice.cpp
+++ b/src/stdfblib/ita/debug_device/DebugDevice.cpp
@@ -13,12 +13,22 @@
 
 #include "DebugDevice.h"
 
-DebugDevice::DebugDevice(const std::string &paMGRID) : 
-  RMT_DEV(paMGRID), mOpcuaMgr(*this), mDebugMgr(*this, mOpcuaMgr) {
+const SFBInterfaceSpec DebugDevice::scmFBInterfaceSpec = {
+  0, nullptr, nullptr, nullptr, nullptr,
+  0, nullptr, nullptr, nullptr, nullptr,
+  0, nullptr, nullptr,
+  0, nullptr, nullptr,
+  0, nullptr,
+  0, nullptr
+};
+
+DebugDevice::DebugDevice(const std::string&) : 
+  CDevice(scmFBInterfaceSpec, CStringDictionary::scmInvalidStringId), 
+  mOpcuaMgr(*this), mDebugMgr(*this, mOpcuaMgr) {
 }
 
 int DebugDevice::startDevice() {
-  RMT_DEV::startDevice();
+  CDevice::startDevice();
   if (!mDebugMgr.initialize()) {
     return -1;
   }
@@ -28,3 +38,26 @@ int DebugDevice::startDevice() {
   }
   return 0;
 }
+
+EMGMResponse DebugDevice::changeExecutionState(EMGMCommandType paCommand){
+  EMGMResponse eRetVal = CDevice::changeExecutionState(paCommand);
+  if(EMGMCommandType::Kill == paCommand){
+    mKillSignal.set_value();
+  }
+  return eRetVal;
+}
+
+void DebugDevice::awaitShutdown() {
+  // wait for the kill signal to arrive
+  mKillSignal.get_future().wait();
+}
+
+CIEC_ANY* DebugDevice::getDI(size_t) {
+  return nullptr;
+}
+
+CDataConnection** DebugDevice::getDIConUnchecked(TPortId) {
+  return nullptr;
+}
+
+

--- a/src/stdfblib/ita/debug_device/DebugDevice.cpp
+++ b/src/stdfblib/ita/debug_device/DebugDevice.cpp
@@ -14,13 +14,17 @@
 #include "DebugDevice.h"
 
 DebugDevice::DebugDevice(const std::string &paMGRID) : 
-  RMT_DEV(paMGRID), mDebugMgr(*this) {
+  RMT_DEV(paMGRID), mOpcuaMgr(*this), mDebugMgr(*this, mOpcuaMgr) {
 }
 
 int DebugDevice::startDevice() {
   RMT_DEV::startDevice();
   if (!mDebugMgr.initialize()) {
     return -1;
+  }
+
+  if(mOpcuaMgr.initialize() != EMGMResponse::Ready){
+    return -2;
   }
   return 0;
 }

--- a/src/stdfblib/ita/debug_device/DebugDevice.cpp
+++ b/src/stdfblib/ita/debug_device/DebugDevice.cpp
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Jose Cabral - initial implementation
+ *******************************************************************************/
+
+#include "DebugDevice.h"
+
+DebugDevice::DebugDevice(const std::string &paMGRID) : 
+  RMT_DEV(paMGRID), mDebugMgr(*this) {
+}
+
+int DebugDevice::startDevice() {
+  RMT_DEV::startDevice();
+  if (!mDebugMgr.initialize()) {
+    return -1;
+  }
+  return 0;
+}

--- a/src/stdfblib/ita/debug_device/DebugDevice.h
+++ b/src/stdfblib/ita/debug_device/DebugDevice.h
@@ -13,14 +13,17 @@
 
 #pragma once
 
-#include "RMT_DEV.h"
+#include "device.h"
 #include "DebugMGR.h"
+
+// std includes
+#include <future>
 
 /**
  * @brief Device that adds debug commands to the device. The commands are defined in DebugMGR
  * 
  */
-class DebugDevice : public RMT_DEV {
+class DebugDevice : public CDevice {
 public:
 
   DebugDevice(const std::string &paMGRID = "localhost:61499");
@@ -31,4 +34,21 @@ public:
   OPCUA_MGR mOpcuaMgr;
 
   DebugMGR mDebugMgr;
+
+  private:
+
+    // the kill signal sent by main is handled by this promise
+    // which is used just as a inter-thread communication
+    // to avoid condition variables and such
+    std::promise<void> mKillSignal;
+
+    static const SFBInterfaceSpec scmFBInterfaceSpec;
+
+    EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
+
+    void awaitShutdown() override;
+
+    // needed as these are abstract in the parent
+    CIEC_ANY *getDI(size_t) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
 };

--- a/src/stdfblib/ita/debug_device/DebugDevice.h
+++ b/src/stdfblib/ita/debug_device/DebugDevice.h
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Jose Cabral - initial implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "RMT_DEV.h"
+#include "DebugMGR.h"
+
+/**
+ * @brief Device that adds debug commands to the device. The commands are defined in DebugMGR
+ * 
+ */
+class DebugDevice : public RMT_DEV {
+public:
+
+  DebugDevice(const std::string &paMGRID = "localhost:61499");
+  ~DebugDevice() override = default;
+
+  int startDevice() override;
+
+  DebugMGR mDebugMgr;
+};

--- a/src/stdfblib/ita/debug_device/DebugDevice.h
+++ b/src/stdfblib/ita/debug_device/DebugDevice.h
@@ -28,5 +28,7 @@ public:
 
   int startDevice() override;
 
+  OPCUA_MGR mOpcuaMgr;
+
   DebugMGR mDebugMgr;
 };

--- a/src/stdfblib/ita/debug_device/DebugMGR.cpp
+++ b/src/stdfblib/ita/debug_device/DebugMGR.cpp
@@ -16,8 +16,8 @@
 #include "core/ecetFactory.h"
 #include "core/ecetFake.h"
 
-DebugMGR::DebugMGR(CDevice& paDevice) : 
-  mOpcuaMgr(paDevice), mDevice(paDevice) {
+DebugMGR::DebugMGR(CDevice& paDevice, OPCUA_MGR& paOpcuaMgr) : 
+  mDevice(paDevice), mOpcuaMgr(paOpcuaMgr) {
   // we need the fake ecet to debug control the device remotely
   EcetFactory::setEcetToCreate(EcetFactory::AvailableEcets::fake);
 }
@@ -28,12 +28,6 @@ bool DebugMGR::initialize(){
   addAddBreakpointMethod();
   addRemoveBreakpointMethod();
 
-  if (mOpcuaMgr.initialize() != EMGMResponse::Ready) {
-    mArgumentsInformation.clear();
-    return false;
-  }
-  // we don't need the strings anymore
-  mArgumentsInformation.clear();
   return true;
 }
 

--- a/src/stdfblib/ita/debug_device/DebugMGR.cpp
+++ b/src/stdfblib/ita/debug_device/DebugMGR.cpp
@@ -1,0 +1,284 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Jose Cabral - initial implementation
+ *******************************************************************************/
+
+#include "DebugMGR.h"
+
+#include "core/ecetFactory.h"
+#include "core/ecetFake.h"
+
+DebugMGR::DebugMGR(CDevice& paDevice) : 
+  mOpcuaMgr(paDevice), mDevice(paDevice) {
+  // we need the fake ecet to debug control the device remotely
+  EcetFactory::setEcetToCreate(EcetFactory::AvailableEcets::fake);
+}
+
+bool DebugMGR::initialize(){
+  addRemoteControlMethod();
+  addTriggerNextEventMethod();
+  addAddBreakpointMethod();
+  addRemoveBreakpointMethod();
+
+  if (mOpcuaMgr.initialize() != EMGMResponse::Ready) {
+    mArgumentsInformation.clear();
+    return false;
+  }
+  // we don't need the strings anymore
+  mArgumentsInformation.clear();
+  return true;
+}
+
+std::string& DebugMGR::getArgumentString(std::string paString) {
+  return mArgumentsInformation.emplace_back(std::move(paString));
+}
+
+void DebugMGR::iterateResources(ResourceIteratorCallback paCallback){
+  for(auto child : mDevice.getChildren()){
+    if(auto resource = static_cast<CResource*>(child); // the first generation of children under the device are always resources
+        !paCallback(resource, static_cast<CFakeEventExecutionThread*>(resource->getResourceEventExecution()))){
+      break;
+    }
+  }
+}
+
+std::optional<TEventEntry> DebugMGR::getEventEntry(CResource* paResource, std::string paDestination){
+  forte::core::TNameIdentifier fullName;
+
+  // fill out the TNameIdentifier
+  size_t index = paDestination.find_first_of(".");
+  while (index != std::string::npos) {
+    auto currentPart = paDestination.substr(0, index); 
+    fullName.pushBack(CStringDictionary::getInstance().insert(currentPart.c_str()));
+    paDestination = paDestination.substr(currentPart.length() + 1);
+    index = paDestination.find_first_of(".");
+  }
+  fullName.pushBack(CStringDictionary::getInstance().insert(paDestination.substr(0, index).c_str()));
+
+  if(fullName.size() < 2){ // at least the FB and the event port must be present
+    return std::nullopt;
+  }
+
+  // separate the fb name from the event id
+  auto eventId = fullName.back();
+  fullName.popBack();
+
+  forte::core::TNameIdentifier::CIterator it(fullName, 0);
+  auto functionBlock = paResource->getFB(it);
+  if(functionBlock == nullptr){
+    // no function block found
+    return std::nullopt;
+  }
+
+  auto portID = functionBlock->getEIID(eventId);
+  if(portID == cgInvalidPortId){
+    // no port ID found in the function block
+    return std::nullopt;
+  }
+
+  return TEventEntry{functionBlock, portID};
+}
+
+void DebugMGR::addRemoteControlMethod(){
+  OPCUA_MGR::MethodInformation newMethod;
+
+  newMethod.mMethodName = "Remote Control";
+  newMethod.mDisplayName = "Remote Control";
+  newMethod.mDescription = "Set control of the device from a remote source or not";
+  newMethod.mCallback = &DebugMGR::onSetRemoteControl;
+  newMethod.mNodeContext = this;
+
+  newMethod.mInArguments.push_back(UA_Argument());
+
+  OPCUA_MGR::initArgument(
+    newMethod.mInArguments[0], 
+    UA_TYPES_BOOLEAN, 
+    getArgumentString("Enable Remote Control").data(), 
+    getArgumentString("True if the remote control should be enabled, false if it should be disabled").data());
+
+  mOpcuaMgr.addExtraMgmMethod(newMethod);
+}
+
+void DebugMGR::addTriggerNextEventMethod(){
+  OPCUA_MGR::MethodInformation newMethod;
+
+  newMethod.mMethodName = "Trigger Next Event";
+  newMethod.mDisplayName = "Trigger Next Event";
+  newMethod.mDescription = "Trigger the next event in the resource";
+  newMethod.mCallback = &DebugMGR::onTriggerNextEvent;
+  newMethod.mNodeContext = this;
+  
+  mOpcuaMgr.addExtraResourceMethod(newMethod);
+}
+
+void DebugMGR::addAddBreakpointMethod() {
+OPCUA_MGR::MethodInformation newMethod;
+
+  newMethod.mMethodName = "Add Breakpoint";
+  newMethod.mDisplayName = "Add Breakpoint";
+  newMethod.mDescription = "Add a breakpoint";
+  newMethod.mCallback = &DebugMGR::onAddBreakpoint;
+  newMethod.mNodeContext = this;
+
+  newMethod.mInArguments.push_back(UA_Argument());
+
+  OPCUA_MGR::initArgument(
+    newMethod.mInArguments[0], 
+    UA_TYPES_STRING, 
+    getArgumentString("Port Name").data(), 
+    getArgumentString("Full name of the port inside the resource").data());
+  
+  mOpcuaMgr.addExtraResourceMethod(newMethod);
+}
+
+void DebugMGR::addRemoveBreakpointMethod() {
+OPCUA_MGR::MethodInformation newMethod;
+
+  newMethod.mMethodName = "Remove Breakpoint";
+  newMethod.mDisplayName = "Remove Breakpoint";
+  newMethod.mDescription = "Remove a breakpoint";
+  newMethod.mCallback = &DebugMGR::onRemoveBreakpoint;
+  newMethod.mNodeContext = this;
+
+  newMethod.mInArguments.push_back(UA_Argument());
+
+  OPCUA_MGR::initArgument(
+    newMethod.mInArguments[0], 
+    UA_TYPES_STRING, 
+    getArgumentString("Port Name").data(), 
+    getArgumentString("Full name of the port inside the resource").data());
+  
+  mOpcuaMgr.addExtraResourceMethod(newMethod);
+}
+
+UA_StatusCode DebugMGR::onSetRemoteControl(UA_Server*,
+  const UA_NodeId*, void*,
+  const UA_NodeId*, void* methodContext,
+  const UA_NodeId*, void*,
+  size_t, const UA_Variant* input,
+  size_t, UA_Variant* ) {
+
+  auto debugMgr = static_cast<DebugMGR*>(methodContext);
+  const auto enableRemoteControl = *static_cast<UA_Boolean*>(input[0].data);
+
+  debugMgr->iterateResources([enableRemoteControl](CResource*, CFakeEventExecutionThread* paEcet){
+     enableRemoteControl ? paEcet->takeExternalControl() : paEcet->removeExternalControl();
+     return true;
+  });
+
+  return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode DebugMGR::onTriggerNextEvent(UA_Server*,
+  const UA_NodeId*, void*,
+  const UA_NodeId*, void* methodContext,
+  const UA_NodeId*, void* objectContext,
+  size_t, const UA_Variant*,
+  size_t, UA_Variant*) {
+
+  auto debugMgr = static_cast<DebugMGR*>(methodContext);
+
+  auto resourceName = static_cast<const char*>(objectContext);
+  bool wasTriggered = false;
+  debugMgr->iterateResources([resourceName, &wasTriggered](CResource* paResource, CFakeEventExecutionThread* paEcet){
+    if(strcmp(paResource->getInstanceName(), resourceName) != 0){
+      // not the resource we are looking for
+      return true;
+    }
+
+    paEcet->triggerNextEvent();
+    wasTriggered = true;
+    return false;
+  });
+
+  if(!wasTriggered){
+    return UA_STATUSCODE_BADNOTSUPPORTED;
+  }
+
+  return UA_STATUSCODE_GOOD;
+}
+
+UA_StatusCode DebugMGR::onAddBreakpoint(UA_Server*,
+  const UA_NodeId*, void*,
+  const UA_NodeId*, void* methodContext,
+  const UA_NodeId*, void* objectContext,
+  size_t, const UA_Variant* input,
+  size_t, UA_Variant*){
+
+  auto debugMgr = static_cast<DebugMGR*>(methodContext);
+  auto resourceName = static_cast<const char*>(objectContext);
+  UA_StatusCode result = UA_STATUSCODE_BADINVALIDARGUMENT;
+
+  // look for the resource in the device, and inside of it find the PortId of the Function block, if they exist
+  debugMgr->iterateResources([debugMgr, resourceName, input, &result](CResource* paResource, CFakeEventExecutionThread* paEcet){
+    
+    if(strcmp(paResource->getInstanceName(), resourceName) != 0){
+      // not the resource we are looking for
+      return true;
+    }
+
+    auto uaStringInput = static_cast<UA_String*>(input[0].data);
+    if(auto desiredEventEntry = debugMgr->getEventEntry(paResource, std::string((const char*)uaStringInput->data, uaStringInput->length)); 
+          desiredEventEntry.has_value()){
+      paEcet->addBreakpoint(desiredEventEntry.value());
+      result = UA_STATUSCODE_GOOD;
+    }
+
+    // setting the breakpoint callback needs to be done only once per ecet, but
+    // since we don't get a callback everytime a resource is created,
+    // we need to set the breakpoint hit callback eveytime a breakpoint is added
+    // the callback takes external control of all ecets in the device
+    paEcet->setBreakpointHitCallback([debugMgr](TEventEntry paEntry){
+      (void) paEntry;   // we don't do anything with the current breakpoint. We could set something later with this info
+                        
+      // if a breakpoint is hit, halt all resources
+      debugMgr->iterateResources([](CResource*, CFakeEventExecutionThread* paCurrentEcet){
+        paCurrentEcet->takeExternalControl();
+        return true;
+      });
+    });
+
+    return false;
+  });
+
+  return result;
+}
+
+UA_StatusCode DebugMGR::onRemoveBreakpoint(UA_Server*,
+  const UA_NodeId*, void*,
+  const UA_NodeId*, void* methodContext,
+  const UA_NodeId*, void* objectContext,
+  size_t, const UA_Variant* input,
+  size_t, UA_Variant*){
+    
+  auto debugMgr = static_cast<DebugMGR*>(methodContext);
+  auto resourceName = static_cast<const char*>(objectContext);
+  UA_StatusCode result = UA_STATUSCODE_BADINVALIDARGUMENT;
+
+  // look for the resource in the device, and inseide of it find the PortId of the Function block, if they exist
+  debugMgr->iterateResources([debugMgr, resourceName, input, &result](CResource* paResource, CFakeEventExecutionThread* paEcet){
+    if(strcmp(paResource->getInstanceName(), resourceName) != 0){
+      // not the resource we are looking for
+      return true;
+    }
+
+    auto uaStringInput = static_cast<UA_String*>(input[0].data);
+    if(auto desiredEventEntry = debugMgr->getEventEntry(paResource, std::string((const char*)uaStringInput->data, uaStringInput->length)); 
+        desiredEventEntry.has_value()){
+      paEcet->removeBreakpoint(desiredEventEntry.value());
+      result = UA_STATUSCODE_GOOD;
+    }
+
+    return false;
+  });
+
+  return result;
+}

--- a/src/stdfblib/ita/debug_device/DebugMGR.h
+++ b/src/stdfblib/ita/debug_device/DebugMGR.h
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Jose Cabral
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Jose Cabral - initial implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "OPCUA_MGR.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+#include <optional>
+
+class CDevice;
+class CResource;
+class CFakeEventExecutionThread;
+
+/**
+ * @brief Owns a OPCUA_MGR and adds device and resource methods on top of that
+ * Device-level Methods:
+ * - Remote Control (bool): void -> Allows enabling/disabling remote control of the device. Pause/Continue buttons in regular debuggers
+ * 
+ * Resource-level methods:
+ * - Trigger Next Event: void -> Execute one event in a resource. Step button in regular debuggers
+ * - Add Breakpoint (string): void -> Adds a breakpoint at certain input port of a function block.
+ * - Remove Breakpoint (string): void -> Removes a breakpoint at certain input port of a function block.
+ */
+class DebugMGR {
+
+public:
+
+  DebugMGR(CDevice& paDevice);
+  ~DebugMGR() = default;
+  
+  /**
+   * @brief Initializes the OpcUa MGR with the extra debugging methods
+   * 
+   * @return true if no problem occurred while initializing, false otherwise.  
+   */
+  bool initialize();
+
+  /**
+   * @brief OpcUa Mgr on top of which the extra debugging methods will be added
+   * 
+   */
+  OPCUA_MGR mOpcuaMgr;
+
+private:
+
+  // device on which the methods will be executed
+  CDevice& mDevice;
+
+  // the definition of the methods (and therefore its arguments) is done in different functions
+  // therefore we need to store the strings for the the arguments so they live until
+  // the methods are created in the opc ua server
+  std::vector<std::string> mArgumentsInformation;
+
+  /**
+   * @brief Store a string and get a reference to it
+   * 
+   * @param paString String to look for from the stored ones
+   * @return reference to the stored string 
+   */
+  std::string& getArgumentString(std::string paString);
+
+  /**
+   * @brief Callback when iterating over the resources of the device. It return true if the iteration should continue,
+   * false otherwise. 
+   */
+  typedef std::function<bool(CResource*, CFakeEventExecutionThread*)> ResourceIteratorCallback;
+
+  /**
+   * @brief Iterates over the resources of the device and calls the callback for each one
+   * 
+   * @param paCallback Function to call for each resource
+   */
+  void iterateResources(ResourceIteratorCallback paCallback);
+
+  /**
+   * @brief Given a resource and the full name to a port, get the EventEntry corresponding to the function block and port
+   * 
+   * @param paResource resource where to look for the EventEntry  
+   * @param paDestination String reprensantion of the full name until the port ID separated by dots
+   * @return the Event Entry if the function block and port id are found, std::nullopt otherwise
+   */
+  std::optional<TEventEntry> getEventEntry(CResource* paResource, std::string paDestination);
+
+  void addRemoteControlMethod();
+
+  void addTriggerNextEventMethod();
+
+  void addAddBreakpointMethod();
+
+  void addRemoveBreakpointMethod();
+
+  static UA_StatusCode onSetRemoteControl(UA_Server*,
+    const UA_NodeId*, void*,
+    const UA_NodeId*, void*,
+    const UA_NodeId*, void*,
+    size_t, const UA_Variant* input,
+    size_t, UA_Variant*);
+
+  static UA_StatusCode onTriggerNextEvent(UA_Server*,
+    const UA_NodeId*, void*,
+    const UA_NodeId*, void* methodContext,
+    const UA_NodeId*, void* objectContext,
+    size_t, const UA_Variant*,
+    size_t, UA_Variant*);
+
+  static UA_StatusCode onAddBreakpoint(UA_Server*,
+    const UA_NodeId*, void*,
+    const UA_NodeId*, void* methodContext,
+    const UA_NodeId*, void* objectContext,
+    size_t, const UA_Variant* input,
+    size_t, UA_Variant*);
+
+  static UA_StatusCode onRemoveBreakpoint(UA_Server*,
+    const UA_NodeId*, void*,
+    const UA_NodeId*, void* methodContext,
+    const UA_NodeId*, void* objectContext,
+    size_t, const UA_Variant* input,
+    size_t, UA_Variant*);
+};

--- a/src/stdfblib/ita/debug_device/DebugMGR.h
+++ b/src/stdfblib/ita/debug_device/DebugMGR.h
@@ -25,7 +25,7 @@ class CResource;
 class CFakeEventExecutionThread;
 
 /**
- * @brief Owns a OPCUA_MGR and adds device and resource methods on top of that
+ * @brief Gets a OPCUA_MGR object and adds device and resource methods on top of that
  * Device-level Methods:
  * - Remote Control (bool): void -> Allows enabling/disabling remote control of the device. Pause/Continue buttons in regular debuggers
  * 
@@ -38,26 +38,24 @@ class DebugMGR {
 
 public:
 
-  DebugMGR(CDevice& paDevice);
+  DebugMGR(CDevice& paDevice, OPCUA_MGR& paOpcuaMgr);
   ~DebugMGR() = default;
   
   /**
-   * @brief Initializes the OpcUa MGR with the extra debugging methods
+   * @brief Add debugging methods to the OPCUA_MGR object
    * 
    * @return true if no problem occurred while initializing, false otherwise.  
    */
   bool initialize();
 
-  /**
-   * @brief OpcUa Mgr on top of which the extra debugging methods will be added
-   * 
-   */
-  OPCUA_MGR mOpcuaMgr;
-
 private:
 
   // device on which the methods will be executed
   CDevice& mDevice;
+  
+  // OpcUa Mgr on top of which the extra debugging methods will be added
+  OPCUA_MGR& mOpcuaMgr;
+
 
   // the definition of the methods (and therefore its arguments) is done in different functions
   // therefore we need to store the strings for the the arguments so they live until


### PR DESCRIPTION
This PR allows pausing, continuing and adding and removing breakpoints. 

1. The FakeEcet was adapted with the desired behaviour when debugging
2. The OPCUA_MGR was changed to allow new methods to be added to the ones it implements
3. A DebugMGR builds on top of the OPCUA_MGR and adds the following functionalities:
   - enable/disable remote control (pausing/ resuming forte)
   - add/remove breakpoints: hitting on a breakpoints will halt forte and all ecets are set to remote control
 4. A DebugDevice simply contain a DebugMGR and is added to the list of devices that can be compiled