### PR TITLE
Generated zephyr fbt files from IDE to also use EInit

### DIFF
--- a/src/modules/zephyr/types/Esp32EthernetKitIO_fbt.cpp
+++ b/src/modules/zephyr/types/Esp32EthernetKitIO_fbt.cpp
@@ -1,4 +1,12 @@
-/*************************************************************************
+/************************************************************************* 
+ *** Copyright (c) 2024 KT Elektronik GmbH 
+ ***  
+ *** This program and the accompanying materials are made  
+ *** available under the terms of the Eclipse Public License 2.0  
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/  
+ ***  
+ *** SPDX-License-Identifier: EPL-2.0   
+ *** 
  *** FORTE Library Element
  ***
  *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
@@ -7,13 +15,6 @@
  *** Description: Template for Modular IO with Esp32EthernetKit board
  *** Version:
  ***     1.0: 2024-01-13/Dirk O. Kaar -  -
- ***
- *** Copyright (c) 2024 KT Elektronik GmbH
- *** This program and the accompanying materials are made available under the
- *** terms of the Eclipse Public License 2.0 which is available at
- *** http://www.eclipse.org/legal/epl-2.0.
- ***
- *** SPDX-License-Identifier: EPL-2.0
  *************************************************************************/
 
 #include "Esp32EthernetKitIO_fbt.h"
@@ -21,6 +22,12 @@
 #include "Esp32EthernetKitIO_fbt_gen.cpp"
 #endif
 
+#include "forte_time.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #pragma region includes
 #include <handler/IOHandleGPIODescriptor.h>
 #include <handler/IOHandleADCDescriptor.h>
@@ -41,7 +48,7 @@ const CStringDictionary::TStringId FORTE_Esp32EthernetKitIO::scmEventInputTypeId
 const TDataIOID FORTE_Esp32EthernetKitIO::scmEOWith[] = {0, 1, scmWithListDelimiter};
 const TForteInt16 FORTE_Esp32EthernetKitIO::scmEOWithIndexes[] = {0};
 const CStringDictionary::TStringId FORTE_Esp32EthernetKitIO::scmEventOutputNames[] = {g_nStringIdINITO};
-const CStringDictionary::TStringId FORTE_Esp32EthernetKitIO::scmEventOutputTypeIds[] = {g_nStringIdEvent};
+const CStringDictionary::TStringId FORTE_Esp32EthernetKitIO::scmEventOutputTypeIds[] = {g_nStringIdEInit};
 const SFBInterfaceSpec FORTE_Esp32EthernetKitIO::scmFBInterfaceSpec = {
   1, scmEventInputNames, scmEventInputTypeIds, scmEIWith, scmEIWithIndexes,
   1, scmEventOutputNames, scmEventOutputTypeIds, scmEOWith, scmEOWithIndexes,
@@ -55,7 +62,14 @@ FORTE_Esp32EthernetKitIO::FORTE_Esp32EthernetKitIO(const CStringDictionary::TStr
 #pragma region base class spec
     FORTE_ZephyrIOBase(paContainer, scmFBInterfaceSpec, paInstanceNameId),
 #pragma endregion base class spec
+    var_QI(0_BOOL),
+    var_LED0(""_STRING),
+    var_SW0(""_STRING),
+    var_ADC_CH_0(""_STRING),
+    var_PWM(""_STRING),
     var_UpdateInterval(40000000_TIME),
+    var_QO(0_BOOL),
+    var_STATUS(""_STRING),
     var_conn_QO(var_QO),
     var_conn_STATUS(var_STATUS),
     conn_INITO(this, 0),

--- a/src/modules/zephyr/types/Esp32EthernetKitIO_fbt.h
+++ b/src/modules/zephyr/types/Esp32EthernetKitIO_fbt.h
@@ -1,4 +1,12 @@
-/*************************************************************************
+/************************************************************************* 
+ *** Copyright (c) 2024 KT Elektronik GmbH
+ ***  
+ *** This program and the accompanying materials are made  
+ *** available under the terms of the Eclipse Public License 2.0  
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/  
+ ***  
+ *** SPDX-License-Identifier: EPL-2.0   
+ *** 
  *** FORTE Library Element
  ***
  *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
@@ -7,17 +15,19 @@
  *** Description: Template for Modular IO with Esp32EthernetKit board
  *** Version:
  ***     1.0: 2024-01-13/Dirk O. Kaar -  -
- ***
- *** Copyright (c) 2024 KT Elektronik GmbH
- *** This program and the accompanying materials are made available under the
- *** terms of the Eclipse Public License 2.0 which is available at
- *** http://www.eclipse.org/legal/epl-2.0.
- ***
- *** SPDX-License-Identifier: EPL-2.0
  *************************************************************************/
 
 #pragma once
 
+#include "funcbloc.h"
+#include "forte_bool.h"
+#include "forte_string.h"
+#include "forte_time.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #pragma region includes
 #include <types/ZephyrIOBase.h>
 #pragma endregion includes
@@ -114,5 +124,4 @@ class FORTE_Esp32EthernetKitIO final : public FORTE_ZephyrIOBase {
       evt_INIT(paQI, paLED0, paSW0, paADC_CH_0, paPWM, paUpdateInterval, paQO, paSTATUS);
     }
 };
-
 

--- a/src/modules/zephyr/types/ZephyrIO_fbt.cpp
+++ b/src/modules/zephyr/types/ZephyrIO_fbt.cpp
@@ -1,4 +1,12 @@
-/*************************************************************************
+/************************************************************************* 
+ *** Copyright (c) 2024 KT Elektronik GmbH 
+ ***  
+ *** This program and the accompanying materials are made  
+ *** available under the terms of the Eclipse Public License 2.0  
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/  
+ ***  
+ *** SPDX-License-Identifier: EPL-2.0   
+ *** 
  *** FORTE Library Element
  ***
  *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
@@ -7,13 +15,6 @@
  *** Description: Template for Modular IO with boards running Zephyr OS
  *** Version:
  ***     1.0: 2024-01-12/Dirk Kaar -  -
- ***
- *** Copyright (c) 2024 KT Elektronik GmbH
- *** This program and the accompanying materials are made available under the
- *** terms of the Eclipse Public License 2.0 which is available at
- *** http://www.eclipse.org/legal/epl-2.0.
- ***
- *** SPDX-License-Identifier: EPL-2.0
  *************************************************************************/
 
 #include "ZephyrIO_fbt.h"
@@ -21,6 +22,12 @@
 #include "ZephyrIO_fbt_gen.cpp"
 #endif
 
+#include "forte_time.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #pragma region includes
 #include <handler/IOHandleGPIODescriptor.h>
 #include <handler/IOHandleADCDescriptor.h>
@@ -40,7 +47,7 @@ const CStringDictionary::TStringId FORTE_ZephyrIO::scmEventInputTypeIds[] = {g_n
 const TDataIOID FORTE_ZephyrIO::scmEOWith[] = {0, 1, scmWithListDelimiter};
 const TForteInt16 FORTE_ZephyrIO::scmEOWithIndexes[] = {0};
 const CStringDictionary::TStringId FORTE_ZephyrIO::scmEventOutputNames[] = {g_nStringIdINITO};
-const CStringDictionary::TStringId FORTE_ZephyrIO::scmEventOutputTypeIds[] = {g_nStringIdEvent};
+const CStringDictionary::TStringId FORTE_ZephyrIO::scmEventOutputTypeIds[] = {g_nStringIdEInit};
 const SFBInterfaceSpec FORTE_ZephyrIO::scmFBInterfaceSpec = {
   1, scmEventInputNames, scmEventInputTypeIds, scmEIWith, scmEIWithIndexes,
   1, scmEventOutputNames, scmEventOutputTypeIds, scmEOWith, scmEOWithIndexes,
@@ -54,7 +61,10 @@ FORTE_ZephyrIO::FORTE_ZephyrIO(const CStringDictionary::TStringId paInstanceName
 #pragma region base class spec
     FORTE_ZephyrIOBase(paContainer, scmFBInterfaceSpec, paInstanceNameId),
 #pragma endregion base class spec
+    var_QI(0_BOOL),
     var_UpdateInterval(40000000_TIME),
+    var_QO(0_BOOL),
+    var_STATUS(""_STRING),
     var_conn_QO(var_QO),
     var_conn_STATUS(var_STATUS),
     conn_INITO(this, 0),

--- a/src/modules/zephyr/types/ZephyrIO_fbt.h
+++ b/src/modules/zephyr/types/ZephyrIO_fbt.h
@@ -1,4 +1,12 @@
-/*************************************************************************
+/************************************************************************* 
+ *** Copyright (c) 2024 KT Elektronik GmbH 
+ ***  
+ *** This program and the accompanying materials are made  
+ *** available under the terms of the Eclipse Public License 2.0  
+ *** which is available at https://www.eclipse.org/legal/epl-2.0/  
+ ***  
+ *** SPDX-License-Identifier: EPL-2.0   
+ *** 
  *** FORTE Library Element
  ***
  *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
@@ -7,17 +15,19 @@
  *** Description: Template for Modular IO with boards running Zephyr OS
  *** Version:
  ***     1.0: 2024-01-12/Dirk Kaar -  -
- ***
- *** Copyright (c) 2024 KT Elektronik GmbH
- *** This program and the accompanying materials are made available under the
- *** terms of the Eclipse Public License 2.0 which is available at
- *** http://www.eclipse.org/legal/epl-2.0.
- ***
- *** SPDX-License-Identifier: EPL-2.0
  *************************************************************************/
 
 #pragma once
 
+#include "funcbloc.h"
+#include "forte_bool.h"
+#include "forte_string.h"
+#include "forte_time.h"
+#include "iec61131_functions.h"
+#include "forte_array_common.h"
+#include "forte_array.h"
+#include "forte_array_fixed.h"
+#include "forte_array_variable.h"
 #pragma region includes
 #include <types/ZephyrIOBase.h>
 #pragma endregion includes
@@ -100,5 +110,4 @@ class FORTE_ZephyrIO final : public FORTE_ZephyrIOBase {
       evt_INIT(paQI, paUpdateInterval, paQO, paSTATUS);
     }
 };
-
 


### PR DESCRIPTION
Generated Esp32EthernetKitIO from IDE to also use EInit

Generated ZephyrIO from IDE to also use EInit

Issue eclipse-4diac/4diac-ide#943
