### PR TITLE
Explicitly set file encoding to UTF8

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
As discussed in #404 this sets the default encoding for text files for the 4diac FORTE eclipse project to UTF8.