### PR TITLE
Add to DECLARE_HANDLER's getIdentifier the 'override' specifier

### DIFF
--- a/src/core/extevhan.h
+++ b/src/core/extevhan.h
@@ -21,7 +21,7 @@ class CFunctionBlock;
 #define DECLARE_HANDLER(TypeName)                          \
   public:                                                  \
     static const size_t mHandlerIdentifier;                \
-    virtual size_t getIdentifier() const override;         \
+    size_t getIdentifier() const override;                 \
     explicit TypeName(CDeviceExecution& paDeviceExecution);\
     ~TypeName();
 

--- a/src/core/extevhan.h
+++ b/src/core/extevhan.h
@@ -18,10 +18,10 @@
 class CEventSourceFB;
 class CFunctionBlock;
 
-#define DECLARE_HANDLER(TypeName)                             \
-  public:                                                     \
-    static const size_t mHandlerIdentifier;              \
-    virtual size_t getIdentifier() const;               \
+#define DECLARE_HANDLER(TypeName)                          \
+  public:                                                  \
+    static const size_t mHandlerIdentifier;                \
+    virtual size_t getIdentifier() const override;         \
     explicit TypeName(CDeviceExecution& paDeviceExecution);\
     ~TypeName();
 


### PR DESCRIPTION
The macro `DECLARE_HANDLER` should include the override specifier because `getIdentifier()` is virtual and every com handler will override the method due to the inheritance of the `CExternalEventHandler` class and the usage of the `DEFINE_HANDLER` macro.