### PR TITLE
Rework CFB If2In and In2If connections

### DIFF
--- a/src/core/cfb.cpp
+++ b/src/core/cfb.cpp
@@ -27,8 +27,6 @@
 CCompositeFB::CCompositeFB(forte::core::CFBContainer &paContainer, const SFBInterfaceSpec& paInterfaceSpec,
                            CStringDictionary::TStringId paInstanceNameId, const SCFB_FBNData & paFBNData) :
         CFunctionBlock(paContainer, paInterfaceSpec, paInstanceNameId),
-        mIf2InDConns(nullptr),
-        mIn2IfDConns(nullptr),
         cmFBNData(paFBNData),
         mEventConnections(nullptr),
         mDataConnections(nullptr),
@@ -76,45 +74,21 @@ CCompositeFB::~CCompositeFB() {
     if (nullptr != mDataConnections) {
       delete[] mDataConnections;
     }
-    if (nullptr != mIf2InDConns) {
-      delete[] mIf2InDConns;
-    }
-    if (nullptr != mIn2IfDConns) {
-      delete[] mIn2IfDConns;
-    }
   }
 }
 
 bool CCompositeFB::connectDI(TPortId paDIPortId, CDataConnection *paDataCon){
-  bool retVal = false;
-
+  // TODO remove?
   if(cgInternal2InterfaceMarker & paDIPortId){
     paDIPortId = static_cast<TPortId>(paDIPortId & cgInternal2InterfaceRemovalMask);
-    if(paDIPortId < getFBInterfaceSpec().mNumDOs){
-      mIn2IfDConns[paDIPortId] = paDataCon;
-      retVal = true;
-    }
+    return paDIPortId < getFBInterfaceSpec().mNumDOs;
   }
-  else if(paDIPortId < getFBInterfaceSpec().mNumDIs){
-    bool needsCloning = (getDI(paDIPortId)->getDataTypeID() == CIEC_ANY::e_ANY);
-    retVal = CFunctionBlock::connectDI(paDIPortId, paDataCon);
-    if((true == retVal) && (true == needsCloning) && (nullptr != paDataCon)) {
-      //if internal connected update the connections data type and maybe internal further connection points
-      (mIf2InDConns + paDIPortId)->setValue(getDI(paDIPortId));
-      (mIf2InDConns + paDIPortId)->cloneInputInterfaceValue();
-    }
-  }
-  return retVal;
+  return CFunctionBlock::connectDI(paDIPortId, paDataCon);
 }
 
 bool CCompositeFB::configureGenericDO(TPortId paDOPortId, const CIEC_ANY &paRefValue){
-  bool bRetVal = CFunctionBlock::configureGenericDO(paDOPortId, paRefValue);
-  CDataConnection *dataCon = mIn2IfDConns[paDOPortId];
-  if(bRetVal && dataCon != nullptr){
-    //issue a reconfiguration attempt so that all connection end points in this connection are also correctly configured
-    dataCon->handleAnySrcPortConnection(paRefValue);
-  }
-  return bRetVal;
+  // TODO remove?
+  return CFunctionBlock::configureGenericDO(paDOPortId, paRefValue);
 }
 
 EMGMResponse CCompositeFB::changeExecutionState(EMGMCommandType paCommand){
@@ -147,7 +121,6 @@ CIEC_ANY *CCompositeFB::getVar(CStringDictionary::TStringId *paNameList, unsigne
 void CCompositeFB::executeEvent(TEventID paEIID, CEventChainExecutionThread * const paECET){
   if(cgInternal2InterfaceMarker & paEIID){
     TEventID internalEvent = static_cast<TEventID>(paEIID & cgInternal2InterfaceRemovalMask);
-    readInternal2InterfaceOutputData(internalEvent);
     sendOutputEvent(internalEvent, paECET);
   }
   else{
@@ -213,16 +186,6 @@ void CCompositeFB::establishConnection(CConnection *paCon, CFunctionBlock *paDst
 
 void CCompositeFB::createDataConnections(){
   if(cmFBNData.mNumDataConnections){
-    if(getFBInterfaceSpec().mNumDIs){
-      prepareIf2InDataCons();
-    }
-    if(getFBInterfaceSpec().mNumDOs){
-      mIn2IfDConns = new CDataConnection *[getFBInterfaceSpec().mNumDOs];
-      for(TPortId i = 0; i < getFBInterfaceSpec().mNumDOs; i++){
-        mIn2IfDConns[i] = nullptr;
-      }
-    }
-
     mDataConnections = new CDataConnection *[cmFBNData.mNumDataConnections];
 
     for(size_t i = 0; i < cmFBNData.mNumDataConnections; ++i){
@@ -252,7 +215,7 @@ CDataConnection * CCompositeFB::getDataConn(CFunctionBlock *paSrcFB, CStringDict
   if(this == paSrcFB){
     TPortId diId = getDIID(paSrcNameId);
     if(diId != cgInvalidPortId) {
-      return &(mIf2InDConns[diId]);
+      return getIf2InConUnchecked(diId);
     } else {
       TPortId dioId = getDIOID(paSrcNameId);
       return getDIOOutConInternalUnchecked(dioId);
@@ -284,13 +247,6 @@ void CCompositeFB::createAdapterConnections(){
     } else{
       DEVLOG_ERROR("[CFB Creation] Source or destination not found in adapter connection!");
     }
-  }
-}
-
-void CCompositeFB::prepareIf2InDataCons(){
-  mIf2InDConns = new CInterface2InternalDataConnection[getFBInterfaceSpec().mNumDIs];
-  for(TPortId i = 0; i < getFBInterfaceSpec().mNumDIs; i++){
-    (mIf2InDConns + i)->setSource(this, i);
   }
 }
 

--- a/src/core/cfb.h
+++ b/src/core/cfb.h
@@ -129,15 +129,10 @@ class CCompositeFB: public CFunctionBlock {
     EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 
   protected:
-    CDataConnection *getIn2IfConUnchecked(TPortId paIndex) {
-      return mIn2IfDConns[paIndex];
-    }
-
     const SCFB_FBNData &getFBNData() const {
       return cmFBNData;
     }
 
-    virtual void readInternal2InterfaceOutputData(TEventID paEOID) = 0;
     void executeEvent(TEventID paEIID, CEventChainExecutionThread * const paECET) override final;
 
   private:
@@ -152,18 +147,15 @@ class CCompositeFB: public CFunctionBlock {
     void createDataConnections();
     CDataConnection * getDataConn(CFunctionBlock *paSrcFB, CStringDictionary::TStringId paSrcNameId);
     void createAdapterConnections();
-    void prepareIf2InDataCons();
     virtual void setFBNetworkInitialValues();
 
     //!Acquire the functionblock for a given function block number this may be a contained fb, an adapter, or the composite itself.
     CFunctionBlock *getFunctionBlock(int paFBNum);
 
+    virtual CDataConnection *getIf2InConUnchecked(TPortId) = 0;
     virtual CInOutDataConnection *getDIOOutConInternalUnchecked(TPortId) {
       return nullptr;
     }
-
-    CInterface2InternalDataConnection *mIf2InDConns;
-    CDataConnection **mIn2IfDConns;
 
     const SCFB_FBNData & cmFBNData;
 

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -513,18 +513,16 @@ class CFunctionBlock : public forte::core::CFBContainer {
      */
     template<typename T, typename U>
     void writeData([[maybe_unused]] TPortId paDONum, T& paValue, U& paConn) {
-      if(paConn.isConnected()) {
 #ifdef FORTE_SUPPORT_MONITORING
-        if(!paValue.isForced()) {
+      if(!paValue.isForced()) {
 #endif //FORTE_SUPPORT_MONITORING
-          paConn.writeData(paValue);
+        paConn.writeData(paValue);
 #ifdef FORTE_SUPPORT_MONITORING
-        } else {
-          //when forcing we write back the value from the connection to keep the forced value on the output
-          paConn.readData(paValue);
-        }
-#endif //FORTE_SUPPORT_MONITORING
+      } else {
+        //when forcing we write back the value from the connection to keep the forced value on the output
+        paConn.readData(paValue);
       }
+#endif //FORTE_SUPPORT_MONITORING
 #ifdef FORTE_TRACE_CTF
       traceWriteData(paDONum, paValue);
 #endif //FORTE_TRACE_CTF

--- a/src/modules/rt_events/RT_E_TRAIN_fbt.cpp
+++ b/src/modules/rt_events/RT_E_TRAIN_fbt.cpp
@@ -76,15 +76,19 @@ FORTE_RT_E_TRAIN::FORTE_RT_E_TRAIN(const CStringDictionary::TStringId paInstance
     conn_N(nullptr),
     conn_Deadline(nullptr),
     conn_WCET(nullptr),
-    conn_CV(this, 0, var_CV) {
+    conn_CV(this, 0, 0_UINT),
+    conn_if2in_DT(this, 0, 0_TIME),
+    conn_if2in_N(this, 1, 0_UINT),
+    conn_if2in_Deadline(this, 2, 0_TIME),
+    conn_if2in_WCET(this, 3, 0_TIME) {
 };
 
 void FORTE_RT_E_TRAIN::setInitialValues() {
-  var_DT = 0_TIME;
-  var_N = 0_UINT;
-  var_Deadline = 0_TIME;
-  var_WCET = 0_TIME;
-  var_CV = 0_UINT;
+  conn_if2in_DT.getValue() = 0_TIME;
+  conn_if2in_N.getValue() = 0_UINT;
+  conn_if2in_Deadline.getValue() = 0_TIME;
+  conn_if2in_WCET.getValue() = 0_TIME;
+  fb_E_CTU->conn_CV.getValue() = 0_UINT;
 }
 
 const SCFB_FBInstanceData FORTE_RT_E_TRAIN::scmInternalFBs[] = {
@@ -127,10 +131,10 @@ const SCFB_FBNData FORTE_RT_E_TRAIN::scmFBNData = {
 void FORTE_RT_E_TRAIN::readInputData(TEventID paEIID) {
   switch(paEIID) {
     case scmEventSTARTID: {
-      readData(0, var_DT, conn_DT);
-      readData(1, var_N, conn_N);
-      readData(2, var_Deadline, conn_Deadline);
-      readData(3, var_WCET, conn_WCET);
+      readData(0, conn_if2in_DT.getValue(), conn_DT);
+      readData(1, conn_if2in_N.getValue(), conn_N);
+      readData(2, conn_if2in_Deadline.getValue(), conn_Deadline);
+      readData(3, conn_if2in_WCET.getValue(), conn_WCET);
       break;
     }
     case scmEventSTOPID: {
@@ -144,18 +148,7 @@ void FORTE_RT_E_TRAIN::readInputData(TEventID paEIID) {
 void FORTE_RT_E_TRAIN::writeOutputData(TEventID paEIID) {
   switch(paEIID) {
     case scmEventEOID: {
-      writeData(0, var_CV, conn_CV);
-      break;
-    }
-    default:
-      break;
-  }
-}
-
-void FORTE_RT_E_TRAIN::readInternal2InterfaceOutputData(TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventEOID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_CV); }
+      writeData(0, fb_E_CTU->conn_CV.getValue(), conn_CV);
       break;
     }
     default:
@@ -165,17 +158,17 @@ void FORTE_RT_E_TRAIN::readInternal2InterfaceOutputData(TEventID paEOID) {
 
 CIEC_ANY *FORTE_RT_E_TRAIN::getDI(size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_DT;
-    case 1: return &var_N;
-    case 2: return &var_Deadline;
-    case 3: return &var_WCET;
+    case 0: return &conn_if2in_DT.getValue();
+    case 1: return &conn_if2in_N.getValue();
+    case 2: return &conn_if2in_Deadline.getValue();
+    case 3: return &conn_if2in_WCET.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_RT_E_TRAIN::getDO(size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_CV;
+    case 0: return &fb_E_CTU->conn_CV.getValue();
   }
   return nullptr;
 }
@@ -200,6 +193,16 @@ CDataConnection **FORTE_RT_E_TRAIN::getDIConUnchecked(TPortId paIndex) {
 CDataConnection *FORTE_RT_E_TRAIN::getDOConUnchecked(TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_CV;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_RT_E_TRAIN::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_DT;
+    case 1: return &conn_if2in_N;
+    case 2: return &conn_if2in_Deadline;
+    case 3: return &conn_if2in_WCET;
   }
   return nullptr;
 }

--- a/src/modules/rt_events/RT_E_TRAIN_fbt.h
+++ b/src/modules/rt_events/RT_E_TRAIN_fbt.h
@@ -63,47 +63,28 @@ private:
 
   void readInputData(TEventID paEIID) override;
   void writeOutputData(TEventID paEIID) override;
-  void readInternal2InterfaceOutputData(TEventID paEOID) override;
   void setInitialValues() override;
+  CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
 public:
   FORTE_RT_E_TRAIN(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
 
-  CIEC_TIME var_DT;
-  CIEC_UINT var_N;
-  CIEC_TIME var_Deadline;
-  CIEC_TIME var_WCET;
-  CIEC_UINT var_CV;
   CEventConnection conn_EO;
   CDataConnection *conn_DT;
   CDataConnection *conn_N;
   CDataConnection *conn_Deadline;
   CDataConnection *conn_WCET;
   COutDataConnection<CIEC_UINT> conn_CV;
+  COutDataConnection<CIEC_TIME> conn_if2in_DT;
+  COutDataConnection<CIEC_UINT> conn_if2in_N;
+  COutDataConnection<CIEC_TIME> conn_if2in_Deadline;
+  COutDataConnection<CIEC_TIME> conn_if2in_WCET;
+
   CIEC_ANY *getDI(size_t) override;
   CIEC_ANY *getDO(size_t) override;
   CEventConnection *getEOConUnchecked(TPortId) override;
   CDataConnection **getDIConUnchecked(TPortId) override;
   CDataConnection *getDOConUnchecked(TPortId) override;
-  void evt_START(const CIEC_TIME &pa_DT, const CIEC_UINT &pa_N, const CIEC_TIME &pa_Deadline, const CIEC_TIME &pa_WCET, CIEC_UINT &pa_CV) {
-    var_DT = pa_DT;
-    var_N = pa_N;
-    var_Deadline = pa_Deadline;
-    var_WCET = pa_WCET;
-    receiveInputEvent(scmEventSTARTID, nullptr);
-    pa_CV = var_CV;
-  }
-  void evt_STOP(const CIEC_TIME &pa_DT, const CIEC_UINT &pa_N, const CIEC_TIME &pa_Deadline, const CIEC_TIME &pa_WCET, CIEC_UINT &pa_CV) {
-    var_DT = pa_DT;
-    var_N = pa_N;
-    var_Deadline = pa_Deadline;
-    var_WCET = pa_WCET;
-    receiveInputEvent(scmEventSTOPID, nullptr);
-    pa_CV = var_CV;
-  }
-  void operator()(const CIEC_TIME &pa_DT, const CIEC_UINT &pa_N, const CIEC_TIME &pa_Deadline, const CIEC_TIME &pa_WCET, CIEC_UINT &pa_CV) {
-    evt_START(pa_DT, pa_N, pa_Deadline, pa_WCET, pa_CV);
-  }
 };
 
 

--- a/src/modules/utils/signals/E_BLINK_TRAIN_fbt.cpp
+++ b/src/modules/utils/signals/E_BLINK_TRAIN_fbt.cpp
@@ -75,22 +75,21 @@ FORTE_E_BLINK_TRAIN::FORTE_E_BLINK_TRAIN(const CStringDictionary::TStringId paIn
     fb_E_TP(STRID(E_TP), *this),
     fb_E_TRAIN(STRID(E_TRAIN), *this),
     fb_ADD_2(STRID(ADD_2), "ADD_2", *this),
-    var_TIMELOW(0_TIME),
-    var_TIMEHIGH(0_TIME),
-    var_N(0_UINT),
-    var_OUT(0_BOOL),
     conn_CNF(this, 0),
     conn_TIMELOW(nullptr),
     conn_TIMEHIGH(nullptr),
     conn_N(nullptr),
-    conn_OUT(this, 0, var_OUT) {
+    conn_OUT(this, 0, 0_BOOL),
+    conn_if2in_TIMELOW(this, 0, 0_TIME),
+    conn_if2in_TIMEHIGH(this, 1, 0_TIME),
+    conn_if2in_N(this, 2, 0_UINT) {
 };
 
 void FORTE_E_BLINK_TRAIN::setInitialValues() {
-  var_TIMELOW = 0_TIME;
-  var_TIMEHIGH = 0_TIME;
-  var_N = 0_UINT;
-  var_OUT = 0_BOOL;
+  conn_if2in_TIMELOW.getValue() = 0_TIME;
+  conn_if2in_TIMEHIGH.getValue() = 0_TIME;
+  conn_if2in_N.getValue() = 0_UINT;
+  fb_E_TP->conn_Q.getValue() = 0_BOOL;
 }
 
 const SCFB_FBInstanceData FORTE_E_BLINK_TRAIN::scmInternalFBs[] = {
@@ -132,22 +131,12 @@ const SCFB_FBNData FORTE_E_BLINK_TRAIN::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_BLINK_TRAIN::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventCNFID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_OUT); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_BLINK_TRAIN::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventSTARTID: {
-      readData(0, var_TIMELOW, conn_TIMELOW);
-      readData(1, var_TIMEHIGH, conn_TIMEHIGH);
-      readData(2, var_N, conn_N);
+      readData(0, conn_if2in_TIMELOW.getValue(), conn_TIMELOW);
+      readData(1, conn_if2in_TIMEHIGH.getValue(), conn_TIMEHIGH);
+      readData(2, conn_if2in_N.getValue(), conn_N);
       break;
     }
     default:
@@ -158,7 +147,7 @@ void FORTE_E_BLINK_TRAIN::readInputData(const TEventID paEIID) {
 void FORTE_E_BLINK_TRAIN::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, var_OUT, conn_OUT);
+      writeData(0, fb_E_TP->conn_Q.getValue(), conn_OUT);
       break;
     }
     default:
@@ -168,16 +157,16 @@ void FORTE_E_BLINK_TRAIN::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_BLINK_TRAIN::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_TIMELOW;
-    case 1: return &var_TIMEHIGH;
-    case 2: return &var_N;
+    case 0: return &conn_if2in_TIMELOW.getValue();
+    case 1: return &conn_if2in_TIMEHIGH.getValue();
+    case 2: return &conn_if2in_N.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_BLINK_TRAIN::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_OUT;
+    case 0: return &fb_E_TP->conn_Q.getValue();
   }
   return nullptr;
 }
@@ -201,6 +190,15 @@ CDataConnection **FORTE_E_BLINK_TRAIN::getDIConUnchecked(const TPortId paIndex) 
 CDataConnection *FORTE_E_BLINK_TRAIN::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_OUT;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_BLINK_TRAIN::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_TIMELOW;
+    case 1: return &conn_if2in_TIMEHIGH;
+    case 2: return &conn_if2in_N;
   }
   return nullptr;
 }

--- a/src/modules/utils/signals/E_BLINK_TRAIN_fbt.h
+++ b/src/modules/utils/signals/E_BLINK_TRAIN_fbt.h
@@ -66,17 +66,11 @@ class FORTE_E_BLINK_TRAIN final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_BLINK_TRAIN(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_TIME var_TIMELOW;
-    CIEC_TIME var_TIMEHIGH;
-    CIEC_UINT var_N;
-
-    CIEC_BOOL var_OUT;
 
     CEventConnection conn_CNF;
 
@@ -86,30 +80,14 @@ class FORTE_E_BLINK_TRAIN final : public CCompositeFB {
 
     COutDataConnection<CIEC_BOOL> conn_OUT;
 
+    COutDataConnection<CIEC_TIME> conn_if2in_TIMELOW;
+    COutDataConnection<CIEC_TIME> conn_if2in_TIMEHIGH;
+    COutDataConnection<CIEC_UINT> conn_if2in_N;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_START(const CIEC_TIME &paTIMELOW, const CIEC_TIME &paTIMEHIGH, const CIEC_UINT &paN, CIEC_BOOL &paOUT) {
-      var_TIMELOW = paTIMELOW;
-      var_TIMEHIGH = paTIMEHIGH;
-      var_N = paN;
-      executeEvent(scmEventSTARTID, nullptr);
-      paOUT = var_OUT;
-    }
-
-    void evt_STOP(const CIEC_TIME &paTIMELOW, const CIEC_TIME &paTIMEHIGH, const CIEC_UINT &paN, CIEC_BOOL &paOUT) {
-      var_TIMELOW = paTIMELOW;
-      var_TIMEHIGH = paTIMEHIGH;
-      var_N = paN;
-      executeEvent(scmEventSTOPID, nullptr);
-      paOUT = var_OUT;
-    }
-
-    void operator()(const CIEC_TIME &paTIMELOW, const CIEC_TIME &paTIMEHIGH, const CIEC_UINT &paN, CIEC_BOOL &paOUT) {
-      evt_START(paTIMELOW, paTIMEHIGH, paN, paOUT);
-    }
 };
 

--- a/src/modules/utils/signals/E_BLINK_fbt.cpp
+++ b/src/modules/utils/signals/E_BLINK_fbt.cpp
@@ -73,19 +73,18 @@ FORTE_E_BLINK::FORTE_E_BLINK(const CStringDictionary::TStringId paInstanceNameId
     fb_E_TP(STRID(E_TP), *this),
     fb_E_CYCLE(STRID(E_CYCLE), *this),
     fb_ADD_2(STRID(ADD_2), "ADD_2", *this),
-    var_TIMELOW(0_TIME),
-    var_TIMEHIGH(0_TIME),
-    var_OUT(0_BOOL),
     conn_CNF(this, 0),
     conn_TIMELOW(nullptr),
     conn_TIMEHIGH(nullptr),
-    conn_OUT(this, 0, var_OUT) {
+    conn_OUT(this, 0, 0_BOOL),
+    conn_if2in_TIMELOW(this, 0, 0_TIME),
+    conn_if2in_TIMEHIGH(this, 1, 0_TIME) {
 };
 
 void FORTE_E_BLINK::setInitialValues() {
-  var_TIMELOW = 0_TIME;
-  var_TIMEHIGH = 0_TIME;
-  var_OUT = 0_BOOL;
+  conn_if2in_TIMELOW.getValue() = 0_TIME;
+  conn_if2in_TIMEHIGH.getValue() = 0_TIME;
+  fb_E_TP->conn_Q.getValue() = 0_BOOL;
 }
 
 const SCFB_FBInstanceData FORTE_E_BLINK::scmInternalFBs[] = {
@@ -126,21 +125,11 @@ const SCFB_FBNData FORTE_E_BLINK::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_BLINK::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventCNFID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_OUT); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_BLINK::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventSTARTID: {
-      readData(0, var_TIMELOW, conn_TIMELOW);
-      readData(1, var_TIMEHIGH, conn_TIMEHIGH);
+      readData(0, conn_if2in_TIMELOW.getValue(), conn_TIMELOW);
+      readData(1, conn_if2in_TIMEHIGH.getValue(), conn_TIMEHIGH);
       break;
     }
     default:
@@ -151,7 +140,7 @@ void FORTE_E_BLINK::readInputData(const TEventID paEIID) {
 void FORTE_E_BLINK::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, var_OUT, conn_OUT);
+      writeData(0, fb_E_TP->conn_Q.getValue(), conn_OUT);
       break;
     }
     default:
@@ -161,15 +150,15 @@ void FORTE_E_BLINK::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_BLINK::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_TIMELOW;
-    case 1: return &var_TIMEHIGH;
+    case 0: return &conn_if2in_TIMELOW.getValue();
+    case 1: return &conn_if2in_TIMEHIGH.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_BLINK::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_OUT;
+    case 0: return &fb_E_TP->conn_Q.getValue();
   }
   return nullptr;
 }
@@ -192,6 +181,14 @@ CDataConnection **FORTE_E_BLINK::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_E_BLINK::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_OUT;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_BLINK::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_TIMELOW;
+    case 1: return &conn_if2in_TIMEHIGH;
   }
   return nullptr;
 }

--- a/src/modules/utils/signals/E_BLINK_fbt.h
+++ b/src/modules/utils/signals/E_BLINK_fbt.h
@@ -65,16 +65,11 @@ class FORTE_E_BLINK final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_BLINK(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_TIME var_TIMELOW;
-    CIEC_TIME var_TIMEHIGH;
-
-    CIEC_BOOL var_OUT;
 
     CEventConnection conn_CNF;
 
@@ -83,28 +78,13 @@ class FORTE_E_BLINK final : public CCompositeFB {
 
     COutDataConnection<CIEC_BOOL> conn_OUT;
 
+    COutDataConnection<CIEC_TIME> conn_if2in_TIMELOW;
+    COutDataConnection<CIEC_TIME> conn_if2in_TIMEHIGH;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_START(const CIEC_TIME &paTIMELOW, const CIEC_TIME &paTIMEHIGH, CIEC_BOOL &paOUT) {
-      var_TIMELOW = paTIMELOW;
-      var_TIMEHIGH = paTIMEHIGH;
-      executeEvent(scmEventSTARTID, nullptr);
-      paOUT = var_OUT;
-    }
-
-    void evt_STOP(const CIEC_TIME &paTIMELOW, const CIEC_TIME &paTIMEHIGH, CIEC_BOOL &paOUT) {
-      var_TIMELOW = paTIMELOW;
-      var_TIMEHIGH = paTIMEHIGH;
-      executeEvent(scmEventSTOPID, nullptr);
-      paOUT = var_OUT;
-    }
-
-    void operator()(const CIEC_TIME &paTIMELOW, const CIEC_TIME &paTIMEHIGH, CIEC_BOOL &paOUT) {
-      evt_START(paTIMELOW, paTIMEHIGH, paOUT);
-    }
 };
 

--- a/src/stdfblib/events/E_F_TRIG_fbt.cpp
+++ b/src/stdfblib/events/E_F_TRIG_fbt.cpp
@@ -55,10 +55,14 @@ FORTE_E_F_TRIG::FORTE_E_F_TRIG(const CStringDictionary::TStringId paInstanceName
     CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData),
     fb_E_D_FF(STRID(E_D_FF), *this),
     fb_E_SWITCH(STRID(E_SWITCH), *this),
-    var_QI(CIEC_BOOL(0)),
     conn_EO(this, 0),
-    conn_QI(nullptr) {
+    conn_QI(nullptr),
+    conn_if2in_QI(this, 0, 0_BOOL) {
 };
+
+void FORTE_E_F_TRIG::setInitialValues() {
+  conn_if2in_QI.getValue() = 0_BOOL;
+}
 
 const SCFB_FBInstanceData FORTE_E_F_TRIG::scmInternalFBs[] = {
   {STRID(E_D_FF), STRID(E_D_FF)},
@@ -91,7 +95,7 @@ const SCFB_FBNData FORTE_E_F_TRIG::scmFBNData = {
 void FORTE_E_F_TRIG::readInputData(TEventID paEIID) {
   switch(paEIID) {
     case scmEventEIID: {
-      readData(0, var_QI, conn_QI);
+      readData(0, conn_if2in_QI.getValue(), conn_QI);
       break;
     }
     default:
@@ -102,12 +106,9 @@ void FORTE_E_F_TRIG::readInputData(TEventID paEIID) {
 void FORTE_E_F_TRIG::writeOutputData(TEventID) {
 }
 
-void FORTE_E_F_TRIG::readInternal2InterfaceOutputData(TEventID) {
-}
-
 CIEC_ANY *FORTE_E_F_TRIG::getDI(size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_QI;
+    case 0: return &conn_if2in_QI.getValue();
   }
   return nullptr;
 }
@@ -131,6 +132,13 @@ CDataConnection **FORTE_E_F_TRIG::getDIConUnchecked(TPortId paIndex) {
 }
 
 CDataConnection *FORTE_E_F_TRIG::getDOConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_F_TRIG::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_QI;
+  }
   return nullptr;
 }
 

--- a/src/stdfblib/events/E_F_TRIG_fbt.h
+++ b/src/stdfblib/events/E_F_TRIG_fbt.h
@@ -56,26 +56,20 @@ private:
 
   void readInputData(TEventID paEIID) override;
   void writeOutputData(TEventID paEIID) override;
-  void readInternal2InterfaceOutputData(TEventID paEOID) override;
+  void setInitialValues() override;
+  CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
 public:
   FORTE_E_F_TRIG(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
 
-  CIEC_BOOL var_QI;
   CEventConnection conn_EO;
   CDataConnection *conn_QI;
+  COutDataConnection<CIEC_BOOL> conn_if2in_QI;
   CIEC_ANY *getDI(size_t) override;
   CIEC_ANY *getDO(size_t) override;
   CEventConnection *getEOConUnchecked(TPortId) override;
   CDataConnection **getDIConUnchecked(TPortId) override;
   CDataConnection *getDOConUnchecked(TPortId) override;
-  void evt_EI(const CIEC_BOOL &pa_QI) {
-    var_QI = pa_QI;
-    receiveInputEvent(scmEventEIID, nullptr);
-  }
-  void operator()(const CIEC_BOOL &pa_QI) {
-    evt_EI(pa_QI);
-  }
 };
 
 

--- a/src/stdfblib/events/E_N_TABLE_fbt.cpp
+++ b/src/stdfblib/events/E_N_TABLE_fbt.cpp
@@ -73,19 +73,19 @@ FORTE_E_N_TABLE::FORTE_E_N_TABLE(const CStringDictionary::TStringId paInstanceNa
     fb_E_TABLE(STRID(E_TABLE), *this),
     fb_E_DEMUX(STRID(E_DEMUX), *this),
     fb_F_SUB(STRID(F_SUB), *this),
-    var_DT(CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>{}),
-    var_N(0_UINT),
     conn_EO0(this, 0),
     conn_EO1(this, 1),
     conn_EO2(this, 2),
     conn_EO3(this, 3),
     conn_DT(nullptr),
-    conn_N(nullptr) {
+    conn_N(nullptr),
+    conn_if2in_DT(this, 0, CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>{}),
+    conn_if2in_N(this, 0, 0_UINT) {
 };
 
 void FORTE_E_N_TABLE::setInitialValues() {
-  var_DT = CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>{};
-  var_N = 0_UINT;
+    conn_if2in_DT.getValue() = CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>{};
+    conn_if2in_N.getValue() = 0_UINT;
 }
 
 void FORTE_E_N_TABLE::setFBNetworkInitialValues() {
@@ -125,14 +125,11 @@ const SCFB_FBNData FORTE_E_N_TABLE::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_N_TABLE::readInternal2InterfaceOutputData(TEventID) {
-  // nothing to do
-}
 void FORTE_E_N_TABLE::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventSTARTID: {
-      readData(0, var_DT, conn_DT);
-      readData(1, var_N, conn_N);
+      readData(0, conn_if2in_DT.getValue(), conn_DT);
+      readData(1, conn_if2in_N.getValue(), conn_N);
       break;
     }
     default:
@@ -146,8 +143,8 @@ void FORTE_E_N_TABLE::writeOutputData(TEventID) {
 
 CIEC_ANY *FORTE_E_N_TABLE::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_DT;
-    case 1: return &var_N;
+    case 0: return &conn_if2in_DT.getValue();
+    case 1: return &conn_if2in_N.getValue();
   }
   return nullptr;
 }
@@ -175,5 +172,13 @@ CDataConnection **FORTE_E_N_TABLE::getDIConUnchecked(const TPortId paIndex) {
 }
 
 CDataConnection *FORTE_E_N_TABLE::getDOConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_N_TABLE::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_DT;
+    case 1: return &conn_if2in_N;
+  }
   return nullptr;
 }

--- a/src/stdfblib/events/E_N_TABLE_fbt.h
+++ b/src/stdfblib/events/E_N_TABLE_fbt.h
@@ -65,15 +65,12 @@ class FORTE_E_N_TABLE final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
     void setFBNetworkInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_N_TABLE(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3> var_DT;
-    CIEC_UINT var_N;
 
     CEventConnection conn_EO0;
     CEventConnection conn_EO1;
@@ -83,26 +80,13 @@ class FORTE_E_N_TABLE final : public CCompositeFB {
     CDataConnection *conn_DT;
     CDataConnection *conn_N;
 
+    COutDataConnection<CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>> conn_if2in_DT;
+    COutDataConnection<CIEC_UINT> conn_if2in_N;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_START(const CIEC_ARRAY_COMMON<CIEC_TIME> &paDT, const CIEC_UINT &paN) {
-      var_DT = paDT;
-      var_N = paN;
-      executeEvent(scmEventSTARTID, nullptr);
-    }
-
-    void evt_STOP(const CIEC_ARRAY_COMMON<CIEC_TIME> &paDT, const CIEC_UINT &paN) {
-      var_DT = paDT;
-      var_N = paN;
-      executeEvent(scmEventSTOPID, nullptr);
-    }
-
-    void operator()(const CIEC_ARRAY_COMMON<CIEC_TIME> &paDT, const CIEC_UINT &paN) {
-      evt_START(paDT, paN);
-    }
 };
 

--- a/src/stdfblib/events/E_PULSE_fbt.cpp
+++ b/src/stdfblib/events/E_PULSE_fbt.cpp
@@ -68,12 +68,13 @@ FORTE_E_PULSE::FORTE_E_PULSE(const CStringDictionary::TStringId paInstanceNameId
     fb_E_SR(STRID(E_SR), *this),
     conn_CNF(this, 0),
     conn_PT(nullptr),
-    conn_Q(this, 0, var_Q) {
+    conn_Q(this, 0, 0_BOOL),
+    conn_if2in_PT(this, 0, 0_TIME) {
 };
 
 void FORTE_E_PULSE::setInitialValues() {
-    var_PT = 0_TIME;
-    var_Q = 0_BOOL;
+    conn_if2in_PT.getValue() = 0_TIME;
+    fb_E_SR->conn_Q.getValue() = 0_BOOL;
 }
 
 const SCFB_FBInstanceData FORTE_E_PULSE::scmInternalFBs[] = {
@@ -109,20 +110,10 @@ const SCFB_FBNData FORTE_E_PULSE::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_PULSE::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventCNFID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_Q); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_PULSE::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventREQID: {
-      readData(0, var_PT, conn_PT);
+      readData(0, conn_if2in_PT.getValue(), conn_PT);
       break;
     }
     default:
@@ -133,7 +124,7 @@ void FORTE_E_PULSE::readInputData(const TEventID paEIID) {
 void FORTE_E_PULSE::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, var_Q, conn_Q);
+      writeData(0, fb_E_SR->conn_Q.getValue(), conn_Q);
       break;
     }
     default:
@@ -143,14 +134,14 @@ void FORTE_E_PULSE::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_PULSE::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_PT;
+    case 0: return &conn_if2in_PT.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_PULSE::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_Q;
+    case 0: return &fb_E_SR->conn_Q.getValue();
   }
   return nullptr;
 }
@@ -172,6 +163,13 @@ CDataConnection **FORTE_E_PULSE::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_E_PULSE::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_Q;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_PULSE::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_PT;
   }
   return nullptr;
 }

--- a/src/stdfblib/events/E_PULSE_fbt.h
+++ b/src/stdfblib/events/E_PULSE_fbt.h
@@ -66,15 +66,11 @@ class FORTE_E_PULSE final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_PULSE(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_TIME var_PT;
-
-    CIEC_BOOL var_Q;
 
     CEventConnection conn_CNF;
 
@@ -82,27 +78,13 @@ class FORTE_E_PULSE final : public CCompositeFB {
 
     COutDataConnection<CIEC_BOOL> conn_Q;
 
+    COutDataConnection<CIEC_TIME> conn_if2in_PT;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_REQ(const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      var_PT = paPT;
-      executeEvent(scmEventREQID, nullptr);
-      paQ = var_Q;
-    }
-
-    void evt_R(const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      var_PT = paPT;
-      executeEvent(scmEventRID, nullptr);
-      paQ = var_Q;
-    }
-
-    void operator()(const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      evt_REQ(paPT, paQ);
-    }
 };
 
 

--- a/src/stdfblib/events/E_RTimeOut_fbt.cpp
+++ b/src/stdfblib/events/E_RTimeOut_fbt.cpp
@@ -78,9 +78,6 @@ const SCFB_FBNData FORTE_E_RTimeOut::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_RTimeOut::readInternal2InterfaceOutputData(TEventID) {
-  // nothing to do
-}
 void FORTE_E_RTimeOut::readInputData(TEventID) {
   // nothing to do
 }
@@ -113,6 +110,10 @@ CDataConnection **FORTE_E_RTimeOut::getDIConUnchecked(TPortId) {
 }
 
 CDataConnection *FORTE_E_RTimeOut::getDOConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_RTimeOut::getIf2InConUnchecked(TPortId) {
   return nullptr;
 }
 

--- a/src/stdfblib/events/E_RTimeOut_fbt.h
+++ b/src/stdfblib/events/E_RTimeOut_fbt.h
@@ -44,7 +44,7 @@ class FORTE_E_RTimeOut final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_RTimeOut(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);

--- a/src/stdfblib/events/E_R_TRIG_fbt.cpp
+++ b/src/stdfblib/events/E_R_TRIG_fbt.cpp
@@ -55,10 +55,14 @@ FORTE_E_R_TRIG::FORTE_E_R_TRIG(const CStringDictionary::TStringId paInstanceName
     CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData),
     fb_E_D_FF(STRID(E_D_FF), *this),
     fb_E_SWITCH(STRID(E_SWITCH), *this),
-    var_QI(CIEC_BOOL(0)),
     conn_EO(this, 0),
-    conn_QI(nullptr) {
+    conn_QI(nullptr),
+    conn_if2in_QI(this, 0, 0_BOOL) {
 };
+
+void FORTE_E_R_TRIG::setInitialValues() {
+  conn_if2in_QI.getValue() = 0_BOOL;
+}
 
 const SCFB_FBInstanceData FORTE_E_R_TRIG::scmInternalFBs[] = {
   {STRID(E_D_FF), STRID(E_D_FF)},
@@ -91,7 +95,7 @@ const SCFB_FBNData FORTE_E_R_TRIG::scmFBNData = {
 void FORTE_E_R_TRIG::readInputData(TEventID paEIID) {
   switch(paEIID) {
     case scmEventEIID: {
-      readData(0, var_QI, conn_QI);
+      readData(0, conn_if2in_QI.getValue(), conn_QI);
       break;
     }
     default:
@@ -102,12 +106,9 @@ void FORTE_E_R_TRIG::readInputData(TEventID paEIID) {
 void FORTE_E_R_TRIG::writeOutputData(TEventID) {
 }
 
-void FORTE_E_R_TRIG::readInternal2InterfaceOutputData(TEventID) {
-}
-
 CIEC_ANY *FORTE_E_R_TRIG::getDI(size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_QI;
+    case 0: return &conn_if2in_QI.getValue();
   }
   return nullptr;
 }
@@ -131,6 +132,13 @@ CDataConnection **FORTE_E_R_TRIG::getDIConUnchecked(TPortId paIndex) {
 }
 
 CDataConnection *FORTE_E_R_TRIG::getDOConUnchecked(TPortId) {
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_R_TRIG::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_QI;
+  }
   return nullptr;
 }
 

--- a/src/stdfblib/events/E_R_TRIG_fbt.h
+++ b/src/stdfblib/events/E_R_TRIG_fbt.h
@@ -56,26 +56,20 @@ private:
 
   void readInputData(TEventID paEIID) override;
   void writeOutputData(TEventID paEIID) override;
-  void readInternal2InterfaceOutputData(TEventID paEOID) override;
+  void setInitialValues() override;
+  CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
 public:
   FORTE_E_R_TRIG(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
 
-  CIEC_BOOL var_QI;
   CEventConnection conn_EO;
   CDataConnection *conn_QI;
+  COutDataConnection<CIEC_BOOL> conn_if2in_QI;
   CIEC_ANY *getDI(size_t) override;
   CIEC_ANY *getDO(size_t) override;
   CEventConnection *getEOConUnchecked(TPortId) override;
   CDataConnection **getDIConUnchecked(TPortId) override;
   CDataConnection *getDOConUnchecked(TPortId) override;
-  void evt_EI(const CIEC_BOOL &pa_QI) {
-    var_QI = pa_QI;
-    receiveInputEvent(scmEventEIID, nullptr);
-  }
-  void operator()(const CIEC_BOOL &pa_QI) {
-    evt_EI(pa_QI);
-  }
 };
 
 

--- a/src/stdfblib/events/E_TABLE_fbt.cpp
+++ b/src/stdfblib/events/E_TABLE_fbt.cpp
@@ -66,19 +66,18 @@ FORTE_E_TABLE::FORTE_E_TABLE(const CStringDictionary::TStringId paInstanceNameId
     CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData),
     fb_E_TABLE_CTRL(STRID(E_TABLE_CTRL), *this),
     fb_E_DELAY(STRID(E_DELAY), *this),
-    var_DT(CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>{}),
-    var_N(0_UINT),
-    var_CV(0_UINT),
     conn_EO(this, 0),
     conn_DT(nullptr),
     conn_N(nullptr),
-    conn_CV(this, 0, var_CV) {
+    conn_CV(this, 0, 0_UINT),
+    conn_if2in_DT(this, 0, CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>{}),
+    conn_if2in_N(this, 0, 0_UINT) {
 };
 
 void FORTE_E_TABLE::setInitialValues() {
-  var_DT = CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>{};
-  var_N = 0_UINT;
-  var_CV = 0_UINT;
+  conn_if2in_DT.getValue() = CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>{};
+  conn_if2in_N.getValue() = 0_UINT;
+  fb_E_TABLE_CTRL->conn_CV.getValue() = 0_UINT;
 }
 
 const SCFB_FBInstanceData FORTE_E_TABLE::scmInternalFBs[] = {
@@ -113,21 +112,11 @@ const SCFB_FBNData FORTE_E_TABLE::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_TABLE::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventEOID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_CV); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_TABLE::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventSTARTID: {
-      readData(0, var_DT, conn_DT);
-      readData(1, var_N, conn_N);
+      readData(0, conn_if2in_DT.getValue(), conn_DT);
+      readData(1, conn_if2in_N.getValue(), conn_N);
       break;
     }
     default:
@@ -138,7 +127,7 @@ void FORTE_E_TABLE::readInputData(const TEventID paEIID) {
 void FORTE_E_TABLE::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventEOID: {
-      writeData(0, var_CV, conn_CV);
+      writeData(0, fb_E_TABLE_CTRL->conn_CV.getValue(), conn_CV);
       break;
     }
     default:
@@ -148,15 +137,15 @@ void FORTE_E_TABLE::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_TABLE::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_DT;
-    case 1: return &var_N;
+    case 0: return &conn_if2in_DT.getValue();
+    case 1: return &conn_if2in_N.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_TABLE::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_CV;
+    case 0: return &fb_E_TABLE_CTRL->conn_CV.getValue();
   }
   return nullptr;
 }
@@ -179,6 +168,14 @@ CDataConnection **FORTE_E_TABLE::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_E_TABLE::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_CV;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_TABLE::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_DT;
+    case 1: return &conn_if2in_N;
   }
   return nullptr;
 }

--- a/src/stdfblib/events/E_TABLE_fbt.h
+++ b/src/stdfblib/events/E_TABLE_fbt.h
@@ -62,16 +62,11 @@ class FORTE_E_TABLE final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_TABLE(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3> var_DT;
-    CIEC_UINT var_N;
-
-    CIEC_UINT var_CV;
 
     CEventConnection conn_EO;
 
@@ -80,28 +75,13 @@ class FORTE_E_TABLE final : public CCompositeFB {
 
     COutDataConnection<CIEC_UINT> conn_CV;
 
+    COutDataConnection<CIEC_ARRAY_FIXED<CIEC_TIME, 0, 3>> conn_if2in_DT;
+    COutDataConnection<CIEC_UINT> conn_if2in_N;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_START(const CIEC_ARRAY_COMMON<CIEC_TIME> &paDT, const CIEC_UINT &paN, CIEC_UINT &paCV) {
-      var_DT = paDT;
-      var_N = paN;
-      executeEvent(scmEventSTARTID, nullptr);
-      paCV = var_CV;
-    }
-
-    void evt_STOP(const CIEC_ARRAY_COMMON<CIEC_TIME> &paDT, const CIEC_UINT &paN, CIEC_UINT &paCV) {
-      var_DT = paDT;
-      var_N = paN;
-      executeEvent(scmEventSTOPID, nullptr);
-      paCV = var_CV;
-    }
-
-    void operator()(const CIEC_ARRAY_COMMON<CIEC_TIME> &paDT, const CIEC_UINT &paN, CIEC_UINT &paCV) {
-      evt_START(paDT, paN, paCV);
-    }
 };
 

--- a/src/stdfblib/events/E_TOF_fbt.cpp
+++ b/src/stdfblib/events/E_TOF_fbt.cpp
@@ -75,13 +75,15 @@ FORTE_E_TOF::FORTE_E_TOF(const CStringDictionary::TStringId paInstanceNameId, fo
     conn_CNF(this, 0),
     conn_IN(nullptr),
     conn_PT(nullptr),
-    conn_Q(this, 0, var_Q) {
+    conn_Q(this, 0, 0_BOOL),
+    conn_if2in_IN(this, 0, 0_BOOL),
+    conn_if2in_PT(this, 1, 0_TIME) {
 };
 
 void FORTE_E_TOF::setInitialValues() {
-    var_IN = 0_BOOL;
-    var_PT = 0_TIME;
-    var_Q = 0_BOOL;
+    conn_if2in_IN.getValue() = 0_BOOL;
+    conn_if2in_PT.getValue() = 0_TIME;
+    fb_E_RS->conn_Q.getValue() = 0_BOOL;
 }
 
 const SCFB_FBInstanceData FORTE_E_TOF::scmInternalFBs[] = {
@@ -121,21 +123,11 @@ const SCFB_FBNData FORTE_E_TOF::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_TOF::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventCNFID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_Q); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_TOF::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventREQID: {
-      readData(0, var_IN, conn_IN);
-      readData(1, var_PT, conn_PT);
+      readData(0, conn_if2in_IN.getValue(), conn_IN);
+      readData(1, conn_if2in_PT.getValue(), conn_PT);
       break;
     }
     default:
@@ -146,7 +138,7 @@ void FORTE_E_TOF::readInputData(const TEventID paEIID) {
 void FORTE_E_TOF::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, var_Q, conn_Q);
+      writeData(0, fb_E_RS->conn_Q.getValue(), conn_Q);
       break;
     }
     default:
@@ -156,15 +148,15 @@ void FORTE_E_TOF::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_TOF::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_IN;
-    case 1: return &var_PT;
+    case 0: return &conn_if2in_IN.getValue();
+    case 1: return &conn_if2in_PT.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_TOF::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_Q;
+    case 0: return &fb_E_RS->conn_Q.getValue();
   }
   return nullptr;
 }
@@ -187,6 +179,14 @@ CDataConnection **FORTE_E_TOF::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_E_TOF::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_Q;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_TOF::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_IN;
+    case 1: return &conn_if2in_PT;
   }
   return nullptr;
 }

--- a/src/stdfblib/events/E_TOF_fbt.h
+++ b/src/stdfblib/events/E_TOF_fbt.h
@@ -67,16 +67,11 @@ class FORTE_E_TOF final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_TOF(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_BOOL var_IN;
-    CIEC_TIME var_PT;
-
-    CIEC_BOOL var_Q;
 
     CEventConnection conn_CNF;
 
@@ -85,29 +80,14 @@ class FORTE_E_TOF final : public CCompositeFB {
 
     COutDataConnection<CIEC_BOOL> conn_Q;
 
+    COutDataConnection<CIEC_BOOL> conn_if2in_IN;
+    COutDataConnection<CIEC_TIME> conn_if2in_PT;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_REQ(const CIEC_BOOL &paIN, const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      var_IN = paIN;
-      var_PT = paPT;
-      executeEvent(scmEventREQID, nullptr);
-      paQ = var_Q;
-    }
-
-    void evt_R(const CIEC_BOOL &paIN, const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      var_IN = paIN;
-      var_PT = paPT;
-      executeEvent(scmEventRID, nullptr);
-      paQ = var_Q;
-    }
-
-    void operator()(const CIEC_BOOL &paIN, const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      evt_REQ(paIN, paPT, paQ);
-    }
 };
 
 

--- a/src/stdfblib/events/E_TONOF_fbt.cpp
+++ b/src/stdfblib/events/E_TONOF_fbt.cpp
@@ -80,14 +80,17 @@ FORTE_E_TONOF::FORTE_E_TONOF(const CStringDictionary::TStringId paInstanceNameId
     conn_IN(nullptr),
     conn_PT_ON(nullptr),
     conn_PT_OFF(nullptr),
-    conn_Q(this, 0, var_Q) {
+    conn_Q(this, 0, 0_BOOL),
+    conn_if2in_IN(this, 0, 0_BOOL),
+    conn_if2in_PT_ON(this, 1, 0_TIME),
+    conn_if2in_PT_OFF(this, 2, 0_TIME) {
 };
 
 void FORTE_E_TONOF::setInitialValues() {
-    var_IN = 0_BOOL;
-    var_PT_ON = 0_TIME;
-    var_PT_OFF = 0_TIME;
-    var_Q = 0_BOOL;
+    conn_if2in_IN.getValue() = 0_BOOL;
+    conn_if2in_PT_ON.getValue() = 0_TIME;
+    conn_if2in_PT_OFF.getValue() = 0_TIME;
+    fb_E_RS->conn_Q.getValue() = 0_BOOL;
 }
 
 const SCFB_FBInstanceData FORTE_E_TONOF::scmInternalFBs[] = {
@@ -131,22 +134,12 @@ const SCFB_FBNData FORTE_E_TONOF::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_TONOF::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventCNFID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_Q); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_TONOF::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventREQID: {
-      readData(0, var_IN, conn_IN);
-      readData(1, var_PT_ON, conn_PT_ON);
-      readData(2, var_PT_OFF, conn_PT_OFF);
+      readData(0, conn_if2in_IN.getValue(), conn_IN);
+      readData(1, conn_if2in_PT_ON.getValue(), conn_PT_ON);
+      readData(2, conn_if2in_PT_OFF.getValue(), conn_PT_OFF);
       break;
     }
     default:
@@ -157,7 +150,7 @@ void FORTE_E_TONOF::readInputData(const TEventID paEIID) {
 void FORTE_E_TONOF::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, var_Q, conn_Q);
+      writeData(0, fb_E_RS->conn_Q.getValue(), conn_Q);
       break;
     }
     default:
@@ -167,16 +160,16 @@ void FORTE_E_TONOF::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_TONOF::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_IN;
-    case 1: return &var_PT_ON;
-    case 2: return &var_PT_OFF;
+    case 0: return &conn_if2in_IN.getValue();
+    case 1: return &conn_if2in_PT_ON.getValue();
+    case 2: return &conn_if2in_PT_OFF.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_TONOF::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_Q;
+    case 0: return &fb_E_RS->conn_Q.getValue();
   }
   return nullptr;
 }
@@ -200,6 +193,15 @@ CDataConnection **FORTE_E_TONOF::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_E_TONOF::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_Q;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_TONOF::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_IN;
+    case 1: return &conn_if2in_PT_ON;
+    case 2: return &conn_if2in_PT_OFF;
   }
   return nullptr;
 }

--- a/src/stdfblib/events/E_TONOF_fbt.h
+++ b/src/stdfblib/events/E_TONOF_fbt.h
@@ -68,17 +68,11 @@ class FORTE_E_TONOF final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_TONOF(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_BOOL var_IN;
-    CIEC_TIME var_PT_ON;
-    CIEC_TIME var_PT_OFF;
-
-    CIEC_BOOL var_Q;
 
     CEventConnection conn_CNF;
 
@@ -88,31 +82,15 @@ class FORTE_E_TONOF final : public CCompositeFB {
 
     COutDataConnection<CIEC_BOOL> conn_Q;
 
+    COutDataConnection<CIEC_BOOL> conn_if2in_IN;
+    COutDataConnection<CIEC_TIME> conn_if2in_PT_ON;
+    COutDataConnection<CIEC_TIME> conn_if2in_PT_OFF;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_REQ(const CIEC_BOOL &paIN, const CIEC_TIME &paPT_ON, const CIEC_TIME &paPT_OFF, CIEC_BOOL &paQ) {
-      var_IN = paIN;
-      var_PT_ON = paPT_ON;
-      var_PT_OFF = paPT_OFF;
-      executeEvent(scmEventREQID, nullptr);
-      paQ = var_Q;
-    }
-
-    void evt_R(const CIEC_BOOL &paIN, const CIEC_TIME &paPT_ON, const CIEC_TIME &paPT_OFF, CIEC_BOOL &paQ) {
-      var_IN = paIN;
-      var_PT_ON = paPT_ON;
-      var_PT_OFF = paPT_OFF;
-      executeEvent(scmEventRID, nullptr);
-      paQ = var_Q;
-    }
-
-    void operator()(const CIEC_BOOL &paIN, const CIEC_TIME &paPT_ON, const CIEC_TIME &paPT_OFF, CIEC_BOOL &paQ) {
-      evt_REQ(paIN, paPT_ON, paPT_OFF, paQ);
-    }
 };
 
 

--- a/src/stdfblib/events/E_TON_fbt.cpp
+++ b/src/stdfblib/events/E_TON_fbt.cpp
@@ -74,13 +74,15 @@ FORTE_E_TON::FORTE_E_TON(const CStringDictionary::TStringId paInstanceNameId, fo
     conn_CNF(this, 0),
     conn_IN(nullptr),
     conn_PT(nullptr),
-    conn_Q(this, 0, var_Q) {
+    conn_Q(this, 0, 0_BOOL),
+    conn_if2in_IN(this, 0, 0_BOOL),
+    conn_if2in_PT(this, 1, 0_TIME) {
 };
 
 void FORTE_E_TON::setInitialValues() {
-    var_IN = 0_BOOL;
-    var_PT = 0_TIME;
-    var_Q = 0_BOOL;
+    conn_if2in_IN.getValue() = 0_BOOL;
+    conn_if2in_PT.getValue() = 0_TIME;
+    fb_E_RS->conn_Q.getValue() = 0_BOOL;
 }
 
 const SCFB_FBInstanceData FORTE_E_TON::scmInternalFBs[] = {
@@ -118,21 +120,11 @@ const SCFB_FBNData FORTE_E_TON::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_TON::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventCNFID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_Q); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_TON::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventREQID: {
-      readData(0, var_IN, conn_IN);
-      readData(1, var_PT, conn_PT);
+      readData(0, conn_if2in_IN.getValue(), conn_IN);
+      readData(1, conn_if2in_PT.getValue(), conn_PT);
       break;
     }
     default:
@@ -143,7 +135,7 @@ void FORTE_E_TON::readInputData(const TEventID paEIID) {
 void FORTE_E_TON::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, var_Q, conn_Q);
+      writeData(0, fb_E_RS->conn_Q.getValue(), conn_Q);
       break;
     }
     default:
@@ -153,15 +145,15 @@ void FORTE_E_TON::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_TON::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_IN;
-    case 1: return &var_PT;
+    case 0: return &conn_if2in_IN.getValue();
+    case 1: return &conn_if2in_PT.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_TON::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_Q;
+    case 0: return &fb_E_RS->conn_Q.getValue();
   }
   return nullptr;
 }
@@ -184,6 +176,14 @@ CDataConnection **FORTE_E_TON::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_E_TON::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_Q;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_TON::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_IN;
+    case 1: return &conn_if2in_PT;
   }
   return nullptr;
 }

--- a/src/stdfblib/events/E_TON_fbt.h
+++ b/src/stdfblib/events/E_TON_fbt.h
@@ -65,16 +65,11 @@ class FORTE_E_TON final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_TON(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_BOOL var_IN;
-    CIEC_TIME var_PT;
-
-    CIEC_BOOL var_Q;
 
     CEventConnection conn_CNF;
 
@@ -83,22 +78,14 @@ class FORTE_E_TON final : public CCompositeFB {
 
     COutDataConnection<CIEC_BOOL> conn_Q;
 
+    COutDataConnection<CIEC_BOOL> conn_if2in_IN;
+    COutDataConnection<CIEC_TIME> conn_if2in_PT;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_REQ(const CIEC_BOOL &paIN, const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      var_IN = paIN;
-      var_PT = paPT;
-      executeEvent(scmEventREQID, nullptr);
-      paQ = var_Q;
-    }
-
-    void operator()(const CIEC_BOOL &paIN, const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      evt_REQ(paIN, paPT, paQ);
-    }
 };
 
 

--- a/src/stdfblib/events/E_TP_fbt.cpp
+++ b/src/stdfblib/events/E_TP_fbt.cpp
@@ -73,13 +73,15 @@ FORTE_E_TP::FORTE_E_TP(const CStringDictionary::TStringId paInstanceNameId, fort
     conn_CNF(this, 0),
     conn_IN(nullptr),
     conn_PT(nullptr),
-    conn_Q(this, 0, var_Q) {
+    conn_Q(this, 0, 0_BOOL),
+    conn_if2in_IN(this, 0, 0_BOOL),
+    conn_if2in_PT(this, 1, 0_TIME) {
 };
 
 void FORTE_E_TP::setInitialValues() {
-    var_IN = 0_BOOL;
-    var_PT = 0_TIME;
-    var_Q = 0_BOOL;
+    conn_if2in_IN.getValue() = 0_BOOL;
+    conn_if2in_PT.getValue() = 0_TIME;
+    fb_E_RS->conn_Q.getValue() = 0_BOOL;
 }
 
 const SCFB_FBInstanceData FORTE_E_TP::scmInternalFBs[] = {
@@ -118,25 +120,15 @@ const SCFB_FBNData FORTE_E_TP::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_E_TP::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventCNFID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_Q); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_TP::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventREQID: {
-      readData(0, var_IN, conn_IN);
-      readData(1, var_PT, conn_PT);
+      readData(0, conn_if2in_IN.getValue(), conn_IN);
+      readData(1, conn_if2in_PT.getValue(), conn_PT);
       break;
     }
     case scmEventRID: {
-      readData(0, var_IN, conn_IN);
+      readData(0, conn_if2in_IN.getValue(), conn_IN);
       break;
     }
     default:
@@ -147,7 +139,7 @@ void FORTE_E_TP::readInputData(const TEventID paEIID) {
 void FORTE_E_TP::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, var_Q, conn_Q);
+      writeData(0, fb_E_RS->conn_Q.getValue(), conn_Q);
       break;
     }
     default:
@@ -157,15 +149,15 @@ void FORTE_E_TP::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_TP::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_IN;
-    case 1: return &var_PT;
+    case 0: return &conn_if2in_IN.getValue();
+    case 1: return &conn_if2in_PT.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_TP::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_Q;
+    case 0: return &fb_E_RS->conn_Q.getValue();
   }
   return nullptr;
 }
@@ -188,6 +180,14 @@ CDataConnection **FORTE_E_TP::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_E_TP::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_Q;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_TP::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_IN;
+    case 1: return &conn_if2in_PT;
   }
   return nullptr;
 }

--- a/src/stdfblib/events/E_TP_fbt.h
+++ b/src/stdfblib/events/E_TP_fbt.h
@@ -67,16 +67,11 @@ class FORTE_E_TP final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_TP(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_BOOL var_IN;
-    CIEC_TIME var_PT;
-
-    CIEC_BOOL var_Q;
 
     CEventConnection conn_CNF;
 
@@ -85,29 +80,14 @@ class FORTE_E_TP final : public CCompositeFB {
 
     COutDataConnection<CIEC_BOOL> conn_Q;
 
+    COutDataConnection<CIEC_BOOL> conn_if2in_IN;
+    COutDataConnection<CIEC_TIME> conn_if2in_PT;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_REQ(const CIEC_BOOL &paIN, const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      var_IN = paIN;
-      var_PT = paPT;
-      executeEvent(scmEventREQID, nullptr);
-      paQ = var_Q;
-    }
-
-    void evt_R(const CIEC_BOOL &paIN, const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      var_IN = paIN;
-      var_PT = paPT;
-      executeEvent(scmEventRID, nullptr);
-      paQ = var_Q;
-    }
-
-    void operator()(const CIEC_BOOL &paIN, const CIEC_TIME &paPT, CIEC_BOOL &paQ) {
-      evt_REQ(paIN, paPT, paQ);
-    }
 };
 
 

--- a/src/stdfblib/events/E_TRAIN_fbt.cpp
+++ b/src/stdfblib/events/E_TRAIN_fbt.cpp
@@ -78,19 +78,18 @@ FORTE_E_TRAIN::FORTE_E_TRAIN(const CStringDictionary::TStringId paInstanceNameId
     fb_CTR(STRID(CTR), *this),
     fb_GATE(STRID(GATE), *this),
     fb_DLY(STRID(DLY), *this),
-    var_DT(0_TIME),
-    var_N(0_UINT),
-    var_CV(0_UINT),
     conn_EO(this, 0),
     conn_DT(nullptr),
     conn_N(nullptr),
-    conn_CV(this, 0, var_CV) {
+    conn_CV(this, 0, 0_UINT),
+    conn_if2in_DT(this, 0, 0_TIME),
+    conn_if2in_N(this, 1, 0_UINT) {
 };
 
 void FORTE_E_TRAIN::setInitialValues() {
-  var_DT = 0_TIME;
-  var_N = 0_UINT;
-  var_CV = 0_UINT;
+  conn_if2in_DT.getValue() = 0_TIME;
+  conn_if2in_N.getValue() = 0_UINT;
+  fb_CTR->conn_CV.getValue() = 0_UINT;
 }
 
 const SCFB_FBInstanceData FORTE_E_TRAIN::scmInternalFBs[] = {
@@ -129,21 +128,11 @@ const SCFB_FBNData FORTE_E_TRAIN::scmFBNData = {
   0, nullptr,
 };
 
-void FORTE_E_TRAIN::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventEOID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_CV); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_E_TRAIN::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventSTARTID: {
-      readData(0, var_DT, conn_DT);
-      readData(1, var_N, conn_N);
+      readData(0, conn_if2in_DT.getValue(), conn_DT);
+      readData(1, conn_if2in_N.getValue(), conn_N);
       break;
     }
     default:
@@ -154,7 +143,7 @@ void FORTE_E_TRAIN::readInputData(const TEventID paEIID) {
 void FORTE_E_TRAIN::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventEOID: {
-      writeData(0, var_CV, conn_CV);
+      writeData(0, fb_CTR->conn_CV.getValue(), conn_CV);
       break;
     }
     default:
@@ -164,15 +153,15 @@ void FORTE_E_TRAIN::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_E_TRAIN::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_DT;
-    case 1: return &var_N;
+    case 0: return &conn_if2in_DT.getValue();
+    case 1: return &conn_if2in_N.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_E_TRAIN::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_CV;
+    case 0: return &fb_CTR->conn_CV.getValue();
   }
   return nullptr;
 }
@@ -195,6 +184,14 @@ CDataConnection **FORTE_E_TRAIN::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_E_TRAIN::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_CV;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_E_TRAIN::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_DT;
+    case 1: return &conn_if2in_N;
   }
   return nullptr;
 }

--- a/src/stdfblib/events/E_TRAIN_fbt.h
+++ b/src/stdfblib/events/E_TRAIN_fbt.h
@@ -67,16 +67,11 @@ class FORTE_E_TRAIN final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_E_TRAIN(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_TIME var_DT;
-    CIEC_UINT var_N;
-
-    CIEC_UINT var_CV;
 
     CEventConnection conn_EO;
 
@@ -85,28 +80,13 @@ class FORTE_E_TRAIN final : public CCompositeFB {
 
     COutDataConnection<CIEC_UINT> conn_CV;
 
+    COutDataConnection<CIEC_TIME> conn_if2in_DT;
+    COutDataConnection<CIEC_UINT> conn_if2in_N;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_START(const CIEC_TIME &paDT, const CIEC_UINT &paN, CIEC_UINT &paCV) {
-      var_DT = paDT;
-      var_N = paN;
-      executeEvent(scmEventSTARTID, nullptr);
-      paCV = var_CV;
-    }
-
-    void evt_STOP(const CIEC_TIME &paDT, const CIEC_UINT &paN, CIEC_UINT &paCV) {
-      var_DT = paDT;
-      var_N = paN;
-      executeEvent(scmEventSTOPID, nullptr);
-      paCV = var_CV;
-    }
-
-    void operator()(const CIEC_TIME &paDT, const CIEC_UINT &paN, CIEC_UINT &paCV) {
-      evt_START(paDT, paN, paCV);
-    }
 };
 

--- a/tests/stdfblib/CFB_TEST.cpp
+++ b/tests/stdfblib/CFB_TEST.cpp
@@ -80,12 +80,13 @@ FORTE_CFB_TEST::FORTE_CFB_TEST(const CStringDictionary::TStringId paInstanceName
     conn_CNF(this, 0),
     conn_CHANGED(this, 1),
     conn_QI(nullptr),
-    conn_QO(this, 0, var_QO) {
+    conn_QO(this, 0, 0_BOOL),
+    conn_if2in_QI(this, 0, 0_BOOL) {
 };
 
 void FORTE_CFB_TEST::setInitialValues() {
-    var_QI = 0_BOOL;
-    var_QO = 0_BOOL;
+    conn_if2in_QI.getValue() = 0_BOOL;
+    fb_E_SR->conn_Q.getValue() = 0_BOOL;
 }
 
 const SCFB_FBInstanceData FORTE_CFB_TEST::scmInternalFBs[] = {
@@ -136,28 +137,14 @@ const SCFB_FBNData FORTE_CFB_TEST::scmFBNData = {
   0, nullptr
 };
 
-void FORTE_CFB_TEST::readInternal2InterfaceOutputData(const TEventID paEOID) {
-  switch(paEOID) {
-    case scmEventCNFID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_QO); }
-      break;
-    }
-    case scmEventCHANGEDID: {
-      if(CDataConnection *conn = getIn2IfConUnchecked(0); conn) { conn->readData(var_QO); }
-      break;
-    }
-    default:
-      break;
-  }
-}
 void FORTE_CFB_TEST::readInputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventSETID: {
-      readData(0, var_QI, conn_QI);
+      readData(0, conn_if2in_QI.getValue(), conn_QI);
       break;
     }
     case scmEventRESETID: {
-      readData(0, var_QI, conn_QI);
+      readData(0, conn_if2in_QI.getValue(), conn_QI);
       break;
     }
     default:
@@ -168,11 +155,11 @@ void FORTE_CFB_TEST::readInputData(const TEventID paEIID) {
 void FORTE_CFB_TEST::writeOutputData(const TEventID paEIID) {
   switch(paEIID) {
     case scmEventCNFID: {
-      writeData(0, var_QO, conn_QO);
+      writeData(0, fb_E_SR->conn_Q.getValue(), conn_QO);
       break;
     }
     case scmEventCHANGEDID: {
-      writeData(0, var_QO, conn_QO);
+      writeData(0, fb_E_SR->conn_Q.getValue(), conn_QO);
       break;
     }
     default:
@@ -182,14 +169,14 @@ void FORTE_CFB_TEST::writeOutputData(const TEventID paEIID) {
 
 CIEC_ANY *FORTE_CFB_TEST::getDI(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_QI;
+    case 0: return &conn_if2in_QI.getValue();
   }
   return nullptr;
 }
 
 CIEC_ANY *FORTE_CFB_TEST::getDO(const size_t paIndex) {
   switch(paIndex) {
-    case 0: return &var_QO;
+    case 0: return &fb_E_SR->conn_Q.getValue();
   }
   return nullptr;
 }
@@ -212,6 +199,13 @@ CDataConnection **FORTE_CFB_TEST::getDIConUnchecked(const TPortId paIndex) {
 CDataConnection *FORTE_CFB_TEST::getDOConUnchecked(const TPortId paIndex) {
   switch(paIndex) {
     case 0: return &conn_QO;
+  }
+  return nullptr;
+}
+
+CDataConnection *FORTE_CFB_TEST::getIf2InConUnchecked(TPortId paIndex) {
+  switch(paIndex) {
+    case 0: return &conn_if2in_QI;
   }
   return nullptr;
 }

--- a/tests/stdfblib/CFB_TEST.h
+++ b/tests/stdfblib/CFB_TEST.h
@@ -66,15 +66,11 @@ class FORTE_CFB_TEST final : public CCompositeFB {
 
     void readInputData(TEventID paEIID) override;
     void writeOutputData(TEventID paEIID) override;
-    void readInternal2InterfaceOutputData(TEventID paEOID) override;
     void setInitialValues() override;
+    CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
   public:
     FORTE_CFB_TEST(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
-
-    CIEC_BOOL var_QI;
-
-    CIEC_BOOL var_QO;
 
     CEventConnection conn_CNF;
     CEventConnection conn_CHANGED;
@@ -83,27 +79,13 @@ class FORTE_CFB_TEST final : public CCompositeFB {
 
     COutDataConnection<CIEC_BOOL> conn_QO;
 
+    COutDataConnection<CIEC_BOOL> conn_if2in_QI;
+
     CIEC_ANY *getDI(size_t) override;
     CIEC_ANY *getDO(size_t) override;
     CEventConnection *getEOConUnchecked(TPortId) override;
     CDataConnection **getDIConUnchecked(TPortId) override;
     CDataConnection *getDOConUnchecked(TPortId) override;
-
-    void evt_SET(const CIEC_BOOL &paQI, CIEC_BOOL &paQO) {
-      var_QI = paQI;
-      executeEvent(scmEventSETID, nullptr);
-      paQO = var_QO;
-    }
-
-    void evt_RESET(const CIEC_BOOL &paQI, CIEC_BOOL &paQO) {
-      var_QI = paQI;
-      executeEvent(scmEventRESETID, nullptr);
-      paQO = var_QO;
-    }
-
-    void operator()(const CIEC_BOOL &paQI, CIEC_BOOL &paQO) {
-      evt_SET(paQI, paQO);
-    }
 };
 
 


### PR DESCRIPTION
Rework CFB interface-to-internal and internal-to-interface connections to directly sample between interface connections and internal FBs. Also remove connected check in write data as this would currently result in a stale (sampled) value in the connection if it became connected later.