### PR TITLE
Make Action References Dependabot Compatible

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -48,7 +48,7 @@ jobs:
             c_compiler: cl
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -14,7 +14,7 @@ jobs:
     container: quay.io/eclipse4diac/4diac-fortebuildcontainer:latest
 
     steps:
-    - uses: actions/checkout@v4.1.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/tab_check.yml
+++ b/.github/workflows/tab_check.yml
@@ -14,7 +14,7 @@ jobs:
     container: quay.io/eclipse4diac/4diac-fortebuildcontainer:latest
 
     steps:
-    - uses: actions/checkout@v4.1.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Test for Tabs
       run: tests/findTabs.sh


### PR DESCRIPTION
Upgraded the references to the checkout action in our workflows. Also added version hashes which are better handled by dpendabot.