### PR TITLE
Reworked FB Test Fixture to not use CInterface2InternalDataConnection

### DIFF
--- a/src/core/cfb.cpp
+++ b/src/core/cfb.cpp
@@ -98,8 +98,7 @@ bool CCompositeFB::connectDI(TPortId paDIPortId, CDataConnection *paDataCon){
   else if(paDIPortId < getFBInterfaceSpec().mNumDIs){
     bool needsCloning = (getDI(paDIPortId)->getDataTypeID() == CIEC_ANY::e_ANY);
     retVal = CFunctionBlock::connectDI(paDIPortId, paDataCon);
-    if((true == retVal) && (true == needsCloning) && (nullptr != paDataCon)
-        && (nullptr != paDataCon->getValue())){
+    if((true == retVal) && (true == needsCloning) && (nullptr != paDataCon)) {
       //if internal connected update the connections data type and maybe internal further connection points
       (mIf2InDConns + paDIPortId)->setValue(getDI(paDIPortId));
       (mIf2InDConns + paDIPortId)->cloneInputInterfaceValue();

--- a/src/core/dataconn.cpp
+++ b/src/core/dataconn.cpp
@@ -28,7 +28,7 @@ EMGMResponse CDataConnection::connect(CFunctionBlock *paDstFB,
   TPortId dstPortId = paDstFB->getDIID(paDstPortNameId);
   if(cgInvalidPortId != dstPortId){
     CIEC_ANY *dstDataPoint = paDstFB->getDIFromPortId(dstPortId);
-    retVal = CDataConnection::establishDataConnection(paDstFB, dstPortId, dstDataPoint);
+    retVal = CDataConnection::establishDataConnection(paDstFB, dstPortId, *dstDataPoint);
   }
   return retVal;
 }
@@ -41,7 +41,7 @@ EMGMResponse CDataConnection::connectToCFBInterface(CFunctionBlock *paDstFB,
   if(cgInvalidEventID != nDOID){
     CIEC_ANY *dstDataPoint = paDstFB->getDataOutput(paDstPortNameId);
     nDOID |= cgInternal2InterfaceMarker;
-    retVal = establishDataConnection(paDstFB, nDOID, dstDataPoint);
+    retVal = establishDataConnection(paDstFB, nDOID, *dstDataPoint);
   }
 
   return retVal;
@@ -49,7 +49,7 @@ EMGMResponse CDataConnection::connectToCFBInterface(CFunctionBlock *paDstFB,
 
 void CDataConnection::handleAnySrcPortConnection(const CIEC_ANY &paDstDataPoint){
   if(CIEC_ANY::e_ANY != paDstDataPoint.getDataTypeID()){
-    mValue->setValue(paDstDataPoint);
+    getValue().setValue(paDstDataPoint);
     getSourceId().mFB->configureGenericDO(getSourceId().mPortId, paDstDataPoint);
     if(isConnected()){
       //We already have some connection also set their correct type
@@ -75,10 +75,10 @@ CDataConnection::disconnect(CFunctionBlock *paDstFB, CStringDictionary::TStringI
   return retval;
 }
 
-bool CDataConnection::canBeConnected(const CIEC_ANY *paSrcDataPoint,
-    const CIEC_ANY *paDstDataPoint){
-  CIEC_ANY::EDataTypeID eSrcId = paSrcDataPoint->getDataTypeID();
-  CIEC_ANY::EDataTypeID eDstId = paDstDataPoint->getDataTypeID();
+bool CDataConnection::canBeConnected(const CIEC_ANY &paSrcDataPoint,
+    const CIEC_ANY &paDstDataPoint){
+  CIEC_ANY::EDataTypeID eSrcId = paSrcDataPoint.getDataTypeID();
+  CIEC_ANY::EDataTypeID eDstId = paDstDataPoint.getDataTypeID();
   bool bCanConnect = false;
 
   if(eSrcId == eDstId){
@@ -96,17 +96,15 @@ bool CDataConnection::canBeConnected(const CIEC_ANY *paSrcDataPoint,
 }
 
 EMGMResponse CDataConnection::establishDataConnection(CFunctionBlock *paDstFB, TPortId paDstPortId,
-    CIEC_ANY *paDstDataPoint){
+    const CIEC_ANY &paDstDataPoint){
   EMGMResponse retVal = EMGMResponse::InvalidOperation;
 
-  if(mValue) {
-    if (mValue->getDataTypeID() == CIEC_ANY::e_ANY) {
-      handleAnySrcPortConnection(*paDstDataPoint);
+  if (getValue().getDataTypeID() == CIEC_ANY::e_ANY) {
+    handleAnySrcPortConnection(paDstDataPoint);
+    retVal = EMGMResponse::Ready;
+  } else {
+    if (canBeConnected(getValue(), paDstDataPoint)) {
       retVal = EMGMResponse::Ready;
-    } else {
-      if (canBeConnected(mValue, paDstDataPoint)) {
-        retVal = EMGMResponse::Ready;
-      }
     }
   }
 

--- a/src/core/dataconn.h
+++ b/src/core/dataconn.h
@@ -74,20 +74,20 @@ class CDataConnection : public CConnection {
     *   Get class member variable mValue.
     *   \return pointer to class member variable mValue
     */
-    CIEC_ANY* getValue() {
-      return mValue;
+    virtual CIEC_ANY& getValue() {
+      return *mValue;
     }
 
   protected:
     /*! \brief check if the the given data points are compatible so that a connection can be established
      *
-     * @param paSrcDataPoint  data point of the connection's source (if 0 than it is a any data type)
-     * @param paDstDataPoint  data point of the connection's destination (if 0 than it is a any data type)
+     * @param paSrcDataPoint  data point of the connection's source
+     * @param paDstDataPoint  data point of the connection's destination
      * @return true if a connection between the given end points is valid
      */
-    static bool canBeConnected(const CIEC_ANY *paSrcDataPoint, const CIEC_ANY *paDstDataPoint);
+    static bool canBeConnected(const CIEC_ANY &paSrcDataPoint, const CIEC_ANY &paDstDataPoint);
 
-    virtual EMGMResponse establishDataConnection(CFunctionBlock *paDstFB, TPortId paDstPortId, CIEC_ANY *paDstDataPoint);
+    virtual EMGMResponse establishDataConnection(CFunctionBlock *paDstFB, TPortId paDstPortId, const CIEC_ANY &paDstDataPoint);
 
     /*! \brief Value for storing the current data of the connection
      */
@@ -98,7 +98,7 @@ template<typename T>
 class COutDataConnection final : public CDataConnection {
   public:
     COutDataConnection(CFunctionBlock *paSrcFB, TPortId paSrcPortId, const T &paValue)
-      : CDataConnection(paSrcFB, paSrcPortId, &mValue), mValue(paValue) {
+      : CDataConnection(paSrcFB, paSrcPortId, nullptr), mValue(paValue) {
     }
 
     void writeData(const T &paValue) {
@@ -107,6 +107,10 @@ class COutDataConnection final : public CDataConnection {
 
     void readData(CIEC_ANY &paValue) const override {
       paValue.setValue(mValue.unwrap());
+    }
+
+    T& getValue() override {
+      return mValue;
     }
 
   private:

--- a/src/core/funcbloc.cpp
+++ b/src/core/funcbloc.cpp
@@ -125,10 +125,10 @@ bool CFunctionBlock::connectDI(TPortId paDIPortId, CDataConnection *paDataCon){
   return bRetVal;
 }
 
-void CFunctionBlock::configureGenericDI(TPortId paDIPortId, const CIEC_ANY* paRefValue) {
+void CFunctionBlock::configureGenericDI(TPortId paDIPortId, const CIEC_ANY& paRefValue) {
   CIEC_ANY *di = getDI(paDIPortId);
-  if(di->getDataTypeID() == CIEC_ANY::e_ANY && (nullptr != paRefValue)) {
-    di->setValue(paRefValue->unwrap());
+  if(di->getDataTypeID() == CIEC_ANY::e_ANY) {
+    di->setValue(paRefValue.unwrap());
   }
 }
 
@@ -145,7 +145,7 @@ bool CFunctionBlock::connectDIO(TPortId paDIOPortId, CInOutDataConnection *paDat
         if(conn == paDataCon) {
           //we have a reconfiguration attempt
           configureGenericDIO(paDIOPortId, paDataCon->getValue());
-          getDIOOutConUnchecked(paDIOPortId)->setValue(paDataCon->getValue());
+          getDIOOutConUnchecked(paDIOPortId)->setValue(&paDataCon->getValue());
           return true;
         } else {
           DEVLOG_ERROR("%s cannot connect InOut data %s to more sources, using the latest connection attempt\n", getInstanceName(), CStringDictionary::get(getFBInterfaceSpec().mDIONames[paDIOPortId]));
@@ -153,7 +153,7 @@ bool CFunctionBlock::connectDIO(TPortId paDIOPortId, CInOutDataConnection *paDat
       } else {
         *getDIOInConUnchecked(paDIOPortId) = paDataCon;
         configureGenericDIO(paDIOPortId, paDataCon->getValue());
-        getDIOOutConUnchecked(paDIOPortId)->setValue(paDataCon->getValue());
+        getDIOOutConUnchecked(paDIOPortId)->setValue(&paDataCon->getValue());
         return true;
       }
     }
@@ -161,10 +161,10 @@ bool CFunctionBlock::connectDIO(TPortId paDIOPortId, CInOutDataConnection *paDat
   return false;
 }
 
-void CFunctionBlock::configureGenericDIO(TPortId paDIOPortId, const CIEC_ANY* paRefValue) {
+void CFunctionBlock::configureGenericDIO(TPortId paDIOPortId, const CIEC_ANY& paRefValue) {
   CIEC_ANY *dio = getDIO(paDIOPortId);
-  if(dio->getDataTypeID() == CIEC_ANY::e_ANY && (nullptr != paRefValue)) {
-    dio->setValue(paRefValue->unwrap());
+  if(dio->getDataTypeID() == CIEC_ANY::e_ANY) {
+    dio->setValue(paRefValue.unwrap());
   }
 }
 

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -678,8 +678,8 @@ class CFunctionBlock : public forte::core::CFBContainer {
     constexpr static char csmToStringSeparator[] = ", ";
 
   private:
-    void configureGenericDI(TPortId paDIPortId, const CIEC_ANY *paRefValue);
-    void configureGenericDIO(TPortId paDIOPortId, const CIEC_ANY *paRefValue);
+    void configureGenericDI(TPortId paDIPortId, const CIEC_ANY &paRefValue);
+    void configureGenericDIO(TPortId paDIOPortId, const CIEC_ANY &paRefValue);
 
 #ifdef FORTE_SUPPORT_MONITORING
     TForteUInt32 *mEOMonitorCount;

--- a/src/core/genfb.h
+++ b/src/core/genfb.h
@@ -418,7 +418,8 @@ void CGenFunctionBlock<T>::freeFBInterfaceData(){
 
   if(nullptr != mDOConns) {
     for (TPortId i = 0; i < T::getFBInterfaceSpec().mNumDOs; ++i) {
-      if(CIEC_ANY* value = mDOConns[i].getValue(); nullptr != value) {
+      //FIXME move gen DO con value handling into dedicated connection class
+      if(CIEC_ANY* value = &mDOConns[i].getValue(); nullptr != value) {
         std::destroy_at(value);
       }
     }

--- a/src/core/inoutdataconn.cpp
+++ b/src/core/inoutdataconn.cpp
@@ -31,7 +31,7 @@ EMGMResponse CInOutDataConnection::connect(CFunctionBlock *paDstFB,
   TPortId dstPortId = paDstFB->getDIOID(paDstPortNameId);
   if(cgInvalidPortId != dstPortId){
     CIEC_ANY *dstDataPoint = paDstFB->getDIOFromPortId(dstPortId);
-    retVal = establishDataConnection(paDstFB, dstPortId, dstDataPoint);
+    retVal = establishDataConnection(paDstFB, dstPortId, *dstDataPoint);
   }
   
   return retVal;
@@ -67,17 +67,15 @@ void CInOutDataConnection::setValue(CIEC_ANY *paValue) {
 }
 
 EMGMResponse CInOutDataConnection::establishDataConnection(CFunctionBlock *paDstFB, TPortId paDstPortId,
-    CIEC_ANY *paDstDataPoint) {
+    const CIEC_ANY &paDstDataPoint) {
   EMGMResponse retVal = EMGMResponse::InvalidOperation;
 
-  if(mValue) {
-    if (mValue->getDataTypeID() == CIEC_ANY::e_ANY) {
-      handleAnySrcPortConnection(*paDstDataPoint);
+  if(getValue().getDataTypeID() == CIEC_ANY::e_ANY) {
+    handleAnySrcPortConnection(paDstDataPoint);
+    retVal = EMGMResponse::Ready;
+  } else {
+    if(canBeConnected(getValue(), paDstDataPoint)) {
       retVal = EMGMResponse::Ready;
-    } else {
-      if (canBeConnected(mValue, paDstDataPoint)) {
-        retVal = EMGMResponse::Ready;
-      }
     }
   }
 

--- a/src/core/inoutdataconn.h
+++ b/src/core/inoutdataconn.h
@@ -32,7 +32,7 @@ class CInOutDataConnection : public CDataConnection {
     bool isConnected() const override;
 
   protected:
-    EMGMResponse establishDataConnection(CFunctionBlock *paDstFB, TPortId paDstPortId, CIEC_ANY *paDstDataPoint);
+    EMGMResponse establishDataConnection(CFunctionBlock *paDstFB, TPortId paDstPortId, const CIEC_ANY &paDstDataPoint) override;
 };
 
 #endif /* _INOUTDATACONN_H_ */

--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -15,9 +15,6 @@
  *   Martin Jobst - add reset tests
  *******************************************************************************/
 #include "fbtestfixture.h"
-#ifdef FORTE_ENABLE_GENERATED_SOURCE_CPP
-#include "fbtestfixture_gen.cpp"
-#endif
 #include "fbtesterglobalfixture.h"
 #include "device.h"
 #include <criticalregion.h>
@@ -27,26 +24,34 @@
 # define usleep(x) Sleep((x)/1000)
 #endif
 
-/**Helper functor for deleting stuff in containers
- *
- */
-struct SDeleteFunctor {
-    template<class T>
-    void operator()(T* paVal) const {
-      delete paVal;
-    }
-};
-
 //! Helper class allowing to access the can be connected function from the FBTester
-class CFBTestConn : public CDataConnection {
+class CFBTestConn final : public CDataConnection {
   public:
-    static bool canBeConnected(const CIEC_ANY *paSrcDataPoint, const CIEC_ANY *paDstDataPoint) {
+    static bool canBeConnected(const CIEC_ANY &paSrcDataPoint, const CIEC_ANY &paDstDataPoint) {
       return CDataConnection::canBeConnected(paSrcDataPoint, paDstDataPoint);
     }
   private:
     //you are not allowed to create this class therefor constructor and destructor are private
     CFBTestConn();
     virtual ~CFBTestConn();
+};
+
+class CFBTestInputDataConn final : public CDataConnection {
+  public:
+    CFBTestInputDataConn(CIEC_ANY &paValue) : CDataConnection(nullptr, CStringDictionary::scmInvalidStringId, nullptr),
+        mValue(paValue) {
+    }
+
+    void readData(CIEC_ANY &paValue) const override {
+      paValue.setValue(mValue.unwrap());
+    }
+
+    CIEC_ANY& getValue() override {
+      return mValue;
+    }
+
+  private:
+    CIEC_ANY &mValue;
 };
 
 CFBTestFixtureBase::CFBTestFixtureBase(CStringDictionary::TStringId paTypeId) :
@@ -85,8 +90,6 @@ CFBTestFixtureBase::~CFBTestFixtureBase(){
   for(size_t i = 0; i < interfaceSpec.mNumDIs; ++i) {
    BOOST_CHECK_EQUAL(EMGMResponse::Ready, mDIConnections[i]->disconnect(mFBUnderTest, interfaceSpec.mDINames[i]));
   }
-
-  for_each(mDIConnections.begin(), mDIConnections.end(), SDeleteFunctor());
 
   performFBDeleteTests();
 
@@ -169,7 +172,7 @@ void CFBTestFixtureBase::triggerEvent(TPortId paEIId) {
 
   for (TPortId index = 0; index < mOutputDataBuffers.size(); ++index) {
     mOutputDataBuffers[index]->setValue(
-      mFBUnderTest->getDOConnection(mFBUnderTest->getFBInterfaceSpec().mDONames[index])->getValue()->unwrap());
+      mFBUnderTest->getDOConnection(mFBUnderTest->getFBInterfaceSpec().mDONames[index])->getValue().unwrap());
   }
 }
 
@@ -293,11 +296,10 @@ void CFBTestFixtureBase::createEventOutputConnections() {
 
 void CFBTestFixtureBase::createDataInputConnections() {
   const SFBInterfaceSpec& interfaceSpec(mFBUnderTest->getFBInterfaceSpec());
+  mDIConnections.reserve(interfaceSpec.mNumDIs);
 
   for(size_t i = 0; i < interfaceSpec.mNumDIs; ++i) {
-    CInterface2InternalDataConnection *con = new CInterface2InternalDataConnection();
-    mDIConnections.push_back(con);
-    con->setValue(mInputDataBuffers[i]);
+    auto& con = mDIConnections.emplace_back(std::make_unique<CFBTestInputDataConn>(*mInputDataBuffers[i]));
     BOOST_REQUIRE_EQUAL(EMGMResponse::Ready, con->connect(mFBUnderTest, interfaceSpec.mDINames[i]));
   }
 }
@@ -306,7 +308,7 @@ void CFBTestFixtureBase::createDataOutputConnections() {
   const SFBInterfaceSpec& interfaceSpec(mFBUnderTest->getFBInterfaceSpec());
 
   for(size_t i = 0; i < interfaceSpec.mNumDOs; ++i) {
-    if(CFBTestConn::canBeConnected(mOutputDataBuffers[i], mFBUnderTest->getDataOutput(interfaceSpec.mDONames[i]))) {
+    if(CFBTestConn::canBeConnected(*mOutputDataBuffers[i], *mFBUnderTest->getDataOutput(interfaceSpec.mDONames[i]))) {
       CDataConnection *dataCon = mFBUnderTest->getDOConnection(interfaceSpec.mDONames[i]);
       BOOST_REQUIRE_EQUAL(EMGMResponse::Ready, dataCon->connect(this, interfaceSpec.mDONames[i]));
     }

--- a/tests/core/fbtests/fbtestfixture.h
+++ b/tests/core/fbtests/fbtestfixture.h
@@ -19,7 +19,6 @@
 
 #include "fortenew.h"
 #include "genfb.h"
-#include "if2indco.h"
 #include "forte_sync.h"
 #include <boost/test/unit_test.hpp>
 #include <vector>
@@ -94,7 +93,7 @@ class CFBTestFixtureBase : public CGenFunctionBlock<CFunctionBlock> {
     CStringDictionary::TStringId mTypeId;
     std::string mConfigString;
     CFunctionBlock *mFBUnderTest;
-    std::vector<CInterface2InternalDataConnection *> mDIConnections;
+    std::vector<std::unique_ptr<CDataConnection>> mDIConnections;
 
     /*! \brief list for storing the output events received from the testee
      *


### PR DESCRIPTION
As preperation for getting rid of the mValue member of DataConnection and simplifying inheriting from CDataConnection mValue access in DataConnection was reworked.