### PR TITLE
Enable Typesafe AND/OR/XOR Operators

### DIFF
--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -1,6 +1,5 @@
 /*******************************************************************************
- * Copyright (c)2018 Johannes Kepler University
- *               2023 Martin Erich Jobst
+ * Copyright (c)2018, 2024 Johannes Kepler University, Martin Erich Jobst, HR Agartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +12,8 @@
  *   Martin Jobst
  *     - refactor for ANY variant
  *     - add generic readInputData and writeOutputData
+ *   Fanz Höpfinger
+ *     - enable Typesafe Blocks
  *******************************************************************************/
 #include "genbitbase_fbt.h"
 #ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP

--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -51,7 +51,7 @@ bool CGenBitBase::createInterfaceSpec(const char *paConfigString, SFBInterfaceSp
   const char *pcPos = strrchr(paConfigString, '_');
 
   if (nullptr != pcPos) {
-    pcPos++;
+    pcPos++;  // move after underscore
     //we have an underscore and it is the first underscore after AND/OR/XOR
     paInterfaceSpec.mNumDIs = static_cast<TPortId>(forte::core::util::strtoul(pcPos, nullptr, 10));
     DEVLOG_DEBUG("DIs: %d;\n", paInterfaceSpec.mNumDIs);

--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -48,7 +48,7 @@ void CGenBitBase::writeOutputData(TEventID) {
 }
 
 bool CGenBitBase::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
-  const char *pcPos = strrchr(paConfigString, '_');
+  const char *pcPos = strchr(paConfigString, '_');
 
   if (nullptr != pcPos) {
     pcPos++;  // move after underscore

--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -52,7 +52,7 @@ bool CGenBitBase::createInterfaceSpec(const char *paConfigString, SFBInterfaceSp
 
   if (nullptr != pcPos) {
     pcPos++;
-    //we have an underscore and it is the first underscore after AND
+    //we have an underscore and it is the first underscore after AND/OR/XOR
     paInterfaceSpec.mNumDIs = static_cast<TPortId>(forte::core::util::strtoul(pcPos, nullptr, 10));
     DEVLOG_DEBUG("DIs: %d;\n", paInterfaceSpec.mNumDIs);
   } else {


### PR DESCRIPTION
Enable Typesafe AND/OR/XOR Operators

This Minimal Change enables the use of Typesafe Blocks in IDE. 
Details to be explained in a Issue. 