### PR TITLE
Refactor GEN_E_MUX for better clarity

### DIFF
--- a/src/stdfblib/events/GEN_E_MUX_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_MUX_fbt.cpp
@@ -25,8 +25,11 @@ USE_STRING_ID(UINT);
 
 #include <stdio.h>
 
-#include "resource.h"
-#include "criticalregion.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_E_MUX, STRID(GEN_E_MUX));
 
@@ -34,24 +37,39 @@ const CStringDictionary::TStringId GEN_E_MUX::scmDataOutputNames[] = { STRID(K) 
 const CStringDictionary::TStringId GEN_E_MUX::scmDODataTypeIds[] = { STRID(UINT) };
 
 const CStringDictionary::TStringId GEN_E_MUX::scmEventOutputNames[] = { STRID(EO) };
-const CStringDictionary::TStringId GEN_E_MUX::scmEventOutputTypeIds[] = { STRID(Event) };
 
 GEN_E_MUX::GEN_E_MUX(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
-    CGenFunctionBlock<CFunctionBlock>(paContainer, paInstanceNameId) {
+    CGenFunctionBlock<CFunctionBlock>(paContainer, paInstanceNameId),
+    var_K(0_UINT),
+    var_conn_K(var_K),
+    conn_EO(this, 0),
+    conn_K(this, 0, &var_conn_K) {
+};
+
+void GEN_E_MUX::setInitialValues() {
+  var_K = 0_UINT;
 }
 
-void GEN_E_MUX::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
+void GEN_E_MUX::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
   if(paEIID < getFBInterfaceSpec().mNumEIs){
-    K() = CIEC_UINT(static_cast<TForteUInt16>(paEIID));
+    var_K = CIEC_UINT(static_cast<TForteUInt16>(paEIID));
     sendOutputEvent(scmEventEOID, paECET);
   }
 }
 
 void GEN_E_MUX::readInputData(TEventID) {
+  // nothing to do
 }
 
-void GEN_E_MUX::writeOutputData(TEventID) {
-  writeData(0, *mDOs[0], mDOConns[0]);
+void GEN_E_MUX::writeOutputData(const TEventID paEIID) {
+  switch(paEIID) {
+    case scmEventEOID: {
+      writeData(0, var_K, conn_K);
+      break;
+    }
+    default:
+      break;
+  }
 }
 
 bool GEN_E_MUX::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec){
@@ -64,21 +82,21 @@ bool GEN_E_MUX::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec
       paInterfaceSpec.mNumEIs = static_cast<TEventID>(forte::core::util::strtoul(acPos, nullptr, 10));
 
       if(paInterfaceSpec.mNumEIs < CFunctionBlock::scmMaxInterfaceEvents && paInterfaceSpec.mNumEIs >= 2){
-        mEventInputNames = std::make_unique<CStringDictionary::TStringId[]>(paInterfaceSpec.mNumEIs);
+        scmEventInputNames = std::make_unique<CStringDictionary::TStringId[]>(paInterfaceSpec.mNumEIs);
 
-        generateGenericInterfacePointNameArray("EI", mEventInputNames.get(), paInterfaceSpec.mNumEIs);
+        generateGenericInterfacePointNameArray("EI", scmEventInputNames.get(), paInterfaceSpec.mNumEIs);
 
-        paInterfaceSpec.mEINames = mEventInputNames.get();
+        paInterfaceSpec.mEINames = scmEventInputNames.get();
         paInterfaceSpec.mNumEOs = 1;
         paInterfaceSpec.mEONames = scmEventOutputNames;
         paInterfaceSpec.mEITypeNames = nullptr;
-        paInterfaceSpec.mEOTypeNames = scmEventOutputTypeIds;
+        paInterfaceSpec.mEOTypeNames = nullptr;
         paInterfaceSpec.mNumDIs = 0;
         paInterfaceSpec.mDINames = nullptr;
         paInterfaceSpec.mDIDataTypeNames = nullptr;
         paInterfaceSpec.mNumDOs = 1;
         paInterfaceSpec.mDONames = scmDataOutputNames;
-        paInterfaceSpec.mDODataTypeNames = scmDODataTypeIds;
+        paInterfaceSpec.mDODataTypeNames = scmDataOutputTypeIds;
         return true;
       }
       else{
@@ -92,4 +110,33 @@ bool GEN_E_MUX::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec
     }
   }
   return false;
+}
+
+CIEC_ANY *GEN_E_MUX::getDI(size_t) {
+  return nullptr;
+}
+
+CIEC_ANY *GEN_E_MUX::getDO(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_K;
+  }
+  return nullptr;
+}
+
+CEventConnection *GEN_E_MUX::getEOConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_EO;
+  }
+  return nullptr;
+}
+
+CDataConnection **GEN_E_MUX::getDIConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection *GEN_E_MUX::getDOConUnchecked(const TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_K;
+  }
+  return nullptr;
 }

--- a/src/stdfblib/events/GEN_E_MUX_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_MUX_fbt.cpp
@@ -36,7 +36,7 @@ USE_STRING_ID(UINT);
 DEFINE_GENERIC_FIRMWARE_FB(GEN_E_MUX, STRID(GEN_E_MUX));
 
 const CStringDictionary::TStringId GEN_E_MUX::scmDataOutputNames[] = { STRID(K) };
-const CStringDictionary::TStringId GEN_E_MUX::scmDODataTypeIds[] = { STRID(UINT) };
+const CStringDictionary::TStringId GEN_E_MUX::scmDataOutputTypeIds[] = { STRID(UINT) };
 
 const CStringDictionary::TStringId GEN_E_MUX::scmEventOutputNames[] = { STRID(EO) };
 

--- a/src/stdfblib/events/GEN_E_MUX_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_MUX_fbt.cpp
@@ -1,7 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 ACIN, Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2011, 2025 ACIN, Profactor GmbH, fortiss GmbH
  *                          Johannes Kepler University
  *                          Martin Erich Jobst
+ *                          HR Agrartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +15,7 @@
  *     - initial API and implementation and/or initial documentation
  *    Alois Zoitl - introduced new CGenFB class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
+ *....Franz Höpfinger - Update it to represent latest Generation Format from 4diac IDE. no Functional Changes. 
  *******************************************************************************/
 #include "GEN_E_MUX_fbt.h"
 

--- a/src/stdfblib/events/GEN_E_MUX_fbt.h
+++ b/src/stdfblib/events/GEN_E_MUX_fbt.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 ACIN, Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2011, 2025 ACIN
  *                          Johannes Kepler University
  *                          Martin Erich Jobst
  *                          HR Agrartechnik GmbH
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Alois Zoitl, Matthias Plasch
+ *   Alois Zoitl
  *     - initial API and implementation and/or initial documentation
  *    Alois Zoitl - introduced new CGenFB class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData

--- a/src/stdfblib/events/GEN_E_MUX_fbt.h
+++ b/src/stdfblib/events/GEN_E_MUX_fbt.h
@@ -1,7 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 ACIN
+ * Copyright (c) 2011, 2025 ACIN, Profactor GmbH, fortiss GmbH
  *                          Johannes Kepler University
  *                          Martin Erich Jobst
+ *                          HR Agrartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,45 +11,60 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Alois Zoitl
+ *   Alois Zoitl, Matthias Plasch
  *     - initial API and implementation and/or initial documentation
  *    Alois Zoitl - introduced new CGenFB class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
+ *....Franz Höpfinger - Update it to represent latest Generation Format from 4diac IDE. no Functional Changes. 
  *******************************************************************************/
-#ifndef _GEN_E_MUX_H_
-#define _GEN_E_MUX_H_
 
-#include <genfb.h>
+#pragma once
 
-#include <memory>
+#include "genfb.h"
+#include "forte_uint.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 
-class GEN_E_MUX : public CGenFunctionBlock<CFunctionBlock>{
+class GEN_E_MUX final : public CGenFunctionBlock<CFunctionBlock> {
   DECLARE_GENERIC_FIRMWARE_FB(GEN_E_MUX)
 
   private:
-    static const CStringDictionary::TStringId scmDataOutputNames[], scmDODataTypeIds[];
+    static const CStringDictionary::TStringId scmDataOutputNames[];
+    static const CStringDictionary::TStringId scmDataOutputTypeIds[];
 
+    std::unique_ptr<CStringDictionary::TStringId[]> scmEventInputNames;
     static const TEventID scmEventEOID = 0;
     static const CStringDictionary::TStringId scmEventOutputNames[];
-    static const CStringDictionary::TStringId scmEventOutputTypeIds[];
 
-    std::unique_ptr<CStringDictionary::TStringId[]> mEventInputNames;
-    std::unique_ptr<CStringDictionary::TStringId[]> mEventInputTypeIds;
+
 
     void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
-    void readInputData(TEventID paEI) override;
-    void writeOutputData(TEventID paEO) override;
+    void readInputData(TEventID paEIID) override;
+    void writeOutputData(TEventID paEIID) override;
+    void setInitialValues() override;
 
     bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
-    CIEC_UINT& K(){
-      return *static_cast<CIEC_UINT*>(getDO(0));
-    }
-
   public:
-    GEN_E_MUX(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-    ~GEN_E_MUX() override = default;
+    GEN_E_MUX(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+
+    CIEC_UINT var_K;
+
+    CIEC_UINT var_conn_K;
+
+    CEventConnection conn_EO;
+
+    CDataConnection conn_K;
+
+    CIEC_ANY *getDI(size_t) override;
+    CIEC_ANY *getDO(size_t) override;
+    CEventConnection *getEOConUnchecked(TPortId) override;
+    CDataConnection **getDIConUnchecked(TPortId) override;
+    CDataConnection *getDOConUnchecked(TPortId) override;
 
 };
-#endif //_GEN_E_MUX_H_
+


### PR DESCRIPTION
Update it to represent latest Generation Format from 4diac IDE.
no Functional Changes.

easier to follow how Generic Blocks work.
