### PR TITLE
Use destination for building Query Connection Response for Adapters

### DIFF
--- a/src/core/adapterconn.h
+++ b/src/core/adapterconn.h
@@ -37,6 +37,10 @@ class CAdapterConnection : public CConnection{
     CAdapter &getPlug(){
       return mPlug;
     }
+    
+    const CAdapter &getPlug() const {
+      return mPlug;
+    }
 
     void setSocket(CAdapter *paSocket){
       mSocket = paSocket;

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -409,12 +409,9 @@ void CResource::createAOConnectionResponse(const CFunctionBlock& paFb, std::stri
   for(size_t i = 0; i < spec.mNumAdapters; i++) {
     const CAdapter *const adapter = paFb.getAdapter(spec.mAdapterInstanceDefinition[i].mAdapterNameID);
     const CAdapterConnection *aConn = adapter->getAdapterConnection();
-    if(spec.mAdapterInstanceDefinition[i].mIsPlug && nullptr != aConn) {
-      if(!aConn->isEmpty()) {
-        const auto &dest = aConn->getDestinationList().front();
-        createConnectionResponseMessage(paFb, spec.mAdapterInstanceDefinition[i].mAdapterNameID,
-            dest.getFB(), dest.getFB().getFBInterfaceSpec().mAdapterInstanceDefinition[dest.getPortId()].mAdapterNameID, paReqResult);
-      }
+    if(!spec.mAdapterInstanceDefinition[i].mIsPlug && aConn != nullptr && aConn->isConnected()) {
+      createConnectionResponseMessage(aConn->getSourceId().getFB(), aConn->getPlug().getInstanceNameId(), 
+          paFb, adapter->getInstanceNameId(), paReqResult);
     }
   }
 }


### PR DESCRIPTION
In order to get rid of the destinationid list also adapter connections are addressed from the destionation side.