### PR TITLE
Reworked Query Connection: Data Connections

### DIFF
--- a/src/core/adapter.cpp
+++ b/src/core/adapter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2015 ACIN, fortiss GmbH, 2018 TU Vienna/ACIN
+ * Copyright (c) 2008, 2025 ACIN, fortiss GmbH, 2018 TU Vienna/ACIN
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -70,7 +70,7 @@ void CAdapter::setParentFB(CFunctionBlock *paParentFB, TForteUInt8 paParentAdapt
 
   if (isPlug()) {
     //the plug is in charge of managing the adapter connection
-    mAdapterConn = new CAdapterConnection(this, paParentAdapterlistID, this);
+    mAdapterConn = new CAdapterConnection(paParentFB, paParentAdapterlistID, *this);
   }
 }
 
@@ -100,9 +100,9 @@ bool CAdapter::disconnect(CAdapterConnection *paAdConn){
   return true;
 }
 
-bool CAdapter::isCompatible(CAdapter *paPeer) const {
+bool CAdapter::isCompatible(const CAdapter &paPeer) const {
   //Need to check any adapter here as we don't know which adapter side is used for checking compatibility
-  return ((getFBTypeId() == paPeer->getFBTypeId()) || ((getFBTypeId() == STRID(ANY_ADAPTER)) && (STRID(ANY_ADAPTER) != paPeer->getFBTypeId())) || ((getFBTypeId() != STRID(ANY_ADAPTER)) && (STRID(ANY_ADAPTER) == paPeer->getFBTypeId())));
+  return ((getFBTypeId() == paPeer.getFBTypeId()) || ((getFBTypeId() == STRID(ANY_ADAPTER)) && (STRID(ANY_ADAPTER) != paPeer.getFBTypeId())) || ((getFBTypeId() != STRID(ANY_ADAPTER)) && (STRID(ANY_ADAPTER) == paPeer.getFBTypeId())));
 }
 
 void CAdapter::executeEvent(TEventID paEIID, CEventChainExecutionThread * const paECET){

--- a/src/core/adapter.h
+++ b/src/core/adapter.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2015 ACIN, fortiss GmbH, 2018 TU Vienna/ACIN
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2008, 2025 ACIN, fortiss GmbH, 2018 TU Vienna/ACIN,
+ *                          Martin Erich Jobst
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -84,7 +84,7 @@ class CAdapter : public CGenFunctionBlock<CFunctionBlock> {
      *   \param paPeer Pointer to a potential peer, whose compatibility has to be checked.
      *   \return compatibility status
      */
-    bool isCompatible(CAdapter *paPeer) const;
+    bool isCompatible(const CAdapter &paPeer) const;
 
     const TForteInt16 *getEventInputWithIndices() const{
       return getFBInterfaceSpec().mEIWithIndexes;

--- a/src/core/adapterconn.cpp
+++ b/src/core/adapterconn.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2015 ACIN, fortiss GmbH, 2018 TU Vienna/ACIN
+ * Copyright (c) 2008, 2025 ACIN, fortiss GmbH, 2018 TU Vienna/ACIN
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -19,7 +19,7 @@ USE_STRING_ID(ANY_ADAPTER);
 #include "adapter.h"
 #include "anyadapter.h"
 
-CAdapterConnection::CAdapterConnection(CFunctionBlock *paSrcFB, TPortId paSrcPortId, CAdapter *paPlug) :
+CAdapterConnection::CAdapterConnection(CFunctionBlock *paSrcFB, TPortId paSrcPortId, CAdapter &paPlug) :
     CConnection(paSrcFB, paSrcPortId), mPlug(paPlug), mSocket(nullptr){
 }
 
@@ -27,13 +27,13 @@ CAdapterConnection::~CAdapterConnection(){
   performDisconnect();
 }
 
-void CAdapterConnection::typifyAnyAdapter(CAdapter *paSocket, CAdapter *paPlug){
+void CAdapterConnection::typifyAnyAdapter(CAdapter *paSocket){
   if(STRID(ANY_ADAPTER) == paSocket->getFBTypeId()){
-    static_cast<CAnyAdapter*>(paSocket)->typifyAnyAdapter(paPlug);
+    static_cast<CAnyAdapter*>(paSocket)->typifyAnyAdapter(mPlug);
   }
 
-  if(STRID(ANY_ADAPTER) == paPlug->getFBTypeId()){
-    static_cast<CAnyAdapter*>(paPlug)->typifyAnyAdapter(paSocket);
+  if(STRID(ANY_ADAPTER) == mPlug.getFBTypeId()){
+    static_cast<CAnyAdapter&>(mPlug).typifyAnyAdapter(*paSocket);
   }
 }
 
@@ -44,16 +44,15 @@ EMGMResponse CAdapterConnection::connect(CFunctionBlock *paDstFB, CStringDiction
   if(cgInvalidPortId != portId){
     if(!isConnected()){
       CAdapter *socket = paDstFB->getAdapter(paDstPortNameId);
-      typifyAnyAdapter(socket, mPlug);
+      typifyAnyAdapter(socket);
 
       if((socket->isSocket()) && (socket->isCompatible(mPlug))){
-        if(mPlug->connect(socket, this) && socket->connect(mPlug, this)) {
+        if(mPlug.connect(socket, this) && socket->connect(&mPlug, this)) {
           mSocket = socket;
-          addDestination(CConnectionPoint(paDstFB, portId));
           retVal = EMGMResponse::Ready;
         }
         else{
-          mPlug->disconnect();
+          mPlug.disconnect();
           socket->disconnect();
           retVal = EMGMResponse::InvalidObject;
         }
@@ -76,20 +75,19 @@ EMGMResponse CAdapterConnection::connectToCFBInterface(CFunctionBlock *, CString
 EMGMResponse CAdapterConnection::disconnect(CFunctionBlock *paDstFB, CStringDictionary::TStringId paDstPortNameId){
   EMGMResponse retVal = EMGMResponse::NoSuchObject;
 
-  TPortId portId = paDstFB->getAdapterPortId(paDstPortNameId);
-  if(cgInvalidPortId != portId){
-    retVal = CConnection::removeDestination(CConnectionPoint(paDstFB, portId));
-    if(EMGMResponse::Ready == retVal){
+  if(isConnected()) {
+    CAdapter *socket = paDstFB->getAdapter(paDstPortNameId);
+    if(socket == mSocket) {
       performDisconnect();
+      retVal = EMGMResponse::Ready;
     }
   }
+
   return retVal;
 }
 
 void CAdapterConnection::performDisconnect(){
-  if(mPlug != nullptr){
-    mPlug->disconnect(this);
-  }
+  mPlug.disconnect(this);
 
   if(mSocket != nullptr){
     mSocket->disconnect(this);

--- a/src/core/adapterconn.h
+++ b/src/core/adapterconn.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 - 2015 ACIN, fortiss GmbH, 2018 TU Vienna/ACIN
+ * Copyright (c) 2008, 2025 ACIN, fortiss GmbH, 2018 TU Vienna/ACIN
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -22,7 +22,7 @@ class CAdapter;
  */
 class CAdapterConnection : public CConnection{
   public:
-    CAdapterConnection(CFunctionBlock *paSrcFB, TPortId paSrcPortId, CAdapter *paPlug);
+    CAdapterConnection(CFunctionBlock *paSrcFB, TPortId paSrcPortId, CAdapter &paPlug);
     ~CAdapterConnection() override;
 
     EMGMResponse connect(CFunctionBlock *paDstFB, CStringDictionary::TStringId paDstPortNameId) override;
@@ -30,7 +30,11 @@ class CAdapterConnection : public CConnection{
 
     EMGMResponse disconnect(CFunctionBlock *paDstFB, CStringDictionary::TStringId paDstPortNameId) override;
 
-    CAdapter *getPlug(){
+    bool isConnected() const override{
+      return mSocket != nullptr;
+    }
+
+    CAdapter &getPlug(){
       return mPlug;
     }
 
@@ -44,10 +48,10 @@ class CAdapterConnection : public CConnection{
 
   private:
 
-    static void typifyAnyAdapter(CAdapter *paSocket, CAdapter *paPlug);
+    void typifyAnyAdapter(CAdapter *paSocket);
     void performDisconnect();
 
-    CAdapter *mPlug;
+    CAdapter &mPlug;
     CAdapter *mSocket;
 
 };

--- a/src/core/anyadapter.cpp
+++ b/src/core/anyadapter.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 fortiss GmbH, 2018 TU Vienna/ACIN
- *                      2018 Johannes Kepler University
+ * Copyright (c) 2013, 2025 fortiss GmbH, TU Vienna/ACIN,
+ *                          Johannes Kepler University
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -36,23 +36,23 @@ CAnyAdapter::CAnyAdapter(CStringDictionary::TStringId paAdapterInstanceName, for
 
 CAnyAdapter::~CAnyAdapter() = default;
 
-void CAnyAdapter::typifyAnyAdapter(CAdapter *paPeer){
-  getGenInterfaceSpec().mNumEIs = paPeer->getFBInterfaceSpec().mNumEOs;
-  getGenInterfaceSpec().mEINames = paPeer->getFBInterfaceSpec().mEONames;
-  getGenInterfaceSpec().mEIWith = paPeer->getFBInterfaceSpec().mEOWith;
-  getGenInterfaceSpec().mEIWithIndexes = paPeer->getFBInterfaceSpec().mEOWithIndexes;
-  getGenInterfaceSpec().mNumEOs = paPeer->getFBInterfaceSpec().mNumEIs;
-  getGenInterfaceSpec().mEONames = paPeer->getFBInterfaceSpec().mEINames;
-  getGenInterfaceSpec().mEOWith = paPeer->getFBInterfaceSpec().mEIWith;
-  getGenInterfaceSpec().mEOWithIndexes = paPeer->getFBInterfaceSpec().mEIWithIndexes;
-  getGenInterfaceSpec().mNumDIs = paPeer->getFBInterfaceSpec().mNumDOs;
-  getGenInterfaceSpec().mDINames = paPeer->getFBInterfaceSpec().mDONames;
-  getGenInterfaceSpec().mDIDataTypeNames = paPeer->getFBInterfaceSpec().mDODataTypeNames;
-  getGenInterfaceSpec().mNumDOs = paPeer->getFBInterfaceSpec().mNumDIs;
-  getGenInterfaceSpec().mDONames = paPeer->getFBInterfaceSpec().mDINames;
-  getGenInterfaceSpec().mDODataTypeNames = paPeer->getFBInterfaceSpec().mDIDataTypeNames;
-  getGenInterfaceSpec().mNumDIOs = paPeer->getFBInterfaceSpec().mNumDIOs;
-  getGenInterfaceSpec().mDIONames = paPeer->getFBInterfaceSpec().mDIONames;
+void CAnyAdapter::typifyAnyAdapter(const CAdapter &paPeer){
+  getGenInterfaceSpec().mNumEIs = paPeer.getFBInterfaceSpec().mNumEOs;
+  getGenInterfaceSpec().mEINames = paPeer.getFBInterfaceSpec().mEONames;
+  getGenInterfaceSpec().mEIWith = paPeer.getFBInterfaceSpec().mEOWith;
+  getGenInterfaceSpec().mEIWithIndexes = paPeer.getFBInterfaceSpec().mEOWithIndexes;
+  getGenInterfaceSpec().mNumEOs = paPeer.getFBInterfaceSpec().mNumEIs;
+  getGenInterfaceSpec().mEONames = paPeer.getFBInterfaceSpec().mEINames;
+  getGenInterfaceSpec().mEOWith = paPeer.getFBInterfaceSpec().mEIWith;
+  getGenInterfaceSpec().mEOWithIndexes = paPeer.getFBInterfaceSpec().mEIWithIndexes;
+  getGenInterfaceSpec().mNumDIs = paPeer.getFBInterfaceSpec().mNumDOs;
+  getGenInterfaceSpec().mDINames = paPeer.getFBInterfaceSpec().mDONames;
+  getGenInterfaceSpec().mDIDataTypeNames = paPeer.getFBInterfaceSpec().mDODataTypeNames;
+  getGenInterfaceSpec().mNumDOs = paPeer.getFBInterfaceSpec().mNumDIs;
+  getGenInterfaceSpec().mDONames = paPeer.getFBInterfaceSpec().mDINames;
+  getGenInterfaceSpec().mDODataTypeNames = paPeer.getFBInterfaceSpec().mDIDataTypeNames;
+  getGenInterfaceSpec().mNumDIOs = paPeer.getFBInterfaceSpec().mNumDIOs;
+  getGenInterfaceSpec().mDIONames = paPeer.getFBInterfaceSpec().mDIONames;
   setupFBInterface();
   fillEventEntryList(m_ParentFB);
 }

--- a/src/core/anyadapter.h
+++ b/src/core/anyadapter.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 fortiss GmbH, 2018 TU Vienna/ACIN
+ * Copyright (c) 2013, 2025 fortiss GmbH, TU Vienna/ACIN
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -29,7 +29,7 @@ class CAnyAdapter : public CAdapter{
     CAnyAdapter(CStringDictionary::TStringId paAdapterInstanceName, forte::core::CFBContainer &paContainer, bool paIsPlug);
     ~CAnyAdapter() override;
 
-    void typifyAnyAdapter(CAdapter *paPeer);
+    void typifyAnyAdapter(const CAdapter &paPeer);
 
     void setParentFB(CFunctionBlock *paParentFB, TForteUInt8 paParentAdapterlistID) override;
 

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -366,7 +366,7 @@ EMGMResponse CResource::queryFBs(std::string &paValue, const CFBContainer &conta
       const CFunctionBlock &fb = static_cast<const CFunctionBlock &>(*itRunner);
       createFBResponseMessage(fb, prefix + fb.getInstanceName(), paValue);
     } else {
-      queryFBs(paValue, *itRunner, prefix + itRunner->getInstanceName() + ".");
+      queryFBs(paValue, *itRunner, prefix + itRunner->getInstanceName() + "."s);
     }
   }
   return EMGMResponse::Ready;
@@ -391,23 +391,19 @@ void CResource::createEOConnectionResponse(const CFunctionBlock &paFb, std::stri
   for(size_t i = 0; i < spec.mNumEOs; i++) {
     const CEventConnection *eConn = paFb.getEOConnection(spec.mEONames[i]);
     for(const auto &it : eConn->getDestinationList()) {
-      if(it != eConn->getDestinationList().front()) {
-        paReqResult.append("\n");
-      }
-      createConnectionResponseMessage(spec.mEONames[i], it.mFB->getFBInterfaceSpec().mEINames[it.mPortId], *it.mFB, paFb, paReqResult);
+      createConnectionResponseMessage(paFb, spec.mEONames[i], *it.mFB, it.mFB->getFBInterfaceSpec().mEINames[it.mPortId],  paReqResult);
     }
   }
 }
 
 void CResource::createDOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult){
   const SFBInterfaceSpec &spec(paFb.getFBInterfaceSpec());
-  for(size_t i = 0; i < spec.mNumDOs; i++) {
-    const CDataConnection *const dConn = paFb.getDOConnection(spec.mDONames[i]);
-    for(const auto &it : dConn->getDestinationList()) {
-      if(it != dConn->getDestinationList().front()) {
-        paReqResult.append("\n");
-      }
-      createConnectionResponseMessage(spec.mDONames[i], it.mFB->getFBInterfaceSpec().mDINames[it.mPortId], *it.mFB, paFb, paReqResult);
+  for(size_t i = 0; i < spec.mNumDIs; i++) {
+    const CDataConnection *const dConn = paFb.getDIConnection(spec.mDINames[i]);
+    if(dConn != nullptr) {
+      const CConnectionPoint srcConnPoint = dConn->getSourceId();
+      createConnectionResponseMessage(*srcConnPoint.mFB, srcConnPoint.mFB->getFBInterfaceSpec().mDONames[srcConnPoint.mPortId],
+          paFb, spec.mDINames[i], paReqResult);
     }
   }
 }
@@ -418,64 +414,38 @@ void CResource::createAOConnectionResponse(const CFunctionBlock& paFb, std::stri
     const CAdapter *const adapter = paFb.getAdapter(spec.mAdapterInstanceDefinition[i].mAdapterNameID);
     const CAdapterConnection *aConn = adapter->getAdapterConnection();
     if(spec.mAdapterInstanceDefinition[i].mIsPlug && nullptr != aConn) {
-      if(i != 0) {
-        paReqResult.append("\n");
-      }
       if(!aConn->isEmpty()) {
         const auto &dest = aConn->getDestinationList().front();
-        createConnectionResponseMessage(spec.mAdapterInstanceDefinition[i].mAdapterNameID,
-          dest.mFB->getFBInterfaceSpec().mAdapterInstanceDefinition[dest.mPortId].mAdapterNameID, *dest.mFB, paFb, paReqResult);
+        createConnectionResponseMessage(paFb, spec.mAdapterInstanceDefinition[i].mAdapterNameID,
+            *dest.mFB, dest.mFB->getFBInterfaceSpec().mAdapterInstanceDefinition[dest.mPortId].mAdapterNameID, paReqResult);
       }
     }
   }
 }
 
 void CResource::createFBResponseMessage(const CFunctionBlock &paFb, const std::string &fullName, std::string &paValue) {
-  if (!paValue.empty()) {
-    paValue.append("\n");
-  }
-  paValue.append("<FB name=\"");
-  paValue.append(fullName);
-  paValue.append("\" type=\"");
-  paValue.append(paFb.getFBTypeName());
-  paValue.append("\"/>");
+  paValue += "<FB name=\""s;
+  paValue += fullName;
+  paValue += "\" type=\""s;
+  paValue += paFb.getFBTypeName();
+  paValue += "\"/>\n"s;
 }
 
-void CResource::createConnectionResponseMessage(const CStringDictionary::TStringId srcId, const CStringDictionary::TStringId dstId,
-    const CFunctionBlock& paDstFb, const CFunctionBlock& paSrcFb, std::string& paReqResult) const {
-  paReqResult.append("<Connection Source=\""s);
+void CResource::createConnectionResponseMessage(const CFunctionBlock& paSrcFb, const CStringDictionary::TStringId paSrcId,
+    const CFunctionBlock& paDstFb, const CStringDictionary::TStringId paDstId, std::string& paReqResult) {
+  paReqResult += "<Connection Source=\""s;
 
-  std::string fullName;
-  fullName.reserve(cgStringInitialSize);
-  fullName = paSrcFb.getInstanceName();
-  fullName += "."s;
-  fullName += CStringDictionary::get(srcId);
+  paReqResult += paSrcFb.getFullQualifiedApplicationInstanceName('.');
+  paReqResult += "."s;
+  paReqResult += CStringDictionary::get(paSrcId);
 
-  CFBContainer* parent = &(paSrcFb.getParent());
-  const CDevice *dev = getDevice();
-
-  if(paSrcFb.getInstanceNameId() != STRID(START) ){
-    while(parent != dev && parent->getInstanceName() != 0){
-      fullName.insert(0, "."s);
-      fullName.insert(0, parent->getInstanceName());
-      parent = &parent->getParent();
-    }
-  }
-  paReqResult.append(fullName);
   paReqResult.append("\" Destination=\""s);
-  fullName = paDstFb.getInstanceName();
-  fullName += "."s;
-  fullName += CStringDictionary::get(dstId);
 
-  parent = &(paDstFb.getParent());
-  while(parent != dev && parent->getInstanceName() != 0){
-    fullName.insert(0, "."s);
-    fullName.insert(0, parent->getInstanceName());
-    parent = &parent->getParent();
-  }
-  fullName.shrink_to_fit();
-  paReqResult.append(fullName);
-  paReqResult.append("\"/>"s);
+  paReqResult += paDstFb.getFullQualifiedApplicationInstanceName('.');
+  paReqResult += "."s;
+  paReqResult += CStringDictionary::get(paDstId);
+
+  paReqResult.append("\"/>\n"s);
 }
 
 EMGMResponse CResource::createFBTypeResponseMessage(const CStringDictionary::TStringId paValue, std::string & paReqResult){

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -246,11 +246,11 @@ class CResource : public CFunctionBlock{
     static void createFBResponseMessage(const CFunctionBlock &paFb, const std::string &fullName, std::string &paValue);
 
     EMGMResponse queryConnections(std::string &paValue, const CFBContainer& container);
-    void createEOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
-    void createDOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
-    void createAOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
-    void createConnectionResponseMessage(const CStringDictionary::TStringId srcId, const CStringDictionary::TStringId dstId, const CFunctionBlock& paDstFb,
-        const CFunctionBlock& paFb, std::string& paValue) const;
+    static void createEOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
+    static void createDOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
+    static void createAOConnectionResponse(const CFunctionBlock& paFb, std::string& paReqResult);
+    static void createConnectionResponseMessage(const CFunctionBlock& paSrcFb, const CStringDictionary::TStringId paSrcId,
+        const CFunctionBlock& paDstFb, const CStringDictionary::TStringId paDstId, std::string& paReqResult);
 
     EMGMResponse createFBTypeResponseMessage(const CStringDictionary::TStringId paValue, std::string & paReqResult);
     EMGMResponse createAdapterTypeResponseMessage(const CStringDictionary::TStringId paValue, std::string & paReqResult);


### PR DESCRIPTION
For building the query connection response string for data connections the input side of FBs is used. This avoids the need for storing destination information into the connections.