### PR TITLE
Allow short case labels on a single line in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,9 @@ AlignTrailingComments: false
 # https://clang.llvm.org/docs/ClangFormatStyleOptions.html#allowshortblocksonasingleline
 AllowShortBlocksOnASingleLine: false
 
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html#allowshortcaselabelsonasingleline
+AllowShortCaseLabelsOnASingleLine: true
+
 # https://clang.llvm.org/docs/ClangFormatStyleOptions.html#allowshortfunctionsonasingleline
 AllowShortFunctionsOnASingleLine: None
 


### PR DESCRIPTION
This adds an option to allow short case labels on a single line in clang-format. There are many functions for reflective access that benefit in terms of space efficiency from placing the switch case on the same line as the accessed element.

The current formatting would force line breaks in short switch cases:
```cpp
CIEC_ANY *FORTE_DebugTest::getDI(const size_t paIndex) {
  switch (paIndex) {
    case 0:
      return &var_DI1;
    case 1:
      return &var_DI2;
  }
  return nullptr;
}
```
while the suggested formatting, which is also currently used by the forte_ng exporter, is:
```cpp
CIEC_ANY *FORTE_DebugTest::getDI(const size_t paIndex) {
  switch (paIndex) {
    case 0: return &var_DI1;
    case 1: return &var_DI2;
  }
  return nullptr;
}
```