### PR TITLE
Processing Timer Add List Lead to One Cycle Delay #410

### DIFF
--- a/src/arch/timerha.cpp
+++ b/src/arch/timerha.cpp
@@ -103,7 +103,7 @@ void CTimerHandler::triggerTimedFB(STimedFBListEntry paTimerListEntry) {
 void CTimerHandler::processAddList() {
   CCriticalRegion criticalRegion(mAddListSync);
   for (auto entry : mAddFBList) {
-    if(entry.mTimeOut < mForteTime) {
+    if(entry.mTimeOut <= mForteTime) {
       triggerTimedFB(entry);
     } else {
       addTimedFBEntry(entry);


### PR DESCRIPTION
Processing the timer add list used an < for checking if entries should be imideatly triggered. This lead to one timer tick delay for very short timed function blocks.

Issue: https://github.com/eclipse-4diac/4diac-forte/issues/410