### PR TITLE
Rework tracing of read and write data

### DIFF
--- a/src/core/funcbloc.cpp
+++ b/src/core/funcbloc.cpp
@@ -355,54 +355,6 @@ bool CFunctionBlock::configureFB(const char *){
   return true;
 }
 
-#ifdef FORTE_TRACE_CTF
-void CFunctionBlock::readData(size_t paDINum, CIEC_ANY& paValue, const CDataConnection *const paConn) {
-  if(!paConn) {
-    return;
-  }
-#ifdef FORTE_SUPPORT_MONITORING
-  if(!paValue.isForced()) {
-#endif //FORTE_SUPPORT_MONITORING
-    paConn->readData(paValue);
-#ifdef FORTE_SUPPORT_MONITORING
-  }
-#endif //FORTE_SUPPORT_MONITORING
-  if(auto& tracer = getResource()->getTracer(); tracer.isEnabled()){
-    std::string valueString;
-    valueString.reserve(paValue.getToStringBufferSize());
-    paValue.toString(valueString.data(), valueString.capacity());
-    tracer.traceInputData(getFBTypeName() ?: "null",
-                          getFullQualifiedApplicationInstanceName('.').c_str() ?: "null",
-                          static_cast<uint64_t>(paDINum), valueString.c_str());
-  }
-}
-#endif //FORTE_TRACE_CTF
-
-#ifdef FORTE_TRACE_CTF
-void CFunctionBlock::writeData(size_t paDONum, CIEC_ANY& paValue, CDataConnection& paConn) {
-  if(paConn.isConnected()) {
-#ifdef FORTE_SUPPORT_MONITORING
-    if(paValue.isForced() != true) {
-#endif //FORTE_SUPPORT_MONITORING
-      paConn.writeData(paValue);
-#ifdef FORTE_SUPPORT_MONITORING
-    } else {
-      //when forcing we write back the value from the connection to keep the forced value on the output
-      paConn.readData(paValue);
-    }
-#endif //FORTE_SUPPORT_MONITORING
-  }
-  if(auto& tracer = getResource()->getTracer(); tracer.isEnabled()){
-    std::string valueString;
-    valueString.reserve(paValue.getToStringBufferSize());
-    paValue.toString(valueString.data(), valueString.capacity());
-    tracer.traceOutputData(getFBTypeName() ?: "null",
-                           getFullQualifiedApplicationInstanceName('.').c_str() ?: "null",
-                          static_cast<uint64_t>(paDONum), valueString.c_str());
-  }
-}
-#endif //FORTE_TRACE_CTF
-
 void CFunctionBlock::setInitialValues() {
   const CStringDictionary::TStringId *pnDataIds;
 
@@ -689,6 +641,28 @@ void CFunctionBlock::traceOutputEvent(TEventID paEOID){
     tracer.traceSendOutputEvent(getFBTypeName() ?: "null",
                                 getFullQualifiedApplicationInstanceName('.').c_str() ?: "null",
                                 static_cast<uint64_t>(paEOID));
+  }
+}
+
+void CFunctionBlock::traceReadData(TPortId paDINum, CIEC_ANY& paValue) {
+  if(auto& tracer = getResource()->getTracer(); tracer.isEnabled()){
+    std::string valueString;
+    valueString.reserve(paValue.getToStringBufferSize());
+    paValue.toString(valueString.data(), valueString.capacity());
+    tracer.traceInputData(getFBTypeName() ?: "null",
+                          getFullQualifiedApplicationInstanceName('.').c_str() ?: "null",
+                          static_cast<uint64_t>(paDINum), valueString.c_str());
+  }
+}
+
+void CFunctionBlock::traceWriteData(TPortId paDONum, CIEC_ANY& paValue) {
+  if(auto& tracer = getResource()->getTracer(); tracer.isEnabled()){
+    std::string valueString;
+    valueString.reserve(paValue.getToStringBufferSize());
+    paValue.toString(valueString.data(), valueString.capacity());
+    tracer.traceOutputData(getFBTypeName() ?: "null",
+                           getFullQualifiedApplicationInstanceName('.').c_str() ?: "null",
+                          static_cast<uint64_t>(paDONum), valueString.c_str());
   }
 }
 

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -485,13 +485,11 @@ class CFunctionBlock : public forte::core::CFBContainer {
 
     /*!\brief Function to read data from an input connection into a variable of the FB.
      *
+     * \param paDINum Input index
      * \param paValue Variable to read into.
      * \param paConn Connection to read from.
      */
-#ifdef FORTE_TRACE_CTF
-    void readData(size_t paDONum, CIEC_ANY &paValue, const CDataConnection *const paConn);
-#else
-    void readData(size_t, CIEC_ANY &paValue, const CDataConnection *const paConn) {
+    void readData([[maybe_unused]] TPortId paDINum, CIEC_ANY &paValue, const CDataConnection *const paConn) {
       if(!paConn) {
         return;
       }
@@ -502,18 +500,18 @@ class CFunctionBlock : public forte::core::CFBContainer {
 #ifdef FORTE_SUPPORT_MONITORING
       }
 #endif //FORTE_SUPPORT_MONITORING
-    }
+#ifdef FORTE_TRACE_CTF
+      traceReadData(paDINum, paValue);
 #endif //FORTE_TRACE_CTF
+    }
 
     /*!\brief Function to write data to an output connection from a variable of the FB.
      *
+     * \param paDONum Output index
      * \param paValue Variable to write from.
      * \param paConn Connection to write into.
      */
-#ifdef FORTE_TRACE_CTF
-    void writeData(size_t paDONum, CIEC_ANY& paValue, CDataConnection& paConn);
-#else
-    void writeData(size_t, CIEC_ANY& paValue, CDataConnection& paConn) {
+    void writeData([[maybe_unused]] TPortId paDONum, CIEC_ANY& paValue, CDataConnection& paConn) {
       if(paConn.isConnected()) {
 #ifdef FORTE_SUPPORT_MONITORING
         if(!paValue.isForced()) {
@@ -526,8 +524,10 @@ class CFunctionBlock : public forte::core::CFBContainer {
         }
 #endif //FORTE_SUPPORT_MONITORING
       }
-    }
+#ifdef FORTE_TRACE_CTF
+      traceWriteData(paDONum, paValue);
 #endif //FORTE_TRACE_CTF
+    }
 
     /*!\brief Set the initial values of data inputs, outputs, and internal vars.
      *
@@ -688,6 +688,8 @@ class CFunctionBlock : public forte::core::CFBContainer {
 #ifdef FORTE_TRACE_CTF
     void traceInputEvent(TEventID paEIID);
     void traceOutputEvent(TEventID paEOID);
+    void traceReadData(TPortId paDINum, CIEC_ANY& paValue);
+    void traceWriteData(TPortId paDONum, CIEC_ANY& paValue);
 #endif
 
     /*!\brief Current state of the runnable object.

--- a/tests/core/trace/ctfTracerTest.cpp
+++ b/tests/core/trace/ctfTracerTest.cpp
@@ -19,12 +19,27 @@
 #include "forte_boost_output_support.h"
 #include "../stdfblib/ita/EMB_RES.h"
 #include "config.h"
-#include "ctfTracerTest_gen.cpp"
 #include "device.h"
 #include "ecet.h"
 #include "EventMessage.h"
 #include "trace/barectf_platform_forte.h"
 #include "../fbtests/fbtesterglobalfixture.h"
+
+USE_STRING_ID(Counter);
+USE_STRING_ID(COLD);
+USE_STRING_ID(CU);
+USE_STRING_ID(CUO);
+USE_STRING_ID(EI);
+USE_STRING_ID(EO1);
+USE_STRING_ID(E_CTU);
+USE_STRING_ID(E_SWITCH);
+USE_STRING_ID(G);
+USE_STRING_ID(MyDevice);
+USE_STRING_ID(PV);
+USE_STRING_ID(Q);
+USE_STRING_ID(R);
+USE_STRING_ID(START);
+USE_STRING_ID(Switch);
 
 /**
  * @brief Get the list of message from a directory containing CTF traces
@@ -75,43 +90,43 @@ BOOST_AUTO_TEST_CASE(sequential_events_test) {
     command.mDestination = CStringDictionary::scmInvalidStringId;
 
     BOOST_TEST_INFO("Event connection: Start.COLD -> Counter.CU");
-    command.mFirstParam.pushBack(startInstanceName);
-    command.mFirstParam.pushBack(STRID(COLD));
-    command.mSecondParam.pushBack(counterInstanceName);
-    command.mSecondParam.pushBack(STRID(CU));
+    command.mFirstParam.push_back(startInstanceName);
+    command.mFirstParam.push_back(STRID(COLD));
+    command.mSecondParam.push_back(counterInstanceName);
+    command.mSecondParam.push_back(STRID(CU));
     BOOST_TEST(EMGMResponse::Ready == resource.executeMGMCommand(command));
 
     BOOST_TEST_INFO("Event connection: Counter.CUO -> Switch.EI");
     command.mFirstParam.clear();
-    command.mFirstParam.pushBack(counterInstanceName);
-    command.mFirstParam.pushBack(STRID(CUO));
+    command.mFirstParam.push_back(counterInstanceName);
+    command.mFirstParam.push_back(STRID(CUO));
     command.mSecondParam.clear();
-    command.mSecondParam.pushBack(switchInstanceName);
-    command.mSecondParam.pushBack(STRID(EI));
+    command.mSecondParam.push_back(switchInstanceName);
+    command.mSecondParam.push_back(STRID(EI));
     BOOST_TEST(EMGMResponse::Ready == resource.executeMGMCommand(command));
 
     BOOST_TEST_INFO("Data connection: Counter.Q -> Switch.G ");
     command.mFirstParam.clear();
-    command.mFirstParam.pushBack(counterInstanceName);
-    command.mFirstParam.pushBack(STRID(Q));
+    command.mFirstParam.push_back(counterInstanceName);
+    command.mFirstParam.push_back(STRID(Q));
     command.mSecondParam.clear();
-    command.mSecondParam.pushBack(switchInstanceName);
-    command.mSecondParam.pushBack(STRID(G));
+    command.mSecondParam.push_back(switchInstanceName);
+    command.mSecondParam.push_back(STRID(G));
     BOOST_TEST(EMGMResponse::Ready == resource.executeMGMCommand(command));
 
     BOOST_TEST_INFO(" Data constant value: Counter.PV = 1");
     command.mFirstParam.clear();
-    command.mFirstParam.pushBack(counterInstanceName);
-    command.mFirstParam.pushBack(STRID(PV));
+    command.mFirstParam.push_back(counterInstanceName);
+    command.mFirstParam.push_back(STRID(PV));
     BOOST_TEST(EMGMResponse::Ready == resource.writeValue(command.mFirstParam, "1", false));
 
     BOOST_TEST_INFO("Event connection: Switch.EO1 -> Counter.R ");
     command.mFirstParam.clear();
-    command.mFirstParam.pushBack(switchInstanceName);
-    command.mFirstParam.pushBack(STRID(EO1));
+    command.mFirstParam.push_back(switchInstanceName);
+    command.mFirstParam.push_back(STRID(EO1));
     command.mSecondParam.clear();
-    command.mSecondParam.pushBack(counterInstanceName);
-    command.mSecondParam.pushBack(STRID(R));
+    command.mSecondParam.push_back(counterInstanceName);
+    command.mSecondParam.push_back(STRID(R));
     BOOST_TEST(EMGMResponse::Ready == resource.executeMGMCommand(command));
 
     device.startDevice();


### PR DESCRIPTION
Rework tracing of read and write data to better encapsulate tracing functionality and make further reworking of connection handling easier. Also fix CTF tracer test after string id and fixed_vector rework.