### PR TITLE
Pack constructor initializers only if the fit in the current line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -93,6 +93,9 @@ MacroBlockEnd: ''
 # https://clang.llvm.org/docs/ClangFormatStyleOptions.html#namespaceindentation
 NamespaceIndentation: All
 
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html#packconstructorinitializers
+PackConstructorInitializers: CurrentLine
+
 # https://clang.llvm.org/docs/ClangFormatStyleOptions.html#spaceaftercstylecast
 SpaceAfterCStyleCast: true
 


### PR DESCRIPTION
This adds an option to pack constructor initializers only if the fit in the current line in clang-format. This is similar to the setting for function parameters and helps readability when there are many similar initializers, such as in FB types or structs.

The current formatting would pack initializers in a single line:
```cpp
FORTE_DebugTest::FORTE_DebugTest(const CStringDictionary::TStringId paInstanceNameId,
                                 forte::core::CFBContainer &paContainer) :
    CSimpleFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, nullptr), var_DI1(0_DINT), var_DI2(0_DINT),
    var_DO1(0_DINT), var_conn_DO1(var_DO1), conn_CNF(this, 0), conn_DI1(nullptr), conn_DI2(nullptr),
    conn_DO1(this, 0, &var_conn_DO1) {
}
```
while the suggested formatting, which is also currently used by the forte_ng exporter, is:
```cpp
FORTE_DebugTest::FORTE_DebugTest(const CStringDictionary::TStringId paInstanceNameId,
                                 forte::core::CFBContainer &paContainer) :
    CSimpleFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, nullptr),
    var_DI1(0_DINT),
    var_DI2(0_DINT),
    var_DO1(0_DINT),
    var_conn_DO1(var_DO1),
    conn_CNF(this, 0),
    conn_DI1(nullptr),
    conn_DI2(nullptr),
    conn_DO1(this, 0, &var_conn_DO1) {
}
```