### PR TITLE
Generated PLCnext fbt files from IDE to also use EInit

### DIFF
--- a/src/modules/PLCnext/types/PLCnextAXLSEDI16.cpp
+++ b/src/modules/PLCnext/types/PLCnextAXLSEDI16.cpp
@@ -1,20 +1,33 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/************************************************************************* 
+ *** Copyright (c) 2022 Peirlberger Juergen  
+ ***  
+ *** This program and the accompanying materials are made  
+ *** available under the terms of the Eclipse Public License 2.0  
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/  
+ ***  
+ *** SPDX-License-Identifier: EPL-2.0   
+ *** 
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextAXLSEDI16
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #include "PLCnextAXLSEDI16.h"
 #ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
 #include "PLCnextAXLSEDI16_gen.cpp"
 #endif
 
+#include "PLCnextBusAdapter.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #include "criticalregion.h"
 #include "resource.h"
 
@@ -31,7 +44,7 @@ const CStringDictionary::TStringId FORTE_PLCnextAXLSEDI16::scmEventInputTypeIds[
 const TDataIOID FORTE_PLCnextAXLSEDI16::scmEOWith[] = {0, 1, scmWithListDelimiter, 0, 1, scmWithListDelimiter};
 const TForteInt16 FORTE_PLCnextAXLSEDI16::scmEOWithIndexes[] = {0, 3};
 const CStringDictionary::TStringId FORTE_PLCnextAXLSEDI16::scmEventOutputNames[] = {g_nStringIdINITO, g_nStringIdIND};
-const CStringDictionary::TStringId FORTE_PLCnextAXLSEDI16::scmEventOutputTypeIds[] = {g_nStringIdEvent, g_nStringIdEvent};
+const CStringDictionary::TStringId FORTE_PLCnextAXLSEDI16::scmEventOutputTypeIds[] = {g_nStringIdEInit, g_nStringIdEvent};
 const SAdapterInstanceDef FORTE_PLCnextAXLSEDI16::scmAdapterInstances[] = {
   {g_nStringIdPLCnextBusAdapter, g_nStringIdBusAdapterIn, false},
   {g_nStringIdPLCnextBusAdapter, g_nStringIdBusAdapterOut, true}
@@ -47,6 +60,27 @@ const SFBInterfaceSpec FORTE_PLCnextAXLSEDI16::scmFBInterfaceSpec = {
 
 FORTE_PLCnextAXLSEDI16::FORTE_PLCnextAXLSEDI16(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
     PLCnextSlaveHandler (PLCnextSlaveHandler::Input, pa_poSrcRes, &scm_stFBInterfaceSpec, pa_nInstanceNameId, m_anFBConnData, m_anFBVarsData),
+    var_QI(0_BOOL),
+    var_DI_1(""_STRING),
+    var_DI_2(""_STRING),
+    var_DI_3(""_STRING),
+    var_DI_4(""_STRING),
+    var_DI_5(""_STRING),
+    var_DI_6(""_STRING),
+    var_DI_7(""_STRING),
+    var_DI_8(""_STRING),
+    var_DI_9(""_STRING),
+    var_DI_10(""_STRING),
+    var_DI_11(""_STRING),
+    var_DI_12(""_STRING),
+    var_DI_13(""_STRING),
+    var_DI_14(""_STRING),
+    var_DI_15(""_STRING),
+    var_DI_16(""_STRING),
+    var_QO(0_BOOL),
+    var_STATUS(u""_WSTRING),
+    var_BusAdapterIn(g_nStringIdBusAdapterIn, *this, false),
+    var_BusAdapterOut(g_nStringIdBusAdapterOut, *this, true),
     var_conn_QO(var_QO),
     var_conn_STATUS(var_STATUS),
     conn_INITO(this, 0),
@@ -71,6 +105,14 @@ FORTE_PLCnextAXLSEDI16::FORTE_PLCnextAXLSEDI16(const CStringDictionary::TStringI
     conn_QO(this, 0, &var_conn_QO),
     conn_STATUS(this, 1, &var_conn_STATUS) {
 };
+
+bool FORTE_PLCnextAXLSEDI16::initialize() {
+  if(!var_BusAdapterIn.initialize()) { return false; }
+  if(!var_BusAdapterOut.initialize()) { return false; }
+  var_BusAdapterIn.setParentFB(this, 0);
+  var_BusAdapterOut.setParentFB(this, 1);
+  return CFunctionBlock::initialize();
+}
 
 void FORTE_PLCnextAXLSEDI16::setInitialValues() {
   var_QI = 0_BOOL;
@@ -165,6 +207,14 @@ CIEC_ANY *FORTE_PLCnextAXLSEDI16::getDO(const size_t paIndex) {
   switch(paIndex) {
     case 0: return &var_QO;
     case 1: return &var_STATUS;
+  }
+  return nullptr;
+}
+
+CAdapter *FORTE_PLCnextAXLSEDI16::getAdapterUnchecked(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_BusAdapterIn;
+    case 1: return &var_BusAdapterOut;
   }
   return nullptr;
 }

--- a/src/modules/PLCnext/types/PLCnextAXLSEDI16.h
+++ b/src/modules/PLCnext/types/PLCnextAXLSEDI16.h
@@ -1,19 +1,28 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextAXLSEDI16
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
+
 #pragma once
 
 #include "funcbloc.h"
 #include "forte_bool.h"
 #include "forte_string.h"
+#include "forte_uint.h"
 #include "forte_wstring.h"
 #include "iec61131_functions.h"
 #include "forte_array_common.h"
@@ -48,12 +57,14 @@ private:
 
   static const SFBInterfaceSpec scmFBInterfaceSpec;
 
+  void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
   void readInputData(TEventID paEIID) override;
   void writeOutputData(TEventID paEIID) override;
   void setInitialValues() override;
 
-    const char* init() override;
-    void initHandles() override;
+  const char* init() override;
+  void initHandles() override;
   
 public:
   FORTE_PLCnextAXLSEDI16(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
@@ -78,6 +89,10 @@ public:
 
   CIEC_BOOL var_QO;
   CIEC_WSTRING var_STATUS;
+
+  FORTE_PLCnextBusAdapter var_BusAdapterIn;
+
+  FORTE_PLCnextBusAdapter var_BusAdapterOut;
 
   CIEC_BOOL var_conn_QO;
   CIEC_WSTRING var_conn_STATUS;
@@ -108,6 +123,7 @@ public:
 
   CIEC_ANY *getDI(size_t) override;
   CIEC_ANY *getDO(size_t) override;
+  CAdapter *getAdapterUnchecked(size_t) override;
   FORTE_PLCnextBusAdapter &var_BusAdapterIn() {
     return *static_cast<FORTE_PLCnextBusAdapter*>(mAdapters[0]);
   };
@@ -147,5 +163,4 @@ public:
     evt_INIT(paQI, paDI_1, paDI_2, paDI_3, paDI_4, paDI_5, paDI_6, paDI_7, paDI_8, paDI_9, paDI_10, paDI_11, paDI_12, paDI_13, paDI_14, paDI_15, paDI_16, paQO, paSTATUS);
   }
 };
-
 

--- a/src/modules/PLCnext/types/PLCnextAXLSEDO16.cpp
+++ b/src/modules/PLCnext/types/PLCnextAXLSEDO16.cpp
@@ -1,20 +1,34 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextAXLSEDO16
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #include "PLCnextAXLSEDO16.h"
 #ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
 #include "PLCnextAXLSEDO16_gen.cpp"
 #endif
 
+#include "PLCnextBusAdapter.h"
+#include "forte_string.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #include "criticalregion.h"
 #include "resource.h"
 
@@ -31,7 +45,7 @@ const CStringDictionary::TStringId FORTE_PLCnextAXLSEDO16::scmEventInputTypeIds[
 const TDataIOID FORTE_PLCnextAXLSEDO16::scmEOWith[] = {0, 1, scmWithListDelimiter, 0, 1, scmWithListDelimiter};
 const TForteInt16 FORTE_PLCnextAXLSEDO16::scmEOWithIndexes[] = {0, 3};
 const CStringDictionary::TStringId FORTE_PLCnextAXLSEDO16::scmEventOutputNames[] = {g_nStringIdINITO, g_nStringIdIND};
-const CStringDictionary::TStringId FORTE_PLCnextAXLSEDO16::scmEventOutputTypeIds[] = {g_nStringIdEvent, g_nStringIdEvent};
+const CStringDictionary::TStringId FORTE_PLCnextAXLSEDO16::scmEventOutputTypeIds[] = {g_nStringIdEInit, g_nStringIdEvent};
 const SAdapterInstanceDef FORTE_PLCnextAXLSEDO16::scmAdapterInstances[] = {
   {g_nStringIdPLCnextBusAdapter, g_nStringIdBusAdapterIn, false},
   {g_nStringIdPLCnextBusAdapter, g_nStringIdBusAdapterOut, true}
@@ -47,7 +61,27 @@ const SFBInterfaceSpec FORTE_PLCnextAXLSEDO16::scmFBInterfaceSpec = {
 
 FORTE_PLCnextAXLSEDO16::FORTE_PLCnextAXLSEDO16(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
    PLCnextSlaveHandler (PLCnextSlaveHandler::Output, pa_poSrcRes, &scm_stFBInterfaceSpec, pa_nInstanceNameId, m_anFBConnData, m_anFBVarsData),
+    var_QI(0_BOOL),
     var_DO_1(""_STRING),
+    var_DO_2(""_STRING),
+    var_DO_3(""_STRING),
+    var_DO_4(""_STRING),
+    var_DO_5(""_STRING),
+    var_DO_6(""_STRING),
+    var_DO_7(""_STRING),
+    var_DO_8(""_STRING),
+    var_DO_9(""_STRING),
+    var_DO_10(""_STRING),
+    var_DO_11(""_STRING),
+    var_DO_12(""_STRING),
+    var_DO_13(""_STRING),
+    var_DO_14(""_STRING),
+    var_DO_15(""_STRING),
+    var_DO_16(""_STRING),
+    var_QO(0_BOOL),
+    var_STATUS(u""_WSTRING),
+    var_BusAdapterIn(g_nStringIdBusAdapterIn, *this, false),
+    var_BusAdapterOut(g_nStringIdBusAdapterOut, *this, true),
     var_conn_QO(var_QO),
     var_conn_STATUS(var_STATUS),
     conn_INITO(this, 0),
@@ -72,6 +106,14 @@ FORTE_PLCnextAXLSEDO16::FORTE_PLCnextAXLSEDO16(const CStringDictionary::TStringI
     conn_QO(this, 0, &var_conn_QO),
     conn_STATUS(this, 1, &var_conn_STATUS) {
 };
+
+bool FORTE_PLCnextAXLSEDO16::initialize() {
+  if(!var_BusAdapterIn.initialize()) { return false; }
+  if(!var_BusAdapterOut.initialize()) { return false; }
+  var_BusAdapterIn.setParentFB(this, 0);
+  var_BusAdapterOut.setParentFB(this, 1);
+  return CFunctionBlock::initialize();
+}
 
 void FORTE_PLCnextAXLSEDO16::setInitialValues() {
   var_QI = 0_BOOL;
@@ -166,6 +208,14 @@ CIEC_ANY *FORTE_PLCnextAXLSEDO16::getDO(const size_t paIndex) {
   switch(paIndex) {
     case 0: return &var_QO;
     case 1: return &var_STATUS;
+  }
+  return nullptr;
+}
+
+CAdapter *FORTE_PLCnextAXLSEDO16::getAdapterUnchecked(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_BusAdapterIn;
+    case 1: return &var_BusAdapterOut;
   }
   return nullptr;
 }

--- a/src/modules/PLCnext/types/PLCnextAXLSEDO16.h
+++ b/src/modules/PLCnext/types/PLCnextAXLSEDO16.h
@@ -1,20 +1,28 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextAXLSEDO16
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #pragma once
 
 #include "funcbloc.h"
 #include "forte_bool.h"
 #include "forte_string.h"
+#include "forte_uint.h"
 #include "forte_wstring.h"
 #include "iec61131_functions.h"
 #include "forte_array_common.h"
@@ -52,6 +60,8 @@ private:
 
   static const SFBInterfaceSpec scmFBInterfaceSpec;
 
+  void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
   void readInputData(TEventID paEIID) override;
   void writeOutputData(TEventID paEIID) override;
   void setInitialValues() override;
@@ -61,6 +71,7 @@ private:
 
 public:
   FORTE_PLCnextAXLSEDO16(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+  bool initialize() override;
 
   CIEC_BOOL var_QI;
   CIEC_STRING var_DO_1;
@@ -82,6 +93,10 @@ public:
 
   CIEC_BOOL var_QO;
   CIEC_WSTRING var_STATUS;
+
+  FORTE_PLCnextBusAdapter var_BusAdapterIn;
+
+  FORTE_PLCnextBusAdapter var_BusAdapterOut;
 
   CIEC_BOOL var_conn_QO;
   CIEC_WSTRING var_conn_STATUS;
@@ -112,6 +127,7 @@ public:
 
   CIEC_ANY *getDI(size_t) override;
   CIEC_ANY *getDO(size_t) override;
+  CAdapter *getAdapterUnchecked(size_t) override;
   FORTE_PLCnextBusAdapter &var_BusAdapterIn() {
     return *static_cast<FORTE_PLCnextBusAdapter*>(mAdapters[0]);
   };
@@ -151,5 +167,4 @@ public:
     evt_INIT(paQI, paDO_1, paDO_2, paDO_3, paDO_4, paDO_5, paDO_6, paDO_7, paDO_8, paDO_9, paDO_10, paDO_11, paDO_12, paDO_13, paDO_14, paDO_15, paDO_16, paQO, paSTATUS);
   }
 };
-
 

--- a/src/modules/PLCnext/types/PLCnextAXLSESC.cpp
+++ b/src/modules/PLCnext/types/PLCnextAXLSESC.cpp
@@ -1,20 +1,33 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextAXLSESC
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #include "PLCnextAXLSESC.h"
 #ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
 #include "PLCnextAXLSESC_gen.cpp"
 #endif
 
+#include "PLCnextBusAdapter.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #include "criticalregion.h"
 #include "resource.h"
 
@@ -31,7 +44,7 @@ const CStringDictionary::TStringId FORTE_PLCnextAXLSESC::scmEventInputTypeIds[] 
 const TDataIOID FORTE_PLCnextAXLSESC::scmEOWith[] = {0, 1, scmWithListDelimiter, 0, 1, scmWithListDelimiter};
 const TForteInt16 FORTE_PLCnextAXLSESC::scmEOWithIndexes[] = {0, 3};
 const CStringDictionary::TStringId FORTE_PLCnextAXLSESC::scmEventOutputNames[] = {g_nStringIdINITO, g_nStringIdIND};
-const CStringDictionary::TStringId FORTE_PLCnextAXLSESC::scmEventOutputTypeIds[] = {g_nStringIdEvent, g_nStringIdEvent};
+const CStringDictionary::TStringId FORTE_PLCnextAXLSESC::scmEventOutputTypeIds[] = {g_nStringIdEInit, g_nStringIdEvent};
 const SAdapterInstanceDef FORTE_PLCnextAXLSESC::scmAdapterInstances[] = {
   {g_nStringIdPLCnextBusAdapter, g_nStringIdBusAdapterIn, false},
   {g_nStringIdPLCnextBusAdapter, g_nStringIdBusAdapterOut, true}
@@ -47,6 +60,11 @@ const SFBInterfaceSpec FORTE_PLCnextAXLSESC::scmFBInterfaceSpec = {
 
 FORTE_PLCnextAXLSESC::FORTE_PLCnextAXLSESC(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
     PLCnextSlaveHandler (PLCnextSlaveHandler::NoUsage, pa_poSrcRes, &scm_stFBInterfaceSpec, pa_nInstanceNameId, m_anFBConnData, m_anFBVarsData),
+    var_QI(0_BOOL),
+    var_QO(0_BOOL),
+    var_STATUS(u""_WSTRING),
+    var_BusAdapterIn(g_nStringIdBusAdapterIn, *this, false),
+    var_BusAdapterOut(g_nStringIdBusAdapterOut, *this, true),
     var_conn_QO(var_QO),
     var_conn_STATUS(var_STATUS),
     conn_INITO(this, 0),
@@ -55,6 +73,14 @@ FORTE_PLCnextAXLSESC::FORTE_PLCnextAXLSESC(const CStringDictionary::TStringId pa
     conn_QO(this, 0, &var_conn_QO),
     conn_STATUS(this, 1, &var_conn_STATUS) {
 };
+
+bool FORTE_PLCnextAXLSESC::initialize() {
+  if(!var_BusAdapterIn.initialize()) { return false; }
+  if(!var_BusAdapterOut.initialize()) { return false; }
+  var_BusAdapterIn.setParentFB(this, 0);
+  var_BusAdapterOut.setParentFB(this, 1);
+  return CFunctionBlock::initialize();
+}
 
 void FORTE_PLCnextAXLSESC::setInitialValues() {
   var_QI = 0_BOOL;
@@ -101,6 +127,14 @@ CIEC_ANY *FORTE_PLCnextAXLSESC::getDO(const size_t paIndex) {
   switch(paIndex) {
     case 0: return &var_QO;
     case 1: return &var_STATUS;
+  }
+  return nullptr;
+}
+
+CAdapter *FORTE_PLCnextAXLSESC::getAdapterUnchecked(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_BusAdapterIn;
+    case 1: return &var_BusAdapterOut;
   }
   return nullptr;
 }

--- a/src/modules/PLCnext/types/PLCnextAXLSESC.h
+++ b/src/modules/PLCnext/types/PLCnextAXLSESC.h
@@ -1,19 +1,27 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextAXLSESC
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #pragma once
 
 #include "funcbloc.h"
 #include "forte_bool.h"
+#include "forte_uint.h"
 #include "forte_wstring.h"
 #include "iec61131_functions.h"
 #include "forte_array_common.h"
@@ -48,6 +56,8 @@ private:
 
   static const SFBInterfaceSpec scmFBInterfaceSpec;
 
+  void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
   void readInputData(TEventID paEIID) override;
   void writeOutputData(TEventID paEIID) override;
   void setInitialValues() override;
@@ -57,11 +67,16 @@ private:
 
 public:
   FORTE_PLCnextAXLSESC(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+  bool initialize() override;
 
   CIEC_BOOL var_QI;
 
   CIEC_BOOL var_QO;
   CIEC_WSTRING var_STATUS;
+
+  FORTE_PLCnextBusAdapter var_BusAdapterIn;
+
+  FORTE_PLCnextBusAdapter var_BusAdapterOut;
 
   CIEC_BOOL var_conn_QO;
   CIEC_WSTRING var_conn_STATUS;
@@ -76,7 +91,7 @@ public:
 
   CIEC_ANY *getDI(size_t) override;
   CIEC_ANY *getDO(size_t) override;
-
+  CAdapter *getAdapterUnchecked(size_t) override;
   FORTE_PLCnextBusAdapter &var_BusAdapterIn() {
     return *static_cast<FORTE_PLCnextBusAdapter*>(mAdapters[0]);
   };

--- a/src/modules/PLCnext/types/PLCnextBusAdapter.cpp
+++ b/src/modules/PLCnext/types/PLCnextBusAdapter.cpp
@@ -1,20 +1,32 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextBusAdapter
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #include "PLCnextBusAdapter.h"
 #ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
 #include "PLCnextBusAdapter_gen.cpp"
 #endif
 
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #include "criticalregion.h"
 #include "resource.h"
 
@@ -31,13 +43,14 @@ const CStringDictionary::TStringId FORTE_PLCnextBusAdapter::scmEventInputTypeIds
 const TDataIOID FORTE_PLCnextBusAdapter::scmEOWith[] = {2, 3, 1, 0, scmWithListDelimiter};
 const TForteInt16 FORTE_PLCnextBusAdapter::scmEOWithIndexes[] = {0};
 const CStringDictionary::TStringId FORTE_PLCnextBusAdapter::scmEventOutputNames[] = {g_nStringIdINIT};
-const CStringDictionary::TStringId FORTE_PLCnextBusAdapter::scmEventOutputTypeIds[] = {g_nStringIdEvent};
+const CStringDictionary::TStringId FORTE_PLCnextBusAdapter::scmEventOutputTypeIds[] = {g_nStringIdEInit};
 
 const SFBInterfaceSpec FORTE_PLCnextBusAdapter::scmFBInterfaceSpecSocket = {
   1, scmEventInputNames, scmEventInputTypeIds, scmEIWith, scmEIWithIndexes,
   1, scmEventOutputNames, scmEventOutputTypeIds, scmEOWith, scmEOWithIndexes,
   1, scmDataInputNames, scmDataInputTypeIds,
   4, scmDataOutputNames, scmDataOutputTypeIds,
+  0, nullptr,
   0, nullptr
 };
 
@@ -46,6 +59,7 @@ const SFBInterfaceSpec FORTE_PLCnextBusAdapter::scmFBInterfaceSpecPlug = {
   1, scmEventInputNames, scmEventInputTypeIds, scmEIWith, scmEIWithIndexes,
   4, scmDataOutputNames, scmDataOutputTypeIds,
   1, scmDataInputNames, scmDataInputTypeIds,
+  0, nullptr,
   0, nullptr
 };
 

--- a/src/modules/PLCnext/types/PLCnextBusAdapter.h
+++ b/src/modules/PLCnext/types/PLCnextBusAdapter.h
@@ -1,14 +1,21 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextBusAdapter
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #pragma once
 
@@ -85,7 +92,10 @@ public:
 
   ADAPTER_CTOR_FOR_IO_MULTI(FORTE_PLCnextBusAdapter) {};
 
+  FORTE_PLCnextBusAdapter(CStringDictionary::TStringId paAdapterInstanceName, forte::core::CFBContainer &paContainer, bool paIsPlug) :
+    CAdapter(paContainer, scmFBInterfaceSpecSocket, paAdapterInstanceName, scmFBInterfaceSpecPlug, paIsPlug) {
+  };
+
   virtual ~FORTE_PLCnextBusAdapter() = default;
 };
-
 

--- a/src/modules/PLCnext/types/PLCnextMaster.cpp
+++ b/src/modules/PLCnext/types/PLCnextMaster.cpp
@@ -1,20 +1,34 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextMaster
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #include "PLCnextMaster.h"
 #ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
 #include "PLCnextMaster_gen.cpp"
 #endif
 
+#include "PLCnextBusAdapter.h"
+#include "forte_uint.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #include "criticalregion.h"
 #include "resource.h"
 
@@ -31,7 +45,7 @@ const CStringDictionary::TStringId FORTE_PLCnextMaster::scmEventInputTypeIds[] =
 const TDataIOID FORTE_PLCnextMaster::scmEOWith[] = {0, 1, scmWithListDelimiter, 0, 1, scmWithListDelimiter};
 const TForteInt16 FORTE_PLCnextMaster::scmEOWithIndexes[] = {0, 3};
 const CStringDictionary::TStringId FORTE_PLCnextMaster::scmEventOutputNames[] = {g_nStringIdINITO, g_nStringIdIND};
-const CStringDictionary::TStringId FORTE_PLCnextMaster::scmEventOutputTypeIds[] = {g_nStringIdEvent, g_nStringIdEvent};
+const CStringDictionary::TStringId FORTE_PLCnextMaster::scmEventOutputTypeIds[] = {g_nStringIdEInit, g_nStringIdEvent};
 const SAdapterInstanceDef FORTE_PLCnextMaster::scmAdapterInstances[] = {
   {g_nStringIdPLCnextBusAdapter, g_nStringIdBusAdapterOut, true}
 };
@@ -46,6 +60,11 @@ const SFBInterfaceSpec FORTE_PLCnextMaster::scmFBInterfaceSpec = {
 
 FORTE_PLCnextMaster::FORTE_PLCnextMaster(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
     forte::core::io::IOConfigFBMultiMaster(paContainer, scmFBInterfaceSpec, paInstanceNameId),
+    var_QI(0_BOOL),
+    var_SlaveUpdateInterval(25_UINT),
+    var_QO(0_BOOL),
+    var_STATUS(u""_WSTRING),
+    var_BusAdapterOut(g_nStringIdBusAdapterOut, *this, true),
     var_conn_QO(var_QO),
     var_conn_STATUS(var_STATUS),
     conn_INITO(this, 0),
@@ -55,6 +74,12 @@ FORTE_PLCnextMaster::FORTE_PLCnextMaster(const CStringDictionary::TStringId paIn
     conn_QO(this, 0, &var_conn_QO),
     conn_STATUS(this, 1, &var_conn_STATUS) {
 };
+
+bool FORTE_PLCnextMaster::initialize() {
+  if(!var_BusAdapterOut.initialize()) { return false; }
+  var_BusAdapterOut.setParentFB(this, 0);
+  return CFunctionBlock::initialize();
+}
 
 void FORTE_PLCnextMaster::setInitialValues() {
   var_QI = 0_BOOL;
@@ -108,6 +133,12 @@ CIEC_ANY *FORTE_PLCnextMaster::getDO(const size_t paIndex) {
   return nullptr;
 }
 
+CAdapter *FORTE_PLCnextMaster::getAdapterUnchecked(const size_t paIndex) {
+  switch(paIndex) {
+    case 0: return &var_BusAdapterOut;
+  }
+  return nullptr;
+}
 
 CEventConnection *FORTE_PLCnextMaster::getEOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {

--- a/src/modules/PLCnext/types/PLCnextMaster.h
+++ b/src/modules/PLCnext/types/PLCnextMaster.h
@@ -1,14 +1,21 @@
-/*******************************************************************************
- * Copyright (c) 2022 Peirlberger Juergen
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Peirlberger Juergen - initial API and implementation and/or initial documentation
- *******************************************************************************/
+/*************************************************************************
+ *** Copyright (c) 2022 Peirlberger Juergen
+ ***
+ *** This program and the accompanying materials are made
+ *** available under the terms of the Eclipse Public License 2.0
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ ***
+ *** Name: PLCnextMaster
+ *** Description: Service Interface Function Block Type
+ *** Version:
+ ***     1.0: 2022-04-07/Peirlberger Juergen -  - initial API and implementation and/or initial documentation
+ *************************************************************************/
 
 #pragma once
 
@@ -49,6 +56,8 @@ private:
 
   static const SFBInterfaceSpec scmFBInterfaceSpec;
 
+  void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
   void readInputData(TEventID paEIID) override;
   void writeOutputData(TEventID paEIID) override;
   void setInitialValues() override;
@@ -58,12 +67,15 @@ private:
 
 public:
   FORTE_PLCnextMaster(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
+  bool initialize() override;
 
   CIEC_BOOL var_QI;
   CIEC_UINT var_SlaveUpdateInterval;
 
   CIEC_BOOL var_QO;
   CIEC_WSTRING var_STATUS;
+
+  FORTE_PLCnextBusAdapter var_BusAdapterOut;
 
   CIEC_BOOL var_conn_QO;
   CIEC_WSTRING var_conn_STATUS;
@@ -79,7 +91,7 @@ public:
 
   CIEC_ANY *getDI(size_t) override;
   CIEC_ANY *getDO(size_t) override;
-
+  CAdapter *getAdapterUnchecked(size_t) override;
   FORTE_PLCnextBusAdapter &var_BusAdapterOut() {
     return *static_cast<FORTE_PLCnextBusAdapter*>(mAdapters[0]);
   };
@@ -100,5 +112,4 @@ public:
     evt_INIT(paQI, paSlaveUpdateInterval, paQO, paSTATUS);
   }
 };
-
 


### PR DESCRIPTION
Generated PLCnextAXLSEDI16 from IDE to also use EInit

Generated PLCnextAXLSEDO16 from IDE to also use EInit

Generated PLCnextAXLSESC from IDE to also use EInit

Generated PLCnextBusAdapter from IDE to also use EInit

Generated PLCnextMaster from IDE to also use EInit

new header and old header have the same information

Issue eclipse-4diac/4diac-ide#943
