### PR TITLE
[cleanup] Removed CTOR Defines

### DIFF
--- a/src/arch/be_m1/GET_CHAN_INFO.h
+++ b/src/arch/be_m1/GET_CHAN_INFO.h
@@ -61,7 +61,8 @@ class FORTE_GET_CHAN_INFO : public CFunctionBlock {
     SINT32 getChannelInfo();
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_GET_CHAN_INFO) {};
+    FORTE_GET_CHAN_INFO(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId) {};
 
     ~FORTE_GET_CHAN_INFO() override = default;
 };

--- a/src/arch/be_m1/GET_VALUE.h
+++ b/src/arch/be_m1/GET_VALUE.h
@@ -67,7 +67,8 @@ class FORTE_GET_VALUE : public CFunctionBlock {
     SINT32 read();
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_GET_VALUE) {};
+    FORTE_GET_VALUE(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId) {};
 
     ~FORTE_GET_VALUE() override = default;
 };

--- a/src/arch/be_m1/SET_VALUE.h
+++ b/src/arch/be_m1/SET_VALUE.h
@@ -67,7 +67,8 @@ class FORTE_SET_VALUE : public CFunctionBlock {
     SINT32 write();
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_SET_VALUE) {};
+    FORTE_SET_VALUE(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId) {};
 
     ~FORTE_SET_VALUE() override = default;
 };

--- a/src/com/ros/EXECUTE_ACTION_CLIENT.h
+++ b/src/com/ros/EXECUTE_ACTION_CLIENT.h
@@ -123,8 +123,16 @@ class FORTE_EXECUTE_ACTION_CLIENT : public CEventSourceFB {
     void connectToActionServer();
 
   public:
-    EVENT_SOURCE_FUNCTION_BLOCK_CTOR(FORTE_EXECUTE_ACTION_CLIENT), m_Initiated(false), m_GoalActive(false),
-        m_ActionClient(0), mResultReady(false), nh(0), m_RosNamespace(""), m_RosMsgName("") {};
+    FORTE_EXECUTE_ACTION_CLIENT(const CStringDictionary::TStringId paInstanceNameId,
+                                forte::core::CFBContainer &paContainer) :
+        CEventSourceFB(paContainer, scmFBInterfaceSpec, paInstanceNameId),
+        m_Initiated(false),
+        m_GoalActive(false),
+        m_ActionClient(0),
+        mResultReady(false),
+        nh(0),
+        m_RosNamespace(""),
+        m_RosMsgName("") {};
 
     ~FORTE_EXECUTE_ACTION_CLIENT() override = default;
 };

--- a/src/com/ros/EXECUTE_ACTION_SERVER.h
+++ b/src/com/ros/EXECUTE_ACTION_SERVER.h
@@ -116,9 +116,15 @@ class FORTE_EXECUTE_ACTION_SERVER : public CEventSourceFB {
     void ActionExecuteCB(const ExecuteGoalConstPtr &pa_goal, CEventChainExecutionThread *const paECET);
 
   public:
-    // cppcheck-suppress noConstructor
-    EVENT_SOURCE_FUNCTION_BLOCK_CTOR(FORTE_EXECUTE_ACTION_SERVER), m_nh(0), m_RosNamespace(""), m_RosMsgName(""),
-        m_Initiated(false), m_ResultAvailable(false), m_ActionServer(0) {};
+    FORTE_EXECUTE_ACTION_SERVER(const CStringDictionary::TStringId paInstanceNameId,
+                                forte::core::CFBContainer &paContainer) :
+        CEventSourceFB(paContainer, scmFBInterfaceSpec, paInstanceNameId),
+        m_nh(0),
+        m_RosNamespace(""),
+        m_RosMsgName(""),
+        m_Initiated(false),
+        m_ResultAvailable(false),
+        m_ActionServer(0) {};
 
     ~FORTE_EXECUTE_ACTION_SERVER() override = default;
 };

--- a/src/com/ros/TRIGGER_SERVICE_CLIENT.h
+++ b/src/com/ros/TRIGGER_SERVICE_CLIENT.h
@@ -89,8 +89,11 @@ class FORTE_TRIGGER_SERVICE_CLIENT : public CEventSourceFB {
     void callService();
     void waitForServer();
 
-    // cppcheck-suppress noConstructor
-    EVENT_SOURCE_FUNCTION_BLOCK_CTOR(FORTE_TRIGGER_SERVICE_CLIENT), m_Initiated(false), m_RosNamespace(""),
+    FORTE_TRIGGER_SERVICE_CLIENT(const CStringDictionary::TStringId paInstanceNameId,
+                                 forte::core::CFBContainer &paContainer) :
+        CEventSourceFB(paContainer, scmFBInterfaceSpec, paInstanceNameId),
+        m_Initiated(false),
+        m_RosNamespace(""),
         m_RosMsgName("") {};
 
     ~FORTE_TRIGGER_SERVICE_CLIENT() override = default;

--- a/src/com/ros/TRIGGER_SERVICE_SERVER.h
+++ b/src/com/ros/TRIGGER_SERVICE_SERVER.h
@@ -89,9 +89,13 @@ class FORTE_TRIGGER_SERVICE_SERVER : public CEventSourceFB {
                          CEventChainExecutionThread *const paECET);
 
   public:
-    // cppcheck-suppress noConstructor
-    EVENT_SOURCE_FUNCTION_BLOCK_CTOR(FORTE_TRIGGER_SERVICE_SERVER), m_Initiated(false), m_RosNamespace(""),
-        m_RosMsgName(""), m_ResponseAvailable(false) {};
+    FORTE_TRIGGER_SERVICE_SERVER(const CStringDictionary::TStringId paInstanceNameId,
+                                 forte::core::CFBContainer &paContainer) :
+        CEventSourceFB(paContainer, scmFBInterfaceSpec, paInstanceNameId),
+        m_Initiated(false),
+        m_RosNamespace(""),
+        m_RosMsgName(""),
+        m_ResponseAvailable(false) {};
 
     ~FORTE_TRIGGER_SERVICE_SERVER() override = default;
 };

--- a/src/core/cfb.h
+++ b/src/core/cfb.h
@@ -150,8 +150,4 @@ class CCompositeFB : public CFunctionBlock {
 #endif // FORTE_FMU
 };
 
-#define COMPOSITE_FUNCTION_BLOCK_CTOR(fbclass)                                                                         \
-  fbclass(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :               \
-      CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData)
-
 #endif /*_CFB_H_*/

--- a/src/core/esfb.h
+++ b/src/core/esfb.h
@@ -47,8 +47,4 @@ class CEventSourceFB : public CFunctionBlock {
     };
 };
 
-#define EVENT_SOURCE_FUNCTION_BLOCK_CTOR(fbclass)                                                                      \
-  fbclass(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :               \
-      CEventSourceFB(paContainer, scmFBInterfaceSpec, paInstanceNameId)
-
 #endif /*_ESFB_H_*/

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -770,14 +770,6 @@ class CFunctionBlock : public forte::core::CFBContainer {
 #endif // FORTE_REPLAY_DEVICE
 };
 
-#define FUNCTION_BLOCK_CTOR(fbclass)                                                                                   \
-  fbclass(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :               \
-      CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId)
-
-#define FUNCTION_BLOCK_CTOR_WITH_BASE_CLASS(fbclass, fbBaseClass)                                                      \
-  fbclass(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :               \
-      fbBaseClass(paContainer, scmFBInterfaceSpec, paInstanceNameId)
-
 #ifdef OPTIONAL
 #undef OPTIONAL
 #endif

--- a/src/core/io/configFB/io_controller_split.h
+++ b/src/core/io/configFB/io_controller_split.h
@@ -21,11 +21,6 @@ namespace forte {
   namespace core {
     namespace io {
 
-#define FUNCTION_BLOCK_CTOR_FOR_IO_SPLIT_CONTROLLER(fbclass)                                                           \
-  fbclass(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :               \
-      IOConfigFBSplitController((const TForteUInt8 *const) &scmSplitAdapter, scmSplitAdapterNum, paContainer,          \
-                                scmFBInterfaceSpec, paInstanceNameId)
-
       class IOConfigFBSplitController;
 
       typedef CSinglyLinkedList<IOConfigFBSplitController *> TControllerList;

--- a/src/core/io/configFB/io_slave_multi.h
+++ b/src/core/io/configFB/io_slave_multi.h
@@ -23,11 +23,6 @@ namespace forte {
   namespace core {
     namespace io {
 
-#define FUNCTION_BLOCK_CTOR_FOR_IO_MULTI_SLAVE(fbclass, fbBaseClass, type)                                             \
-  fbclass(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :               \
-      fbBaseClass((const TForteUInt8 *const) &scmSlaveConfigurationIO, scmSlaveConfigurationIONum, type, paContainer,  \
-                  scmFBInterfaceSpec, paInstanceNameId)
-
       class IOConfigFBMultiSlave : public IOConfigFBBase {
         public:
           IOConfigFBMultiSlave(const TForteUInt8 *const paSlaveConfigurationIO,

--- a/src/modules/PLC01A1/plc01a1_config_fb.h
+++ b/src/modules/PLC01A1/plc01a1_config_fb.h
@@ -139,7 +139,8 @@ class PLC01A1ConfigFB : public forte::core::io::IOConfigFBController {
     void setInitialValues() override;
 
   public:
-    FUNCTION_BLOCK_CTOR_WITH_BASE_CLASS(PLC01A1ConfigFB, forte::core::io::IOConfigFBController) {
+    PLC01A1ConfigFB(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        forte::core::io::IOConfigFBController(paContainer, scmFBInterfaceSpec, paInstanceNameId) {
     }
 
     CIEC_BOOL var_QI;

--- a/src/modules/ads/ADS_SERVER_CONFIG_fbt.h
+++ b/src/modules/ads/ADS_SERVER_CONFIG_fbt.h
@@ -85,7 +85,6 @@ class FORTE_ADS_SERVER_CONFIG final : public CFunctionBlock {
     void setInitialValues() override;
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_ADS_SERVER_CONFIG) {};
     ~FORTE_ADS_SERVER_CONFIG() override = default;
 
     FORTE_ADS_SERVER_CONFIG(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);

--- a/src/modules/ads/SET_LOCAL_ADS_ADDRESS_fbt.h
+++ b/src/modules/ads/SET_LOCAL_ADS_ADDRESS_fbt.h
@@ -77,7 +77,9 @@ class FORTE_SET_LOCAL_ADS_ADDRESS final : public CFunctionBlock {
     void setInitialValues() override;
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_SET_LOCAL_ADS_ADDRESS) {};
+    FORTE_SET_LOCAL_ADS_ADDRESS(const CStringDictionary::TStringId paInstanceNameId,
+                                forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId) {};
     ~FORTE_SET_LOCAL_ADS_ADDRESS() override = default;
 
     FORTE_SET_LOCAL_ADS_ADDRESS(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);

--- a/src/modules/arrowhead/common/JSON/ANYToJSON_fbt.h
+++ b/src/modules/arrowhead/common/JSON/ANYToJSON_fbt.h
@@ -50,7 +50,8 @@ class FORTE_ANYToJSON : public CFunctionBlock {
     void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_ANYToJSON) {};
+    FORTE_ANYToJSON(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId) {};
 
     ~FORTE_ANYToJSON() override = default;
 };

--- a/src/modules/arrowhead/common/JSON/GetArrayResponseFromJSON_fbt.h
+++ b/src/modules/arrowhead/common/JSON/GetArrayResponseFromJSON_fbt.h
@@ -56,7 +56,9 @@ class FORTE_GetArrayResponseFromJSON : public CFunctionBlock {
     bool isResponseEmpty(char *paText);
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_GetArrayResponseFromJSON) {};
+    FORTE_GetArrayResponseFromJSON(const CStringDictionary::TStringId paInstanceNameId,
+                                   forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId) {};
 
     ~FORTE_GetArrayResponseFromJSON() override = default;
 };

--- a/src/modules/arrowhead/eventHandler/ArrowheadPublish.h
+++ b/src/modules/arrowhead/eventHandler/ArrowheadPublish.h
@@ -58,7 +58,9 @@ class FORTE_ArrowheadPublish : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_ArrowheadPublish) {};
+    FORTE_ArrowheadPublish(const CStringDictionary::TStringId paInstanceNameId,
+                           forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_ArrowheadPublish() override = default;
 };

--- a/src/modules/arrowhead/eventHandler/HTTP/PublishEventHTTP.h
+++ b/src/modules/arrowhead/eventHandler/HTTP/PublishEventHTTP.h
@@ -44,7 +44,9 @@ class FORTE_PublishEventHTTP : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_PublishEventHTTP) {};
+    FORTE_PublishEventHTTP(const CStringDictionary::TStringId paInstanceNameId,
+                           forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_PublishEventHTTP() override = default;
 };

--- a/src/modules/arrowhead/eventHandler/HTTP/SubscribeEventHTTP.h
+++ b/src/modules/arrowhead/eventHandler/HTTP/SubscribeEventHTTP.h
@@ -44,7 +44,9 @@ class FORTE_SubscribeEventHTTP : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_SubscribeEventHTTP) {};
+    FORTE_SubscribeEventHTTP(const CStringDictionary::TStringId paInstanceNameId,
+                             forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_SubscribeEventHTTP() override = default;
 };

--- a/src/modules/arrowhead/eventHandler/OpcUa/PublishEventOpcUa.h
+++ b/src/modules/arrowhead/eventHandler/OpcUa/PublishEventOpcUa.h
@@ -44,7 +44,9 @@ class FORTE_PublishEventOpcUa : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_PublishEventOpcUa) {};
+    FORTE_PublishEventOpcUa(const CStringDictionary::TStringId paInstanceNameId,
+                            forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_PublishEventOpcUa() override = default;
 };

--- a/src/modules/arrowhead/eventHandler/OpcUa/SubscribeEventOpcUa.h
+++ b/src/modules/arrowhead/eventHandler/OpcUa/SubscribeEventOpcUa.h
@@ -44,7 +44,9 @@ class FORTE_SubscribeEventOpcUa : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_SubscribeEventOpcUa) {};
+    FORTE_SubscribeEventOpcUa(const CStringDictionary::TStringId paInstanceNameId,
+                              forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_SubscribeEventOpcUa() override = default;
 };

--- a/src/modules/arrowhead/eventHandler/SubscribeEvent.h
+++ b/src/modules/arrowhead/eventHandler/SubscribeEvent.h
@@ -60,7 +60,8 @@ class FORTE_SubscribeEvent : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_SubscribeEvent) {};
+    FORTE_SubscribeEvent(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_SubscribeEvent() override = default;
 };

--- a/src/modules/arrowhead/orchestrator/HTTP/RequestOrchestrationHTTP.h
+++ b/src/modules/arrowhead/orchestrator/HTTP/RequestOrchestrationHTTP.h
@@ -44,7 +44,9 @@ class FORTE_RequestOrchestrationHTTP : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_RequestOrchestrationHTTP) {};
+    FORTE_RequestOrchestrationHTTP(const CStringDictionary::TStringId paInstanceNameId,
+                                   forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_RequestOrchestrationHTTP() override = default;
 };

--- a/src/modules/arrowhead/orchestrator/OpcUa/RequestOrchestrationOpcUa.h
+++ b/src/modules/arrowhead/orchestrator/OpcUa/RequestOrchestrationOpcUa.h
@@ -44,7 +44,9 @@ class FORTE_RequestOrchestrationOpcUa : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_RequestOrchestrationOpcUa) {};
+    FORTE_RequestOrchestrationOpcUa(const CStringDictionary::TStringId paInstanceNameId,
+                                    forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_RequestOrchestrationOpcUa() override = default;
 };

--- a/src/modules/arrowhead/orchestrator/OrchestrationForm2OrchestrationForm_fbt.h
+++ b/src/modules/arrowhead/orchestrator/OrchestrationForm2OrchestrationForm_fbt.h
@@ -49,7 +49,9 @@ class FORTE_OrchestrationForm2OrchestrationForm : public CFunctionBlock {
     void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_OrchestrationForm2OrchestrationForm) {};
+    FORTE_OrchestrationForm2OrchestrationForm(const CStringDictionary::TStringId paInstanceNameId,
+                                              forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId) {};
 
     ~FORTE_OrchestrationForm2OrchestrationForm() override = default;
 };

--- a/src/modules/arrowhead/orchestrator/RequestOrchestrationForm.h
+++ b/src/modules/arrowhead/orchestrator/RequestOrchestrationForm.h
@@ -72,7 +72,9 @@ class FORTE_RequestOrchestrationForm : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_RequestOrchestrationForm) {};
+    FORTE_RequestOrchestrationForm(const CStringDictionary::TStringId paInstanceNameId,
+                                   forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_RequestOrchestrationForm() override = default;
 };

--- a/src/modules/arrowhead/serviceRegistry/HTTP/QueryServiceHTTP.h
+++ b/src/modules/arrowhead/serviceRegistry/HTTP/QueryServiceHTTP.h
@@ -44,7 +44,9 @@ class FORTE_QueryServiceHTTP : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_QueryServiceHTTP) {};
+    FORTE_QueryServiceHTTP(const CStringDictionary::TStringId paInstanceNameId,
+                           forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_QueryServiceHTTP() override = default;
 };

--- a/src/modules/arrowhead/serviceRegistry/HTTP/RegisterServiceHTTP.h
+++ b/src/modules/arrowhead/serviceRegistry/HTTP/RegisterServiceHTTP.h
@@ -44,7 +44,9 @@ class FORTE_RegisterServiceHTTP : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_RegisterServiceHTTP) {};
+    FORTE_RegisterServiceHTTP(const CStringDictionary::TStringId paInstanceNameId,
+                              forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_RegisterServiceHTTP() override = default;
 };

--- a/src/modules/arrowhead/serviceRegistry/OpcUa/QueryServiceOpcUa.h
+++ b/src/modules/arrowhead/serviceRegistry/OpcUa/QueryServiceOpcUa.h
@@ -44,7 +44,9 @@ class FORTE_QueryServiceOpcUa : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_QueryServiceOpcUa) {};
+    FORTE_QueryServiceOpcUa(const CStringDictionary::TStringId paInstanceNameId,
+                            forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_QueryServiceOpcUa() override = default;
 };

--- a/src/modules/arrowhead/serviceRegistry/OpcUa/RegisterServiceOpcUa.h
+++ b/src/modules/arrowhead/serviceRegistry/OpcUa/RegisterServiceOpcUa.h
@@ -44,7 +44,9 @@ class FORTE_RegisterServiceOpcUa : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_RegisterServiceOpcUa) {};
+    FORTE_RegisterServiceOpcUa(const CStringDictionary::TStringId paInstanceNameId,
+                               forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_RegisterServiceOpcUa() override = default;
 };

--- a/src/modules/arrowhead/serviceRegistry/QueryService.h
+++ b/src/modules/arrowhead/serviceRegistry/QueryService.h
@@ -72,7 +72,8 @@ class FORTE_QueryService : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_QueryService) {};
+    FORTE_QueryService(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_QueryService() override = default;
 };

--- a/src/modules/arrowhead/serviceRegistry/RegisterService.h
+++ b/src/modules/arrowhead/serviceRegistry/RegisterService.h
@@ -60,7 +60,8 @@ class FORTE_RegisterService : public CCompositeFB {
     static const SCFB_FBNData scmFBNData;
 
   public:
-    COMPOSITE_FUNCTION_BLOCK_CTOR(FORTE_RegisterService) {};
+    FORTE_RegisterService(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        CCompositeFB(paContainer, scmFBInterfaceSpec, paInstanceNameId, scmFBNData) {};
 
     ~FORTE_RegisterService() override = default;
 };

--- a/src/modules/arrowhead/serviceRegistry/ServiceRegistryEntry2ServiceRegistryEntry_fbt.h
+++ b/src/modules/arrowhead/serviceRegistry/ServiceRegistryEntry2ServiceRegistryEntry_fbt.h
@@ -49,7 +49,9 @@ class FORTE_ServiceRegistryEntry2ServiceRegistryEntry : public CFunctionBlock {
     void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
   public:
-    FUNCTION_BLOCK_CTOR(FORTE_ServiceRegistryEntry2ServiceRegistryEntry) {};
+    FORTE_ServiceRegistryEntry2ServiceRegistryEntry(const CStringDictionary::TStringId paInstanceNameId,
+                                                    forte::core::CFBContainer &paContainer) :
+        CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId) {};
 
     ~FORTE_ServiceRegistryEntry2ServiceRegistryEntry() override = default;
 };

--- a/src/modules/gpiochip/gpiochip_config_fb.h
+++ b/src/modules/gpiochip/gpiochip_config_fb.h
@@ -89,6 +89,7 @@ class GPIOChipConfigFB : public forte::core::io::IOConfigFBController {
     void onStartup(CEventChainExecutionThread *const paECET) override;
 
   public:
-    FUNCTION_BLOCK_CTOR_WITH_BASE_CLASS(GPIOChipConfigFB, forte::core::io::IOConfigFBController) {
+    GPIOChipConfigFB(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        forte::core::io::IOConfigFBController(paContainer, scmFBInterfaceSpec, paInstanceNameId) {
     }
 };

--- a/src/modules/revolutionPi/RevPiConfig.h
+++ b/src/modules/revolutionPi/RevPiConfig.h
@@ -176,7 +176,8 @@ class RevPiConfig : public forte::core::io::IOConfigFBController {
     virtual void setInitialValues();
 
   public:
-    FUNCTION_BLOCK_CTOR_WITH_BASE_CLASS(RevPiConfig, forte::core::io::IOConfigFBController) {};
+    RevPiConfig(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :
+        forte::core::io::IOConfigFBController(paContainer, scm_stFBInterfaceSpec, paInstanceNameId) {};
 
     virtual ~RevPiConfig() {};
 

--- a/src/modules/wagokbus/types/WagoSlaveBase.h
+++ b/src/modules/wagokbus/types/WagoSlaveBase.h
@@ -11,10 +11,6 @@
 
 #include "../../../core/io/configFB/io_slave_multi.h"
 
-#define FUNCTION_BLOCK_CTOR_FOR_WAGO_SLAVES(fbclass, type)                                                             \
-  fbclass(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer) :               \
-      WagoSlaveBase(type, paContainer, scmFBInterfaceSpec, paInstanceNameId)
-
 #define INIT_HANDLES(noOfBoolInputs, noOfBoolOutputs, noOfAnalogInputs, noOfAnalogOutputs)                             \
   void initHandles() override {                                                                                        \
     initHandlesBase(noOfBoolInputs, noOfBoolOutputs, noOfAnalogInputs, noOfAnalogOutputs);                             \


### PR DESCRIPTION
The CTOR defines was original added to hide CTOR setups to make 4diac FORTE easier upgradeable. With the latest changes they are not realy used anymore and do not make sense. Therefore they are removed and the last FBs that still had them where ported to the latest setup. However, please note that these FBs have not tested in quite some while and my still not work.