### PR TITLE
Use PARAMS input to specify ID for I/O mapping

### DIFF
--- a/src/core/io/processinterface.cpp
+++ b/src/core/io/processinterface.cpp
@@ -71,7 +71,7 @@ bool ProcessInterface::initialise(bool paIsInput, CEventChainExecutionThread *co
 // If PARAMS is not empty use the string specified here "as is" for the IO mapping to the configuration.
 // Otherwise use the full qualified instance name of our FB.
 std::string ProcessInterface::getId() {
-  if (PARAMS().length()) {  
+  if (!PARAMS().empty()) {  
     return static_cast<std::string>(PARAMS());
   }
   else {

--- a/src/core/io/processinterface.cpp
+++ b/src/core/io/processinterface.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Johannes Messmer (admin@jomess.com), fortiss GmbH,
- *                          Johannes Kepler University Linz
+ * Copyright (c) 2016, 2025 Johannes Messmer (admin@jomess.com), fortiss GmbH,
+ *                          Johannes Kepler University Linz, Thomas Öllinger
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -56,13 +56,7 @@ bool ProcessInterface::initialise(bool paIsInput, CEventChainExecutionThread *co
   deinitialise();
 
   // Register interface
-  if (PARAMS().length()) {  // If PARAMS is not empty we use the string specified here "as is" for the IO mapping to the configuration. Otherwise use the full qualified instance name of our FB.
-    if (!(mIsListening = IOMapper::getInstance().registerObserver(std::string(PARAMS().c_str()), this))) {
-      STATUS() = scmFailedToRegister;
-      return false;
-    }
-  }
-  else if(!(mIsListening = IOMapper::getInstance().registerObserver(getFullQualifiedApplicationInstanceName('.'), this))) {
+  if(!(mIsListening = IOMapper::getInstance().registerObserver(getId(), this))) {
     STATUS() = scmFailedToRegister;
     return false;
   }
@@ -72,6 +66,17 @@ bool ProcessInterface::initialise(bool paIsInput, CEventChainExecutionThread *co
   }
 
   return mIsReady;
+}
+
+// If PARAMS is not empty use the string specified here "as is" for the IO mapping to the configuration.
+// Otherwise use the full qualified instance name of our FB.
+std::string ProcessInterface::getId() {
+  if (PARAMS().length()) {  
+    return PARAMS().getStorage();
+  }
+  else {
+    return getFullQualifiedApplicationInstanceName('.');
+  }
 }
 
 bool ProcessInterface::deinitialise() {

--- a/src/core/io/processinterface.cpp
+++ b/src/core/io/processinterface.cpp
@@ -72,7 +72,7 @@ bool ProcessInterface::initialise(bool paIsInput, CEventChainExecutionThread *co
 // Otherwise use the full qualified instance name of our FB.
 std::string ProcessInterface::getId() {
   if (PARAMS().length()) {  
-    return PARAMS().getStorage();
+    return static_cast<std::string>(PARAMS());
   }
   else {
     return getFullQualifiedApplicationInstanceName('.');

--- a/src/core/io/processinterface.cpp
+++ b/src/core/io/processinterface.cpp
@@ -12,6 +12,7 @@
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
  *   Alois Zoitl - further clean-ups and performance improvements on IOHandle
+ *   Thomas Öllinger - use PARAMS to reference to I/O configuration
  *******************************************************************************/
 
 #include "processinterface.h"
@@ -55,7 +56,13 @@ bool ProcessInterface::initialise(bool paIsInput, CEventChainExecutionThread *co
   deinitialise();
 
   // Register interface
-  if(!(mIsListening = IOMapper::getInstance().registerObserver(getFullQualifiedApplicationInstanceName('.'), this))) {
+  if (PARAMS().length()) {  // If PARAMS is not empty we use the string specified here "as is" for the IO mapping to the configuration. Otherwise use the full qualified instance name of our FB.
+    if (!(mIsListening = IOMapper::getInstance().registerObserver(std::string(PARAMS().c_str()), this))) {
+      STATUS() = scmFailedToRegister;
+      return false;
+    }
+  }
+  else if(!(mIsListening = IOMapper::getInstance().registerObserver(getFullQualifiedApplicationInstanceName('.'), this))) {
     STATUS() = scmFailedToRegister;
     return false;
   }

--- a/src/core/io/processinterface.h
+++ b/src/core/io/processinterface.h
@@ -40,7 +40,6 @@ namespace forte {
         protected:
           bool initialise(bool paIsInput, CEventChainExecutionThread *const paECET);
           bool deinitialise();
-          std::string getId();
           bool readPin() {
             return read(IN_X());
           }
@@ -92,6 +91,8 @@ namespace forte {
           static const CIEC_STRING scmMappedWrongDirectionOutput;
           static const CIEC_STRING scmMappedWrongDirectionInput;
           static const CIEC_STRING scmMappedWrongDataType;
+          
+          std::string getId(); 
       };
 
     } //namespace IO

--- a/src/core/io/processinterface.h
+++ b/src/core/io/processinterface.h
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2016 - 2018 Johannes Messmer (admin@jomess.com), fortiss GmbH
+ * Copyright (c) 2016 - 2025 Johannes Messmer (admin@jomess.com), fortiss GmbH,
+ *                           Thomas Öllinger
+ * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +11,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
+ *   Thomas Öllinger - added getId method to detremine Id for reference to I/O configuration
  *******************************************************************************/
 
 #ifndef SRC_CORE_IO_PROCESSINTERFACE_H_
@@ -37,6 +40,7 @@ namespace forte {
         protected:
           bool initialise(bool paIsInput, CEventChainExecutionThread *const paECET);
           bool deinitialise();
+          std::string getId();
           bool readPin() {
             return read(IN_X());
           }


### PR DESCRIPTION
For I/O read and write function blocks the PARAMS input can now be used to specify the ID of the I/O that should be accessed.
If PARAMS ist empty the full qualified instance name of the I/O read or write function block is used like before. 
The ID is defined via the I/O configuration function blocks.
