### PR TITLE
Add parseTypeName method to CommandParser

### DIFF
--- a/src/stdfblib/ita/CommandParser.cpp
+++ b/src/stdfblib/ita/CommandParser.cpp
@@ -297,7 +297,7 @@ bool CommandParser::parseFBData(char *paRequestPartLeft){
     if(acBuf != nullptr){
       if(acBuf[1] != '*'){
         ++acBuf;
-        i = parseIdentifier(acBuf, mCommand.mSecondParam);
+        i = parseTypeName(acBuf, mCommand.mSecondParam);
         if(-1 != i){
           acBuf = strchr(&(acBuf[i + 1]), '\"');
           if(acBuf != nullptr){
@@ -336,6 +336,18 @@ int CommandParser::parseIdentifier(char *paIdentifierStart, forte::core::TNameId
     }
   }
   return -1;
+}
+
+int CommandParser::parseTypeName(const std::string_view paTypeName, forte::core::TNameIdentifier &paIdentifier){
+  size_t endIndex = paTypeName.find('"');
+  if(endIndex == std::string::npos) {
+    return -1;
+  }
+  const std::string_view result = paTypeName.substr(0, endIndex);
+  if(!paIdentifier.pushBack(CStringDictionary::getInstance().insert(result.data(), result.length()))){
+    return -1;
+  }
+  return static_cast<int>(result.length());
 }
 
 bool CommandParser::parseConnectionData(char *paRequestPartLeft){

--- a/src/stdfblib/ita/CommandParser.h
+++ b/src/stdfblib/ita/CommandParser.h
@@ -114,6 +114,14 @@ namespace forte::ita {
       */
     int parseIdentifier(char *paIdentifierStart, forte::core::TNameIdentifier &paIdentifier);
 
+    /*! \brief Parse the name of the type
+      *
+      * @param paTypeName string containing the type name that will be parsed
+      * @param paIdentifier identifier vector where to write the parsed identifiers to
+      * @return number of bytes used from the character array or -1 if the identifier could not be parsed
+      */
+    int parseTypeName(const std::string_view paTypeName, forte::core::TNameIdentifier &paIdentifier);
+
   #ifdef FORTE_SUPPORT_MONITORING
     bool parseMonitoringData(char *paRequestPartLeft);
     std::string generateMonitorResponse();


### PR DESCRIPTION
Use parseTypeName to parse the CreateFB request instead of parseIdentifier