### PR TITLE
Add a CAN communication layer for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,6 @@
 
 /src_gen/
 
-# CMake user-defined files
-
-/CMakeUserPresets.json
-
 # CMake intermediate files
 
 CMakeCache.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 
 /src_gen/
 
+# CMake user-defined files
+
+/CMakeUserPresets.json
+
 # CMake intermediate files
 
 CMakeCache.txt

--- a/com/CMakeLists.txt
+++ b/com/CMakeLists.txt
@@ -11,7 +11,7 @@
 #    Martin Erich Jobst
 #      - initial API and implementation and/or initial documentation
 #############################################################################
-
+add_subdirectory(can)
 add_subdirectory(HTTP)
 add_subdirectory(modbus)
 add_subdirectory(mqtt_paho)

--- a/com/can/CANHandler.cpp
+++ b/com/can/CANHandler.cpp
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Alexander Trojnin github.com/trojninalex
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Alexander Trojnin - initial API and implementation and/or initial documentation
+ *  Malte Grave - Adapt the CAN handler to the new 4diac-FORTE structure
+ *******************************************************************************/
+
+#include "forte/cominfra/comCallback.h"
+#include "forte/cominfra/commfb.h"
+#include "forte/devexec.h"
+#include "forte/util/criticalregion.h"
+#include "forte/util/devlog.h"
+
+#include "CANHandler.h"
+
+CCANHandler::CCANHandler(CDeviceExecution &paDeviceExecution) : CExternalEventHandler(paDeviceExecution) {
+  mConnectionListChanged = false;
+}
+
+CCANHandler::~CCANHandler() {
+  mConnectionsList.clear();
+
+  this->end();
+}
+
+void CCANHandler::addComCallback(CFDSelectHandler::TFileDescriptor paFD, forte::com_infra::CComCallback *paCanLayer) {
+  DEVLOG_DEBUG("[CAN Handler] Callback handler added\n");
+
+  CCriticalRegion criticalRegion(mSync);
+  TConnContType stNewNode = {paFD, paCanLayer};
+
+  mConnectionsList.push_back(stNewNode);
+  mConnectionListChanged = true;
+
+  if (!isAlive()) {
+    this->start();
+  }
+}
+
+void CCANHandler::removeComCallback(CFDSelectHandler::TFileDescriptor paFD) {
+  CCriticalRegion criticalRegion(mSync);
+
+  auto itRunner(mConnectionsList.begin());
+  auto itRefNode(mConnectionsList.end());
+  auto itEnd(mConnectionsList.end());
+
+  while (itRunner != itEnd) {
+    if (itRunner->mSockDes == paFD) {
+      if (itRefNode != itEnd) {
+        mConnectionsList.erase(itRefNode);
+      }
+      break;
+    }
+
+    itRefNode = itRunner;
+    ++itRunner;
+  }
+
+  mConnectionListChanged = true;
+}
+
+CFDSelectHandler::TFileDescriptor CCANHandler::createFDSet(fd_set *m_panFDSet) {
+  CFDSelectHandler::TFileDescriptor nRetVal = CFDSelectHandler::scmInvalidFileDescriptor;
+  FD_ZERO(m_panFDSet);
+
+  auto itEnd(mConnectionsList.end());
+  for (auto itRunner = mConnectionsList.begin(); itRunner != itEnd; ++itRunner) {
+    FD_SET(itRunner->mSockDes, m_panFDSet);
+    if (itRunner->mSockDes > nRetVal || CFDSelectHandler::scmInvalidFileDescriptor == nRetVal) {
+      nRetVal = itRunner->mSockDes;
+    }
+  }
+  mConnectionListChanged = false;
+  return nRetVal;
+}
+
+void CCANHandler::run() {
+  while (isAlive()) {
+    auto itEnd(mConnectionsList.end());
+    for (auto itRunner = mConnectionsList.begin(); itRunner != itEnd; ++itRunner) {
+      memset(&frame, 0, sizeof(can_frame));
+
+      if (read(itRunner->mSockDes, &frame, sizeof(struct can_frame)) > 0) {
+        forte::com_infra::CComCallback *called = itRunner->mCalled;
+
+        if (forte::com_infra::e_Nothing != called->recvData(&frame, frame.can_dlc)) {
+          CExternalEventHandler::startNewEventChain(called->getCommFB());
+        }
+      }
+    }
+
+    CThread::sleepThread(1);
+  }
+}

--- a/com/can/CANHandler.cpp
+++ b/com/can/CANHandler.cpp
@@ -19,82 +19,87 @@
 
 #include "CANHandler.h"
 
-CCANHandler::CCANHandler(CDeviceExecution &paDeviceExecution) : CExternalEventHandler(paDeviceExecution) {
-  mConnectionListChanged = false;
-}
+using namespace forte::arch;
+using namespace forte::util;
 
-CCANHandler::~CCANHandler() {
-  mConnectionsList.clear();
-
-  this->end();
-}
-
-void CCANHandler::addComCallback(CFDSelectHandler::TFileDescriptor paFD, forte::com_infra::CComCallback *paCanLayer) {
-  DEVLOG_DEBUG("[CAN Handler] Callback handler added\n");
-
-  CCriticalRegion criticalRegion(mSync);
-  TConnContType stNewNode = {paFD, paCanLayer};
-
-  mConnectionsList.push_back(stNewNode);
-  mConnectionListChanged = true;
-
-  if (!isAlive()) {
-    this->start();
+namespace forte::com_infra {
+  CCANHandler::CCANHandler(CDeviceExecution &paDeviceExecution) : CExternalEventHandler(paDeviceExecution) {
+    mConnectionListChanged = false;
   }
-}
 
-void CCANHandler::removeComCallback(CFDSelectHandler::TFileDescriptor paFD) {
-  CCriticalRegion criticalRegion(mSync);
+  CCANHandler::~CCANHandler() {
+    mConnectionsList.clear();
 
-  auto itRunner(mConnectionsList.begin());
-  auto itRefNode(mConnectionsList.end());
-  auto itEnd(mConnectionsList.end());
+    this->end();
+  }
 
-  while (itRunner != itEnd) {
-    if (itRunner->mSockDes == paFD) {
-      if (itRefNode != itEnd) {
-        mConnectionsList.erase(itRefNode);
+  void CCANHandler::addComCallback(CFDSelectHandler::TFileDescriptor paFD, CComCallback *paCanLayer) {
+    DEVLOG_DEBUG("[CAN Handler] Callback handler added\n");
+
+    util::CCriticalRegion criticalRegion(mSync);
+    TConnContType stNewNode = {paFD, paCanLayer};
+
+    mConnectionsList.push_back(stNewNode);
+    mConnectionListChanged = true;
+
+    if (!isAlive()) {
+      this->start();
+    }
+  }
+
+  void CCANHandler::removeComCallback(CFDSelectHandler::TFileDescriptor paFD) {
+    util::CCriticalRegion criticalRegion(mSync);
+
+    auto itRunner(mConnectionsList.begin());
+    auto itRefNode(mConnectionsList.end());
+    auto itEnd(mConnectionsList.end());
+
+    while (itRunner != itEnd) {
+      if (itRunner->mSockDes == paFD) {
+        if (itRefNode != itEnd) {
+          mConnectionsList.erase(itRefNode);
+        }
+        break;
       }
-      break;
+
+      itRefNode = itRunner;
+      ++itRunner;
     }
 
-    itRefNode = itRunner;
-    ++itRunner;
+    mConnectionListChanged = true;
   }
 
-  mConnectionListChanged = true;
-}
+  CFDSelectHandler::TFileDescriptor CCANHandler::createFDSet(fd_set *m_panFDSet) {
+    CFDSelectHandler::TFileDescriptor nRetVal = CFDSelectHandler::scmInvalidFileDescriptor;
+    FD_ZERO(m_panFDSet);
 
-CFDSelectHandler::TFileDescriptor CCANHandler::createFDSet(fd_set *m_panFDSet) {
-  CFDSelectHandler::TFileDescriptor nRetVal = CFDSelectHandler::scmInvalidFileDescriptor;
-  FD_ZERO(m_panFDSet);
-
-  auto itEnd(mConnectionsList.end());
-  for (auto itRunner = mConnectionsList.begin(); itRunner != itEnd; ++itRunner) {
-    FD_SET(itRunner->mSockDes, m_panFDSet);
-    if (itRunner->mSockDes > nRetVal || CFDSelectHandler::scmInvalidFileDescriptor == nRetVal) {
-      nRetVal = itRunner->mSockDes;
-    }
-  }
-  mConnectionListChanged = false;
-  return nRetVal;
-}
-
-void CCANHandler::run() {
-  while (isAlive()) {
     auto itEnd(mConnectionsList.end());
     for (auto itRunner = mConnectionsList.begin(); itRunner != itEnd; ++itRunner) {
-      memset(&frame, 0, sizeof(can_frame));
-
-      if (read(itRunner->mSockDes, &frame, sizeof(struct can_frame)) > 0) {
-        forte::com_infra::CComCallback *called = itRunner->mCalled;
-
-        if (forte::com_infra::e_Nothing != called->recvData(&frame, frame.can_dlc)) {
-          CExternalEventHandler::startNewEventChain(called->getCommFB());
-        }
+      FD_SET(itRunner->mSockDes, m_panFDSet);
+      if (itRunner->mSockDes > nRetVal || CFDSelectHandler::scmInvalidFileDescriptor == nRetVal) {
+        nRetVal = itRunner->mSockDes;
       }
     }
-
-    CThread::sleepThread(1);
+    mConnectionListChanged = false;
+    return nRetVal;
   }
-}
+
+  void CCANHandler::run() {
+    while (isAlive()) {
+      auto itEnd(mConnectionsList.end());
+      for (auto itRunner = mConnectionsList.begin(); itRunner != itEnd; ++itRunner) {
+        memset(&frame, 0, sizeof(can_frame));
+
+        if (read(itRunner->mSockDes, &frame, sizeof(struct can_frame)) > 0) {
+          forte::com_infra::CComCallback *called = itRunner->mCalled;
+
+          if (forte::com_infra::e_Nothing != called->recvData(&frame, frame.can_dlc)) {
+            CExternalEventHandler::startNewEventChain(called->getCommFB());
+          }
+        }
+      }
+
+      CThread::sleepThread(1);
+    }
+  }
+} // namespace forte::com_infra

--- a/com/can/CANHandler.h
+++ b/com/can/CANHandler.h
@@ -21,46 +21,50 @@
 #include "forte/arch/sockhand.h"
 #include "forte/extevhan.h"
 
-class CCANHandler : public CExternalEventHandler, public RegisterExternalEventHandler<CCANHandler>, private CThread {
-  public:
-    explicit CCANHandler(CDeviceExecution &paDeviceExecution);
-    ~CCANHandler() override;
-    void addComCallback(CFDSelectHandler::TFileDescriptor paFD, forte::com_infra::CComCallback *paCanLayer);
-    void removeComCallback(CFDSelectHandler::TFileDescriptor paFD);
+using namespace forte::arch;
 
-    void enableHandler() override {
-      start();
-    }
+namespace forte::com_infra {
+  class CCANHandler : public CExternalEventHandler, public RegisterExternalEventHandler<CCANHandler>, private CThread {
+    public:
+      explicit CCANHandler(CDeviceExecution &paDeviceExecution);
+      ~CCANHandler() override;
+      void addComCallback(CFDSelectHandler::TFileDescriptor paFD, CComCallback *paCanLayer);
+      void removeComCallback(CFDSelectHandler::TFileDescriptor paFD);
 
-    void disableHandler() override {
-      end();
-    }
+      void enableHandler() override {
+        start();
+      }
 
-    void setPriority(int) {
-    }
+      void disableHandler() override {
+        end();
+      }
 
-    int getPriority() const {
-      return 0;
-    }
+      void setPriority(int) {
+      }
 
-  protected:
-    void run() override;
+      int getPriority() const {
+        return 0;
+      }
 
-  private:
-    struct TConnContType {
-        CFDSelectHandler::TFileDescriptor mSockDes;
-        forte::com_infra::CComCallback *mCalled;
-    };
+    protected:
+      void run() override;
 
-    struct can_frame frame;
+    private:
+      struct TConnContType {
+          CFDSelectHandler::TFileDescriptor mSockDes;
+          CComCallback *mCalled;
+      };
 
-    typedef std::vector<TConnContType> TConnectionContainer;
+      struct can_frame frame;
 
-    CFDSelectHandler::TFileDescriptor createFDSet(fd_set *m_panFDSet);
+      typedef std::vector<TConnContType> TConnectionContainer;
 
-    TConnectionContainer mConnectionsList;
-    CSyncObject mSync;
-    bool mConnectionListChanged;
-};
+      CFDSelectHandler::TFileDescriptor createFDSet(fd_set *m_panFDSet);
+
+      TConnectionContainer mConnectionsList;
+      CSyncObject mSync;
+      bool mConnectionListChanged;
+  };
+} // namespace forte::com_infra
 
 #endif

--- a/com/can/CANHandler.h
+++ b/com/can/CANHandler.h
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Alexander Trojnin github.com/trojninalex
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Alexander Trojnin - initial API and implementation and/or initial documentation
+ *  Malte Grave - Adapt the CAN handler to the new 4diac-FORTE structure
+ *******************************************************************************/
+
+#ifndef CANHANDLER_H_
+#define CANHANDLER_H_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+#include "forte/arch/forte_thread.h"
+#include "forte/arch/sockhand.h"
+#include "forte/extevhan.h"
+
+class CCANHandler : public CExternalEventHandler, public RegisterExternalEventHandler<CCANHandler>, private CThread {
+  public:
+    explicit CCANHandler(CDeviceExecution &paDeviceExecution);
+    ~CCANHandler() override;
+    void addComCallback(CFDSelectHandler::TFileDescriptor paFD, forte::com_infra::CComCallback *paCanLayer);
+    void removeComCallback(CFDSelectHandler::TFileDescriptor paFD);
+
+    void enableHandler() override {
+      start();
+    }
+
+    void disableHandler() override {
+      end();
+    }
+
+    void setPriority(int) {
+    }
+
+    int getPriority() const {
+      return 0;
+    }
+
+  protected:
+    void run() override;
+
+  private:
+    struct TConnContType {
+        CFDSelectHandler::TFileDescriptor mSockDes;
+        forte::com_infra::CComCallback *mCalled;
+    };
+
+    struct can_frame frame;
+
+    typedef std::vector<TConnContType> TConnectionContainer;
+
+    CFDSelectHandler::TFileDescriptor createFDSet(fd_set *m_panFDSet);
+
+    TConnectionContainer mConnectionsList;
+    CSyncObject mSync;
+    bool mConnectionListChanged;
+};
+
+#endif

--- a/com/can/CANLayer.cpp
+++ b/com/can/CANLayer.cpp
@@ -34,184 +34,191 @@
 #include "CANLayer.h"
 #include "CANHandler.h"
 
-using namespace forte::com_infra;
+using namespace forte::arch;
+using namespace forte::util;
 
-CCANComLayer::CCANComLayer(CComLayer *paUpperLayer, CBaseCommFB *paComFB) : CComLayer(paUpperLayer, paComFB) {
-}
+namespace forte::com_infra {
+  CCANComLayer::CCANComLayer(CComLayer *paUpperLayer, CBaseCommFB *paComFB) : CComLayer(paUpperLayer, paComFB) {
+  }
 
-EComResponse CCANComLayer::openConnection(char *paLayerParameter) {
-  EComResponse eRetVal = e_InitInvalidId;
-  CParameterParser parser(paLayerParameter, ';', eCANComParamterAmount);
-  if (eCANComParamterAmount != parser.parseParameters()) {
-    DEVLOG_ERROR("[CAN Layer] Parsing of the parameters failed.\n");
+  EComResponse CCANComLayer::openConnection(char *paLayerParameter) {
+    EComResponse eRetVal = e_InitInvalidId;
+    CParameterParser parser(paLayerParameter, ';', eCANComParamterAmount);
+    if (eCANComParamterAmount != parser.parseParameters()) {
+      DEVLOG_ERROR("[CAN Layer] Parsing of the parameters failed.\n");
+      return eRetVal;
+    }
+
+    SCANParameters can_params = setupCANInternals(parser);
+
+    DEVLOG_DEBUG("[CAN Layer] Opening connection\n");
+
+    CFDSelectHandler::TFileDescriptor fd = socket(PF_CAN, SOCK_RAW | SOCK_NONBLOCK, CAN_RAW);
+
+    switch (mFb->getComServiceType()) {
+      case e_Server:
+        DEVLOG_ERROR("[CAN Layer] the layer only supports the PUB/SUB "
+                     "pattern. Please use a Publisher block to send data.");
+        eRetVal = e_InitTerminated;
+        break;
+      case e_Client:
+        DEVLOG_ERROR("[CAN Layer] the layer only supports the PUB/SUB "
+                     "pattern. Please use a Subscribe block to receive data.");
+        eRetVal = e_InitTerminated;
+        break;
+      case e_Publisher:
+        // is only sendData
+        mFrame.can_id = can_params.CANId;
+        break;
+      case e_Subscriber:
+        // is only recvData
+        rfilter.can_id = can_params.CANId;
+        rfilter.can_mask = CAN_SFF_MASK;
+        setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &rfilter, sizeof(rfilter));
+        break;
+
+      default:
+        DEVLOG_ERROR("[CAN Layer] Invalid communication service type.\n");
+        eRetVal = e_InitTerminated;
+        break;
+    }
+
+    if (eRetVal != e_InitInvalidId) {
+      return eRetVal;
+    }
+
+    if (CFDSelectHandler::scmInvalidFileDescriptor == fd) {
+      DEVLOG_ERROR("[CAN Layer] Socket can't be created: %s\n", strerror(errno));
+      return e_InitInvalidId;
+    }
+
+    std::strncpy(mIfr.ifr_name, can_params.interfaceName.c_str(), IFNAMSIZ - 1);
+    mIfr.ifr_name[IFNAMSIZ - 1] = '\0'; // Ensure that null termination is added if input is too long.
+
+    if (-1 == ioctl(fd, SIOCGIFINDEX, &mIfr)) {
+      DEVLOG_ERROR("[CAN Layer] Socket cannot be controlled. %s\n", strerror(errno));
+      close(fd);
+      return eRetVal;
+    }
+
+    mCANSocket = fd;
+    mAddr.can_family = AF_CAN;
+    mAddr.can_ifindex = mIfr.ifr_ifindex;
+
+    if (-1 == bind(mCANSocket, (struct sockaddr *) &mAddr, sizeof(mAddr))) {
+      DEVLOG_ERROR("[CAN Layer] Binding of the socket unsuccessful: %s\n", strerror(errno));
+      close(mCANSocket);
+      return eRetVal;
+    }
+
+    this->getExtEvHandler<CCANHandler>().addComCallback(mCANSocket, this);
+    DEVLOG_DEBUG("[CAN Layer] Callback handler added.\n");
+
+    eRetVal = e_InitOk;
     return eRetVal;
   }
 
-  SCANParameters can_params = setupCANInternals(parser);
-
-  DEVLOG_DEBUG("[CAN Layer] Opening connection\n");
-
-  CFDSelectHandler::TFileDescriptor fd = socket(PF_CAN, SOCK_RAW | SOCK_NONBLOCK, CAN_RAW);
-
-  switch (mFb->getComServiceType()) {
-    case e_Server:
-      DEVLOG_ERROR("[CAN Layer] the layer only supports the PUB/SUB "
-                   "pattern. Please use a Publisher block to send data.");
-      eRetVal = e_InitTerminated;
-      break;
-    case e_Client:
-      DEVLOG_ERROR("[CAN Layer] the layer only supports the PUB/SUB "
-                   "pattern. Please use a Subscribe block to receive data.");
-      eRetVal = e_InitTerminated;
-      break;
-    case e_Publisher:
-      // is only sendData
-      mFrame.can_id = can_params.CANId;
-      break;
-    case e_Subscriber:
-      // is only recvData
-      rfilter.can_id = can_params.CANId;
-      rfilter.can_mask = CAN_SFF_MASK;
-      setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &rfilter, sizeof(rfilter));
-      break;
-
-    default:
-      DEVLOG_ERROR("[CAN Layer] Invalid communication service type.\n");
-      eRetVal = e_InitTerminated;
-      break;
+  CCANComLayer::~CCANComLayer() {
   }
 
-  if (eRetVal != e_InitInvalidId) {
-    return eRetVal;
-  }
-
-  if (CFDSelectHandler::scmInvalidFileDescriptor == fd) {
-    DEVLOG_ERROR("[CAN Layer] Socket can't be created: %s\n", strerror(errno));
-    return e_InitInvalidId;
-  }
-
-  std::strncpy(mIfr.ifr_name, can_params.interfaceName.c_str(), IFNAMSIZ - 1);
-  mIfr.ifr_name[IFNAMSIZ - 1] = '\0'; // Ensure that null termination is added if input is too long.
-
-  if (-1 == ioctl(fd, SIOCGIFINDEX, &mIfr)) {
-    DEVLOG_ERROR("[CAN Layer] Socket cannot be controlled. %s\n", strerror(errno));
-    close(fd);
-    return eRetVal;
-  }
-
-  mCANSocket = fd;
-  mAddr.can_family = AF_CAN;
-  mAddr.can_ifindex = mIfr.ifr_ifindex;
-
-  if (-1 == bind(mCANSocket, (struct sockaddr *) &mAddr, sizeof(mAddr))) {
-    DEVLOG_ERROR("[CAN Layer] Binding of the socket unsuccessful: %s\n", strerror(errno));
-    close(mCANSocket);
-    return eRetVal;
-  }
-
-  this->getExtEvHandler<CCANHandler>().addComCallback(mCANSocket, this);
-  DEVLOG_DEBUG("[CAN Layer] Callback handler added.\n");
-
-  eRetVal = e_InitOk;
-  return eRetVal;
-}
-
-CCANComLayer::~CCANComLayer() {
-}
-
-void CCANComLayer::closeConnection() {
-  if (mCANSocket != CFDSelectHandler::scmInvalidFileDescriptor) {
-    DEVLOG_DEBUG("[CAN Layer] Closing socket\n");
-    close(mCANSocket);
-    DEVLOG_DEBUG("[CAN Layer] Unregister layer\n");
-    this->getExtEvHandler<CCANHandler>().removeComCallback(mCANSocket);
-  }
-}
-
-EComResponse CCANComLayer::sendData(void *paData, unsigned int) {
-  EComResponse eRetVal = e_InitOk;
-
-  CIEC_ANY **apoSDs = mFb->getSDs();
-  size_t size = mFb->getNumSD();
-
-  auto data = std::make_unique<uint8_t[]>(size);
-
-  for (size_t i = 0; i < size; i++) {
-    CIEC_ANY &sd(apoSDs[i]->unwrap());
-    data[i] = *sd.getConstDataPtr();
-    DEVLOG_DEBUG("[CAN Layer] send data[%d] = %d\n", i, data[i]);
-  }
-
-  eRetVal = e_ProcessDataOk;
-
-  size_t offset = 0;
-  while (offset < size && eRetVal == e_ProcessDataOk) {
-
-    mFrame.can_dlc = static_cast<uint8_t>((size - offset > CAN_MAX_DLEN) ? CAN_MAX_DLEN : (size - offset));
-
-    // Clear old data and copy new chunk
-    std::memset(mFrame.data, 0, CAN_MAX_DLEN);
-    std::memcpy(mFrame.data, &data[offset], mFrame.can_dlc);
-
-    offset += mFrame.can_dlc;
-
-    DEVLOG_DEBUG("[CAN Layer] Sending data ...\n");
-
-    if (write(mCANSocket, &mFrame, sizeof(struct can_frame)) < 0) {
-      DEVLOG_ERROR("CAN send failed: %s\n", strerror(errno));
-      eRetVal = e_ProcessDataSendFailed;
-      break;
+  void CCANComLayer::closeConnection() {
+    if (mCANSocket != CFDSelectHandler::scmInvalidFileDescriptor) {
+      DEVLOG_DEBUG("[CAN Layer] Closing socket\n");
+      close(mCANSocket);
+      DEVLOG_DEBUG("[CAN Layer] Unregister layer\n");
+      this->getExtEvHandler<CCANHandler>().removeComCallback(mCANSocket);
     }
   }
 
-  return e_ProcessDataOk;
-}
+  EComResponse CCANComLayer::sendData(void *paData, unsigned int) {
+    EComResponse eRetVal = e_InitOk;
 
-EComResponse CCANComLayer::recvData(const void *paData, unsigned int paSize) {
-  DEVLOG_DEBUG("[CAN Layer] Receive data.\n");
+    CIEC_ANY **apoSDs = mFb->getSDs();
+    size_t size = mFb->getNumSD();
 
-  m_eInterruptResp = e_Nothing;
+    auto data = std::make_unique<uint8_t[]>(size);
 
-  if (mFb->getComServiceType() == e_Subscriber) {
-    const can_frame *frame = (can_frame *) (paData);
-    memcpy(&mFrame, frame, sizeof(struct can_frame));
+    for (size_t i = 0; i < size; i++) {
+      CIEC_ANY &sd(apoSDs[i]->unwrap());
+      data[i] = *sd.getConstDataPtr();
+      DEVLOG_DEBUG("[CAN Layer] send data[%d] = %d\n", i, data[i]);
+    }
 
-    mFb->interruptCommFB(this);
-    m_eInterruptResp = e_ProcessDataOk;
-  }
+    eRetVal = e_ProcessDataOk;
 
-  return m_eInterruptResp;
-}
+    size_t offset = 0;
+    while (offset < size && eRetVal == e_ProcessDataOk) {
 
-EComResponse CCANComLayer::processInterrupt() {
-  DEVLOG_DEBUG("[CAN Layer] Interupt process.\n");
+      mFrame.can_dlc = static_cast<uint8_t>((size - offset > CAN_MAX_DLEN) ? CAN_MAX_DLEN : (size - offset));
 
-  if (m_eInterruptResp == e_ProcessDataOk) {
-    CIEC_ANY **apoRDs = mFb->getRDs();
-    size_t size_rd = mFb->getNumRD();
+      // Clear old data and copy new chunk
+      std::memset(mFrame.data, 0, CAN_MAX_DLEN);
+      std::memcpy(mFrame.data, &data[offset], mFrame.can_dlc);
 
-    for (size_t i = 0; i < size_rd; i++) {
-      CIEC_ANY &rd(apoRDs[i]->unwrap());
+      offset += mFrame.can_dlc;
 
-      if (i >= mFrame.can_dlc) {
-        rd.setValue(CIEC_BYTE(0));
-      } else {
-        rd.setValue(CIEC_BYTE(mFrame.data[i]));
+      DEVLOG_DEBUG("[CAN Layer] Sending data ...\n");
+
+      if (write(mCANSocket, &mFrame, sizeof(struct can_frame)) < 0) {
+        DEVLOG_ERROR("CAN send failed: %s\n", strerror(errno));
+        eRetVal = e_ProcessDataSendFailed;
+        break;
       }
     }
+
+    return e_ProcessDataOk;
   }
 
-  return m_eInterruptResp;
-}
+  EComResponse CCANComLayer::recvData(const void *paData, unsigned int paSize) {
+    DEVLOG_DEBUG("[CAN Layer] Receive data.\n");
 
-CCANComLayer::SCANParameters CCANComLayer::setupCANInternals(CParameterParser &parser) {
-  SCANParameters can_params;
+    m_eInterruptResp = e_Nothing;
 
-  can_params.interfaceName = std::string(parser[eInterface], strlen(parser[eInterface]));
+    if (mFb->getComServiceType() == e_Subscriber) {
+      const can_frame *frame = (can_frame *) (paData);
+      memcpy(&mFrame, frame, sizeof(struct can_frame));
 
-  can_params.CANId = static_cast<TForteUInt32>(forte::core::util::strtoul(parser[eCANId], nullptr, 10));
+      mFb->interruptCommFB(this);
+      m_eInterruptResp = e_ProcessDataOk;
+    }
 
-  DEVLOG_DEBUG("[CAN Layer] Using interface: %s and CAN-ID: %u\n", can_params.interfaceName.c_str(), can_params.CANId);
+    return m_eInterruptResp;
+  }
 
-  return can_params;
-}
+  EComResponse CCANComLayer::processInterrupt() {
+    DEVLOG_DEBUG("[CAN Layer] Interupt process.\n");
+
+    if (m_eInterruptResp == e_ProcessDataOk) {
+      CIEC_ANY **apoRDs = mFb->getRDs();
+      size_t size_rd = mFb->getNumRD();
+
+      for (size_t i = 0; i < size_rd; i++) {
+        CIEC_ANY &rd(apoRDs[i]->unwrap());
+
+        if (i >= mFrame.can_dlc) {
+          rd.setValue(CIEC_BYTE(0));
+        } else {
+          rd.setValue(CIEC_BYTE(mFrame.data[i]));
+        }
+      }
+    }
+
+    return m_eInterruptResp;
+  }
+
+  namespace {
+    SCANParameters setupCANInternals(CParameterParser &parser) {
+      SCANParameters can_params;
+
+      can_params.interfaceName = std::string(parser[eInterface], strlen(parser[eInterface]));
+
+      can_params.CANId = static_cast<TForteUInt32>(std::strtoul(parser[eCANId], nullptr, 10));
+
+      DEVLOG_DEBUG("[CAN Layer] Using interface: %s and CAN-ID: %u\n", can_params.interfaceName.c_str(),
+                   can_params.CANId);
+
+      return can_params;
+    }
+  } // namespace
+
+} // namespace forte::com_infra

--- a/com/can/CANLayer.cpp
+++ b/com/can/CANLayer.cpp
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Malte Grave, LIT CPS Johannes Kepler Universität,
+ *                                 github.com/gravemalte
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Malte Grave, Alexander Trojnin - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <memory>
+#include <string>
+#include <linux/can.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "forte/cominfra/basecommfb.h"
+#include "forte/cominfra/comtypes.h"
+#include "forte/datatype.h"
+#include "forte/datatypes/forte_any.h"
+#include "forte/datatypes/forte_byte.h"
+#include "forte/util/devlog.h"
+#include "forte/util/string_utils.h"
+
+#include "CANLayer.h"
+#include "CANHandler.h"
+
+using namespace forte::com_infra;
+
+CCANComLayer::CCANComLayer(CComLayer *paUpperLayer, CBaseCommFB *paComFB) : CComLayer(paUpperLayer, paComFB) {
+}
+
+EComResponse CCANComLayer::openConnection(char *paLayerParameter) {
+  EComResponse eRetVal = e_InitInvalidId;
+  CParameterParser parser(paLayerParameter, ';', eCANComParamterAmount);
+  if (eCANComParamterAmount != parser.parseParameters()) {
+    DEVLOG_ERROR("[CAN Layer] Parsing of the parameters failed.\n");
+    return eRetVal;
+  }
+
+  SCANParameters can_params = setupCANInternals(parser);
+
+  DEVLOG_DEBUG("[CAN Layer] Opening connection\n");
+
+  CFDSelectHandler::TFileDescriptor fd = socket(PF_CAN, SOCK_RAW | SOCK_NONBLOCK, CAN_RAW);
+
+  switch (mFb->getComServiceType()) {
+    case e_Server:
+      DEVLOG_ERROR("[CAN Layer] the layer only supports the PUB/SUB "
+                   "pattern. Please use a Publisher block to send data.");
+      eRetVal = e_InitTerminated;
+      break;
+    case e_Client:
+      DEVLOG_ERROR("[CAN Layer] the layer only supports the PUB/SUB "
+                   "pattern. Please use a Subscribe block to receive data.");
+      eRetVal = e_InitTerminated;
+      break;
+    case e_Publisher:
+      // is only sendData
+      mFrame.can_id = can_params.CANId;
+      break;
+    case e_Subscriber:
+      // is only recvData
+      rfilter.can_id = can_params.CANId;
+      rfilter.can_mask = CAN_SFF_MASK;
+      setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &rfilter, sizeof(rfilter));
+      break;
+
+    default:
+      DEVLOG_ERROR("[CAN Layer] Invalid communication service type.\n");
+      eRetVal = e_InitTerminated;
+      break;
+  }
+
+  if (eRetVal != e_InitInvalidId) {
+    return eRetVal;
+  }
+
+  if (CFDSelectHandler::scmInvalidFileDescriptor == fd) {
+    DEVLOG_ERROR("[CAN Layer] Socket can't be created: %s\n", strerror(errno));
+    return e_InitInvalidId;
+  }
+
+  std::strncpy(mIfr.ifr_name, can_params.interfaceName.c_str(), IFNAMSIZ - 1);
+  mIfr.ifr_name[IFNAMSIZ - 1] = '\0'; // Ensure that null termination is added if input is too long.
+
+  if (-1 == ioctl(fd, SIOCGIFINDEX, &mIfr)) {
+    DEVLOG_ERROR("[CAN Layer] Socket cannot be controlled. %s\n", strerror(errno));
+    close(fd);
+    return eRetVal;
+  }
+
+  mCANSocket = fd;
+  mAddr.can_family = AF_CAN;
+  mAddr.can_ifindex = mIfr.ifr_ifindex;
+
+  if (-1 == bind(mCANSocket, (struct sockaddr *) &mAddr, sizeof(mAddr))) {
+    DEVLOG_ERROR("[CAN Layer] Binding of the socket unsuccessful: %s\n", strerror(errno));
+    close(mCANSocket);
+    return eRetVal;
+  }
+
+  this->getExtEvHandler<CCANHandler>().addComCallback(mCANSocket, this);
+  DEVLOG_DEBUG("[CAN Layer] Callback handler added.\n");
+
+  eRetVal = e_InitOk;
+  return eRetVal;
+}
+
+CCANComLayer::~CCANComLayer() {
+}
+
+void CCANComLayer::closeConnection() {
+  if (mCANSocket != CFDSelectHandler::scmInvalidFileDescriptor) {
+    DEVLOG_DEBUG("[CAN Layer] Closing socket\n");
+    close(mCANSocket);
+    DEVLOG_DEBUG("[CAN Layer] Unregister layer\n");
+    this->getExtEvHandler<CCANHandler>().removeComCallback(mCANSocket);
+  }
+}
+
+EComResponse CCANComLayer::sendData(void *paData, unsigned int) {
+  EComResponse eRetVal = e_InitOk;
+
+  CIEC_ANY **apoSDs = mFb->getSDs();
+  size_t size = mFb->getNumSD();
+
+  auto data = std::make_unique<uint8_t[]>(size);
+
+  for (size_t i = 0; i < size; i++) {
+    CIEC_ANY &sd(apoSDs[i]->unwrap());
+    data[i] = *sd.getConstDataPtr();
+    DEVLOG_DEBUG("[CAN Layer] send data[%d] = %d\n", i, data[i]);
+  }
+
+  eRetVal = e_ProcessDataOk;
+
+  size_t offset = 0;
+  while (offset < size && eRetVal == e_ProcessDataOk) {
+
+    mFrame.can_dlc = static_cast<uint8_t>((size - offset > CAN_MAX_DLEN) ? CAN_MAX_DLEN : (size - offset));
+
+    // Clear old data and copy new chunk
+    std::memset(mFrame.data, 0, CAN_MAX_DLEN);
+    std::memcpy(mFrame.data, &data[offset], mFrame.can_dlc);
+
+    offset += mFrame.can_dlc;
+
+    DEVLOG_DEBUG("[CAN Layer] Sending data ...\n");
+
+    if (write(mCANSocket, &mFrame, sizeof(struct can_frame)) < 0) {
+      DEVLOG_ERROR("CAN send failed: %s\n", strerror(errno));
+      eRetVal = e_ProcessDataSendFailed;
+      break;
+    }
+  }
+
+  return e_ProcessDataOk;
+}
+
+EComResponse CCANComLayer::recvData(const void *paData, unsigned int paSize) {
+  DEVLOG_DEBUG("[CAN Layer] Receive data.\n");
+
+  m_eInterruptResp = e_Nothing;
+
+  if (mFb->getComServiceType() == e_Subscriber) {
+    const can_frame *frame = (can_frame *) (paData);
+    memcpy(&mFrame, frame, sizeof(struct can_frame));
+
+    mFb->interruptCommFB(this);
+    m_eInterruptResp = e_ProcessDataOk;
+  }
+
+  return m_eInterruptResp;
+}
+
+EComResponse CCANComLayer::processInterrupt() {
+  DEVLOG_DEBUG("[CAN Layer] Interupt process.\n");
+
+  if (m_eInterruptResp == e_ProcessDataOk) {
+    CIEC_ANY **apoRDs = mFb->getRDs();
+    size_t size_rd = mFb->getNumRD();
+
+    for (size_t i = 0; i < size_rd; i++) {
+      CIEC_ANY &rd(apoRDs[i]->unwrap());
+
+      if (i >= mFrame.can_dlc) {
+        rd.setValue(CIEC_BYTE(0));
+      } else {
+        rd.setValue(CIEC_BYTE(mFrame.data[i]));
+      }
+    }
+  }
+
+  return m_eInterruptResp;
+}
+
+CCANComLayer::SCANParameters CCANComLayer::setupCANInternals(CParameterParser &parser) {
+  SCANParameters can_params;
+
+  can_params.interfaceName = std::string(parser[eInterface], strlen(parser[eInterface]));
+
+  can_params.CANId = static_cast<TForteUInt32>(forte::core::util::strtoul(parser[eCANId], nullptr, 10));
+
+  DEVLOG_DEBUG("[CAN Layer] Using interface: %s and CAN-ID: %u\n", can_params.interfaceName.c_str(), can_params.CANId);
+
+  return can_params;
+}

--- a/com/can/CANLayer.h
+++ b/com/can/CANLayer.h
@@ -24,7 +24,11 @@
 #include "forte/datatype.h"
 #include "forte/util/parameterParser.h"
 
+using namespace forte::arch;
+using namespace forte::util;
+
 namespace forte::com_infra {
+
   class CCANComLayer : public CComLayer {
     public:
       typedef FORTE_SOCKET_TYPE TCANSocketHandle;
@@ -38,25 +42,28 @@ namespace forte::com_infra {
       EComResponse processInterrupt() override;
 
     private:
-      struct SCANParameters {
-          std::string interfaceName;
-          TForteUInt32 CANId;
-      };
-
-      enum ECANCommunicationParameter { eInterface = 0, eCANId = 1, eCANComParamterAmount = 2 };
-
-      CFDSelectHandler::TFileDescriptor mCANSocket = CFDSelectHandler::scmInvalidFileDescriptor;
-
-      EComResponse m_eInterruptResp;
-
       struct sockaddr_can mAddr;
       struct ifreq mIfr;
       struct can_frame mFrame;
       struct can_filter rfilter;
 
+      CFDSelectHandler::TFileDescriptor mCANSocket = CFDSelectHandler::scmInvalidFileDescriptor;
+
+      EComResponse m_eInterruptResp;
+
       EComResponse openConnection(char *paLayerParameter) override;
       void closeConnection() override;
-
-      SCANParameters setupCANInternals(CParameterParser &parser);
   };
+
+  namespace {
+    enum ECANCommunicationParameter { eInterface = 0, eCANId = 1, eCANComParamterAmount = 2 };
+
+    struct SCANParameters {
+        std::string interfaceName;
+        TForteUInt32 CANId;
+    };
+    SCANParameters setupCANInternals(CParameterParser &parser);
+
+  } // namespace
+
 } // namespace forte::com_infra

--- a/com/can/CANLayer.h
+++ b/com/can/CANLayer.h
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Malte Grave, LIT CPS Johannes Kepler Universität,
+ *                                 github.com/gravemalte
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Malte Grave, Alexander Trojnin - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <net/if.h>
+
+#include "forte/arch/sockhand.h"
+#include "forte/arch/gensockhand.h"
+#include "forte/cominfra/comlayer.h"
+#include "forte/datatype.h"
+#include "forte/util/parameterParser.h"
+
+namespace forte::com_infra {
+  class CCANComLayer : public CComLayer {
+    public:
+      typedef FORTE_SOCKET_TYPE TCANSocketHandle;
+
+      CCANComLayer(CComLayer *paUpperLayer, CBaseCommFB *paComFB);
+      ~CCANComLayer() override;
+
+      EComResponse sendData(void *paData, unsigned int paSize) override;
+      EComResponse recvData(const void *paData, unsigned int paSize) override;
+
+      EComResponse processInterrupt() override;
+
+    private:
+      struct SCANParameters {
+          std::string interfaceName;
+          TForteUInt32 CANId;
+      };
+
+      enum ECANCommunicationParameter { eInterface = 0, eCANId = 1, eCANComParamterAmount = 2 };
+
+      CFDSelectHandler::TFileDescriptor mCANSocket = CFDSelectHandler::scmInvalidFileDescriptor;
+
+      EComResponse m_eInterruptResp;
+
+      struct sockaddr_can mAddr;
+      struct ifreq mIfr;
+      struct can_frame mFrame;
+      struct can_filter rfilter;
+
+      EComResponse openConnection(char *paLayerParameter) override;
+      void closeConnection() override;
+
+      SCANParameters setupCANInternals(CParameterParser &parser);
+  };
+} // namespace forte::com_infra

--- a/com/can/CMakeLists.txt
+++ b/com/can/CMakeLists.txt
@@ -1,0 +1,63 @@
+# *******************************************************************************
+# *******************************************************************************
+# Copyright (c) 2025 Malte Grave, LIT CPS Johannes Kepler Universität,
+#                                 github.com/gravemalte
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     Malte Grave, Alexander Trojnin - initial API and implementation and/or initial documentation
+# *******************************************************************************/
+# *******************************************************************************/
+#############################################################################
+# CAN Com Layer (currently only usable on Linux)
+#############################################################################
+
+option(FORTE_COM_CAN "Enable the CAN Commuication Layer" OFF)
+
+if(FORTE_COM_CAN)
+  set(FORTE_COM_CAN_MODULE_CHECK ON CACHE BOOL "Checking for the Presence of CAN Modules.")
+
+  if(FORTE_COM_CAN_MODULE_CHECK)
+    execute_process(
+      COMMAND lsmod
+      COMMAND grep -wE "^(can|can_raw|vcan|can_dev)"
+      COMMAND awk "{print $1}"
+      COMMAND tr "\n" " "
+      OUTPUT_VARIABLE CAN_MODULES_FOUND
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    
+    message(STATUS "Found CAN modules: ${CAN_MODULES_FOUND}")
+    if(NOT "${CAN_MODULES_FOUND}" MATCHES "can")
+        message(FATAL_ERROR "can module is missing!")
+    endif(NOT "${CAN_MODULES_FOUND}" MATCHES "can")
+    
+    if(NOT "${CAN_MODULES_FOUND}" MATCHES "vcan")
+        message(FATAL_ERROR "vcan module is missing!")
+    endif(NOT "${CAN_MODULES_FOUND}" MATCHES "vcan")
+
+    if(NOT "${CAN_MODULES_FOUND}" MATCHES "can_raw")
+        message(FATAL_ERROR "can_raw module is missing!")
+    endif(NOT "${CAN_MODULES_FOUND}" MATCHES "can_raw")
+
+    if(NOT "${CAN_MODULES_FOUND}" MATCHES "can_dev")
+        message(FATAL_ERROR "can_dev module is missing!")
+    endif(NOT "${CAN_MODULES_FOUND}" MATCHES "can_dev")
+
+  endif(FORTE_COM_CAN_MODULE_CHECK)
+
+
+  add_library(forte-com-CAN
+              CANLayer.cpp
+              CANLayer.h
+              CANHandler.cpp
+              CANHandler.h
+  )
+  target_include_directories(forte-com-CAN PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+  target_link_libraries(forte-com-CAN PUBLIC forte-core)
+  target_link_libraries(forte PUBLIC $<LINK_LIBRARY:WHOLE_ARCHIVE,forte-com-CAN>)
+endif(FORTE_COM_CAN)


### PR DESCRIPTION
This PR is a draft, so please bear with me.

I hacked this thing together over the weekend, in some hours, so it's not yet clean.

This PR introduces the first concept of a CAN (Controller Area Network) layer in FORTE, enabling communication with a CAN bus. 
~~Currently, a basic example of sending data is functional. However, both the message ID and data are fixed values for initial testing purposes. These will be made configurable in the coming days as development progresses.~~

As for now, communication with a `vcan` is possible by sending `CIEC_STRING` or `CIEC_WSTRING`. The strings are not filtered. All bytes are sent to the CAN interface. It is therefore a raw CAN layer in terms of the raw nature of the data.

Adding a CAN layer to FORTE opens up new possibilities for integration with various domains, making it a valuable enhancement. Feedback and suggestions are welcome!