### PR TITLE
Extract InternalVar handling into common base class

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,7 +30,7 @@ forte_add_sourcefile_h(conn.h)
 forte_add_sourcefile_hcpp(dataconn inoutdataconn eventconn)
 
 forte_add_sourcefile_h(esfb.h event.h fortenode.h fortelist.h genfb.h)
-forte_add_sourcefile_hcpp(interfacespec basicfb cfb simplefb device devexec forteinstance mgmcmd)
+forte_add_sourcefile_hcpp(interfacespec basefb basicfb cfb simplefb device devexec forteinstance mgmcmd)
 forte_add_sourcefile_hcpp(extevhan funcbloc fbcontainer)
 forte_add_sourcefile_hcpp(resource stringdict typelib ecet)
 forte_add_sourcefile_hcpp(adapterconn adapter anyadapter iec61131_functions)

--- a/src/core/basefb.cpp
+++ b/src/core/basefb.cpp
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2005, 2025 Profactor GmbH, ACIN, fortiss GmbH,
+ *                          Martin Erich Jobst, Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Thomas Strasser, Gunnar Grabmair, Alois Zoitl, Gerhard Ebenhofer, Ingo Hegny
+ *      - initial implementation and rework communication infrastructure
+ *   Martin Jobst - account for data type size in FB initialization
+ *   Alois Zoitl  - exracted internal variable handling to new CBaseFB
+ *******************************************************************************/
+
+#include "basefb.h"
+
+TPortId SInternalVarsInformation::getVarId(CStringDictionary::TStringId paInternalName) const {
+  for (TPortId i = 0; i < mNumIntVars; ++i) {
+    if (mIntVarsNames[i] == paInternalName) {
+      return i;
+    }
+  }
+  return cgInvalidPortId;
+}
+
+CBaseFB::CBaseFB(forte::core::CFBContainer &paContainer,
+                 const SFBInterfaceSpec &paInterfaceSpec,
+                 const CStringDictionary::TStringId paInstanceNameId,
+                 const SInternalVarsInformation *const paVarInternals) :
+    CFunctionBlock(paContainer, paInterfaceSpec, paInstanceNameId),
+    cmVarInternals(paVarInternals) {
+}
+
+void CBaseFB::setInitialValues() {
+  CFunctionBlock::setInitialValues();
+}
+
+CIEC_ANY *CBaseFB::getVar(CStringDictionary::TStringId *paNameList, unsigned int paNameListSize) {
+  CIEC_ANY *poRetVal = CFunctionBlock::getVar(paNameList, paNameListSize);
+  if ((nullptr == poRetVal) && (1 == paNameListSize)) {
+    poRetVal = getInternalVar(*paNameList);
+  }
+  return poRetVal;
+}
+
+CIEC_ANY *CBaseFB::getInternalVar(CStringDictionary::TStringId paInternalName) {
+  if (cmVarInternals != nullptr) {
+    TPortId unVarId = cmVarInternals->getVarId(paInternalName);
+    if (unVarId != cgInvalidPortId) {
+      return getVarInternal(unVarId);
+    }
+  }
+  return nullptr;
+}
+
+int CBaseFB::toString(char *paValue, size_t paBufferSize) const {
+  int usedBuffer = CFunctionBlock::toString(paValue, paBufferSize);
+  if (usedBuffer < 1 || cmVarInternals == nullptr || (cmVarInternals != nullptr && cmVarInternals->mNumIntVars == 0)) {
+    return usedBuffer; // nothing to do
+  }
+
+  --usedBuffer; // move the pointer to the position of the closing )
+  if (usedBuffer > 1) { // not only ()
+    strncpy(paValue + usedBuffer, csmToStringSeparator, paBufferSize - usedBuffer);
+    usedBuffer += sizeof(csmToStringSeparator) - 1;
+  }
+
+  for (size_t i = 0; i < cmVarInternals->mNumIntVars; ++i) {
+    const CIEC_ANY *const variable = getVarInternal(i);
+    const CStringDictionary::TStringId nameId = cmVarInternals->mIntVarsNames[i];
+    int result = writeToStringNameValuePair(paValue + usedBuffer, paBufferSize - usedBuffer, nameId, variable);
+    if (result >= 0) {
+      usedBuffer += result;
+    } else {
+      return -1;
+    }
+    if (paBufferSize - usedBuffer >= sizeof(csmToStringSeparator)) {
+      strncpy(paValue + usedBuffer, csmToStringSeparator, paBufferSize - usedBuffer);
+      usedBuffer += sizeof(csmToStringSeparator) - 1;
+    } else {
+      return -1;
+    }
+  }
+  strncpy(paValue + std::max(1, usedBuffer - 2), ")",
+          paBufferSize - std::max(1, usedBuffer - 2)); // overwrite the last two bytes with the closing )
+  return std::max(2, usedBuffer - 1);
+};
+
+size_t CBaseFB::getToStringBufferSize() const {
+  size_t bufferSize = CFunctionBlock::getToStringBufferSize();
+  if (cmVarInternals != nullptr) {
+    for (size_t i = 0; i < cmVarInternals->mNumIntVars; ++i) {
+      const CIEC_ANY *const variable = getVarInternal(i);
+      const CStringDictionary::TStringId nameId = cmVarInternals->mIntVarsNames[i];
+      const char *varName = CStringDictionary::get(nameId);
+      bufferSize += strlen(varName) + 4 + variable->getToStringBufferSize();
+    }
+  }
+  return bufferSize;
+}
+
+#ifdef FORTE_TRACE_CTF
+void CBasicFB::traceInstanceData() {
+  std::vector<std::string> inputs(getFBInterfaceSpec().mNumDIs);
+  std::vector<std::string> outputs(getFBInterfaceSpec().mNumDOs);
+  std::vector<std::string> internals(cmVarInternals ? cmVarInternals->mNumIntVars : 0);
+  std::vector<std::string> internalFbs(getChildren().size());
+  std::vector<const char *> inputs_c_str(inputs.size());
+  std::vector<const char *> outputs_c_str(outputs.size());
+  std::vector<const char *> internals_c_str(internals.size());
+  std::vector<const char *> internalFbs_c_str(internalFbs.size());
+
+  for (TPortId i = 0; i < inputs.size(); ++i) {
+    CIEC_ANY *value = getDI(i);
+    std::string &valueString = inputs[i];
+    valueString.reserve(value->getToStringBufferSize());
+    value->toString(valueString.data(), valueString.capacity());
+    inputs_c_str[i] = valueString.c_str();
+  }
+
+  for (TPortId i = 0; i < outputs.size(); ++i) {
+    CIEC_ANY *value = getDO(i);
+    std::string &valueString = outputs[i];
+    valueString.reserve(value->getToStringBufferSize());
+    value->toString(valueString.data(), valueString.capacity());
+    outputs_c_str[i] = valueString.c_str();
+  }
+
+  for (TPortId i = 0; i < internals.size(); ++i) {
+    CIEC_ANY *value = getVarInternal(i);
+    std::string &valueString = internals[i];
+    valueString.reserve(value->getToStringBufferSize());
+    value->toString(valueString.data(), valueString.capacity());
+    internals_c_str[i] = valueString.c_str();
+  }
+
+  TPortId i = 0;
+  for (auto child : getChildren()) {
+    CFunctionBlock &value = static_cast<CFunctionBlock &>(*child);
+    std::string &valueString = internalFbs[i];
+    valueString.reserve(value.getToStringBufferSize());
+    value.toString(valueString.data(), valueString.capacity());
+    internalFbs_c_str[i] = valueString.c_str();
+    ++i;
+  }
+
+  getResource()->getTracer().traceInstanceData(
+      getFBTypeName() ?: "null", getFullQualifiedApplicationInstanceName('.').c_str() ?: "null",
+      static_cast<uint32_t>(inputs.size()), inputs_c_str.data(), static_cast<uint32_t>(outputs.size()),
+      outputs_c_str.data(), static_cast<uint32_t>(internals.size()), internals_c_str.data(),
+      static_cast<uint32_t>(internalFbs.size()), internalFbs_c_str.data());
+}
+#endif

--- a/src/core/basefb.h
+++ b/src/core/basefb.h
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2005, 2025 Profactor GmbH, ACIN, fortiss GmbH,
+ *                          Martin Erich Jobst, Johannes Kepler University Linz
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Thomas Strasser, Gunnar Grabmair, Alois Zoitl, Gerhard Ebenhofer, Ingo Hegny
+ *                - initial implementation and rework communication infrastructure
+ *   Martin Jobst - account for data type size in FB initialization
+ *   Alois Zoitl  - exracted internal variable handling to new CBaseFB
+ *******************************************************************************/
+
+#pragma once
+
+#include "funcbloc.h"
+
+/*!\ingroup CORE
+ * \brief structure to hold the data needed for creating the internal vars
+ *
+ */
+struct SInternalVarsInformation {
+    TPortId mNumIntVars; //!< Number of internal vars
+    const CStringDictionary::TStringId *mIntVarsNames; //!< List of the internalvarsnames
+    const CStringDictionary::TStringId *mIntVarsDataTypeNames; //!< List of the data type names for the internal vars
+
+    TPortId getVarId(CStringDictionary::TStringId paInternalName) const;
+};
+
+class CBaseFB : public CFunctionBlock {
+  public:
+    ~CBaseFB() override = default;
+
+    CIEC_ANY *getVar(CStringDictionary::TStringId *paNameList, unsigned int paNameListSize) override;
+
+    int toString(char *paValue, size_t paBufferSize) const override;
+
+    size_t getToStringBufferSize() const override;
+
+#ifdef FORTE_TRACE_CTF
+    void traceInstanceData() override;
+#endif
+
+  protected:
+    CBaseFB(forte::core::CFBContainer &paContainer,
+            const SFBInterfaceSpec &paInterfaceSpec,
+            CStringDictionary::TStringId paInstanceNameId,
+            const SInternalVarsInformation *const paVarInternals);
+
+    /*! \brief Get the internal variable with given number
+     *
+     * Attention this function will not perform any range checks on the paVarIntNum parameter!
+     * @param paVarIntNum number of the internal variable starting with 0
+     * @return pointer to the internal variable
+     */
+    virtual CIEC_ANY *getVarInternal(size_t paVarIntNum) = 0;
+
+    const CIEC_ANY *getVarInternal(size_t paVarIntNum) const {
+      return const_cast<CBaseFB *>(this)->getVarInternal(paVarIntNum);
+    }
+
+    void setInitialValues() override = 0;
+
+  private:
+    /*!\brief Get the pointer to a internal variable of the basic FB.
+     *
+     * \param paInternalName StringId of the internal variable name.
+     * \return Pointer to the internal variable or 0.
+     */
+    CIEC_ANY *getInternalVar(CStringDictionary::TStringId paInternalName);
+
+    const SInternalVarsInformation *const cmVarInternals; //!< struct holding the information on the internal vars.
+};

--- a/src/core/basicfb.cpp
+++ b/src/core/basicfb.cpp
@@ -9,156 +9,33 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    Thomas Strasser, Alois Zoitl, Gerhard Ebenhofer, Ingo Hegny
+ *   Thomas Strasser, Gunnar Grabmair, Alois Zoitl, Gerhard Ebenhofer, Ingo Hegny
  *      - initial implementation and rework communication infrastructure
- *    Martin Jobst - account for data type size in FB initialization
+ *   Martin Jobst - account for data type size in FB initialization
+ *   Alois Zoitl  - exracted internal variable handling to new CBaseFB
  *******************************************************************************/
 #include <string.h>
 #include "basicfb.h"
-#include "funcbloc.h"
-#include "typelib.h"
-
-TPortId SInternalVarsInformation::getVarId(CStringDictionary::TStringId paInternalName) const {
-  for (TPortId i = 0; i < mNumIntVars; ++i) {
-    if (mIntVarsNames[i] == paInternalName) {
-      return i;
-    }
-  }
-  return cgInvalidPortId;
-}
 
 CBasicFB::CBasicFB(forte::core::CFBContainer &paContainer,
                    const SFBInterfaceSpec &paInterfaceSpec,
                    const CStringDictionary::TStringId paInstanceNameId,
-                   const SInternalVarsInformation *paVarInternals) :
-    CFunctionBlock(paContainer, paInterfaceSpec, paInstanceNameId),
-    mECCState(0),
-    cmVarInternals(paVarInternals) {
+                   const SInternalVarsInformation *const paVarInternals) :
+    CBaseFB(paContainer, paInterfaceSpec, paInstanceNameId, paVarInternals),
+    mECCState(0) {
 }
 
 void CBasicFB::setInitialValues() {
-  CFunctionBlock::setInitialValues();
+  CBaseFB::setInitialValues();
   mECCState = CIEC_STATE(0);
 }
 
 CIEC_ANY *CBasicFB::getVar(CStringDictionary::TStringId *paNameList, unsigned int paNameListSize) {
-  CIEC_ANY *poRetVal = CFunctionBlock::getVar(paNameList, paNameListSize);
-  if ((nullptr == poRetVal) && (1 == paNameListSize)) {
-    poRetVal = getInternalVar(*paNameList);
-    if (nullptr == poRetVal &&
-        !strcmp("!ECC", CStringDictionary::get(
-                            *paNameList))) { // TODO consider if this can also be an string ID in a different way
-      poRetVal = &mECCState;
-    }
+  CIEC_ANY *poRetVal = CBaseFB::getVar(paNameList, paNameListSize);
+  if ((nullptr == poRetVal) && (1 == paNameListSize) &&
+      !strcmp("!ECC", CStringDictionary::get(
+                          *paNameList))) { // TODO consider if this can also be an string ID in a different way
+    poRetVal = &mECCState;
   }
   return poRetVal;
 }
-
-CIEC_ANY *CBasicFB::getInternalVar(CStringDictionary::TStringId paInternalName) {
-  if (cmVarInternals != nullptr) {
-    TPortId unVarId = cmVarInternals->getVarId(paInternalName);
-    if (unVarId != cgInvalidPortId) {
-      return getVarInternal(unVarId);
-    }
-  }
-  return nullptr;
-}
-
-int CBasicFB::toString(char *paValue, size_t paBufferSize) const {
-  int usedBuffer = CFunctionBlock::toString(paValue, paBufferSize);
-  if (usedBuffer < 1 || cmVarInternals == nullptr || (cmVarInternals != nullptr && cmVarInternals->mNumIntVars == 0)) {
-    return usedBuffer; // nothing to do
-  }
-
-  --usedBuffer; // move the pointer to the position of the closing )
-  if (usedBuffer > 1) { // not only ()
-    strncpy(paValue + usedBuffer, csmToStringSeparator, paBufferSize - usedBuffer);
-    usedBuffer += sizeof(csmToStringSeparator) - 1;
-  }
-
-  for (size_t i = 0; i < cmVarInternals->mNumIntVars; ++i) {
-    const CIEC_ANY *const variable = getVarInternal(i);
-    const CStringDictionary::TStringId nameId = cmVarInternals->mIntVarsNames[i];
-    int result = writeToStringNameValuePair(paValue + usedBuffer, paBufferSize - usedBuffer, nameId, variable);
-    if (result >= 0) {
-      usedBuffer += result;
-    } else {
-      return -1;
-    }
-    if (paBufferSize - usedBuffer >= sizeof(csmToStringSeparator)) {
-      strncpy(paValue + usedBuffer, csmToStringSeparator, paBufferSize - usedBuffer);
-      usedBuffer += sizeof(csmToStringSeparator) - 1;
-    } else {
-      return -1;
-    }
-  }
-  strncpy(paValue + std::max(1, usedBuffer - 2), ")",
-          paBufferSize - std::max(1, usedBuffer - 2)); // overwrite the last two bytes with the closing )
-  return std::max(2, usedBuffer - 1);
-};
-
-size_t CBasicFB::getToStringBufferSize() const {
-  size_t bufferSize = CFunctionBlock::getToStringBufferSize();
-  if (cmVarInternals) {
-    for (size_t i = 0; i < cmVarInternals->mNumIntVars; ++i) {
-      const CIEC_ANY *const variable = getVarInternal(i);
-      const CStringDictionary::TStringId nameId = cmVarInternals->mIntVarsNames[i];
-      const char *varName = CStringDictionary::get(nameId);
-      bufferSize += strlen(varName) + 4 + variable->getToStringBufferSize();
-    }
-  }
-  return bufferSize;
-}
-
-#ifdef FORTE_TRACE_CTF
-void CBasicFB::traceInstanceData() {
-  std::vector<std::string> inputs(getFBInterfaceSpec().mNumDIs);
-  std::vector<std::string> outputs(getFBInterfaceSpec().mNumDOs);
-  std::vector<std::string> internals(cmVarInternals ? cmVarInternals->mNumIntVars : 0);
-  std::vector<std::string> internalFbs(getChildren().size());
-  std::vector<const char *> inputs_c_str(inputs.size());
-  std::vector<const char *> outputs_c_str(outputs.size());
-  std::vector<const char *> internals_c_str(internals.size());
-  std::vector<const char *> internalFbs_c_str(internalFbs.size());
-
-  for (TPortId i = 0; i < inputs.size(); ++i) {
-    CIEC_ANY *value = getDI(i);
-    std::string &valueString = inputs[i];
-    valueString.reserve(value->getToStringBufferSize());
-    value->toString(valueString.data(), valueString.capacity());
-    inputs_c_str[i] = valueString.c_str();
-  }
-
-  for (TPortId i = 0; i < outputs.size(); ++i) {
-    CIEC_ANY *value = getDO(i);
-    std::string &valueString = outputs[i];
-    valueString.reserve(value->getToStringBufferSize());
-    value->toString(valueString.data(), valueString.capacity());
-    outputs_c_str[i] = valueString.c_str();
-  }
-
-  for (TPortId i = 0; i < internals.size(); ++i) {
-    CIEC_ANY *value = getVarInternal(i);
-    std::string &valueString = internals[i];
-    valueString.reserve(value->getToStringBufferSize());
-    value->toString(valueString.data(), valueString.capacity());
-    internals_c_str[i] = valueString.c_str();
-  }
-
-  TPortId i = 0;
-  for (auto child : getChildren()) {
-    CFunctionBlock &value = static_cast<CFunctionBlock &>(*child);
-    std::string &valueString = internalFbs[i];
-    valueString.reserve(value.getToStringBufferSize());
-    value.toString(valueString.data(), valueString.capacity());
-    internalFbs_c_str[i] = valueString.c_str();
-    ++i;
-  }
-
-  getResource()->getTracer().traceInstanceData(
-      getFBTypeName() ?: "null", getFullQualifiedApplicationInstanceName('.').c_str() ?: "null",
-      static_cast<uint32_t>(inputs.size()), inputs_c_str.data(), static_cast<uint32_t>(outputs.size()),
-      outputs_c_str.data(), static_cast<uint32_t>(internals.size()), internals_c_str.data(),
-      static_cast<uint32_t>(internalFbs.size()), internalFbs_c_str.data());
-}
-#endif

--- a/src/core/basicfb.h
+++ b/src/core/basicfb.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2005 - 2015 Profactor GmbH, ACIN, fortiss GmbH
- *               2023 Martin Erich Jobst
+ * Copyright (c) 2005, 2025 Profactor GmbH, ACIN, fortiss GmbH,
+ *                          Martin Erich Jobst, Johannes Kepler University Linz
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,82 +9,38 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    Thomas Strasser, Gunnar Grabmair, Alois Zoitl, Gerhard Ebenhofer, Ingo Hegny
+ *   Thomas Strasser, Gunnar Grabmair, Alois Zoitl, Gerhard Ebenhofer, Ingo Hegny
  *      - initial implementation and rework communication infrastructure
- *    Martin Jobst - account for data type size in FB initialization
+ *   Martin Jobst - account for data type size in FB initialization
+ *   Alois Zoitl  - exracted internal variable handling to new CBaseFB
  *******************************************************************************/
-#ifndef _BASICFB_H_
-#define _BASICFB_H_
 
-#include "funcbloc.h"
+#pragma once
+
+#include "basefb.h"
 #include "forte_state.h"
-
-/*!\ingroup CORE
- * \brief structure to hold the data needed for creating the internal vars
- *
- */
-struct SInternalVarsInformation {
-    TPortId mNumIntVars; //!< Number of internal vars
-    const CStringDictionary::TStringId *mIntVarsNames; //!< List of the internalvarsnames
-    const CStringDictionary::TStringId *mIntVarsDataTypeNames; //!< List of the data type names for the internal vars
-
-    TPortId getVarId(CStringDictionary::TStringId paInternalName) const;
-};
 
 /*!\ingroup CORE
  *
  * \brief Class for handling firmware basic function blocks.
  */
-class CBasicFB : public CFunctionBlock {
+class CBasicFB : public CBaseFB {
   public:
-    /*!\brief The main constructur for a basic function block.
-     */
-    CBasicFB(forte::core::CFBContainer &paContainer,
-             const SFBInterfaceSpec &paInterfaceSpec,
-             CStringDictionary::TStringId paInstanceNameId,
-             const SInternalVarsInformation *paVarInternals);
-
     ~CBasicFB() override = default;
 
     CIEC_ANY *getVar(CStringDictionary::TStringId *paNameList, unsigned int paNameListSize) override;
 
-    int toString(char *paValue, size_t paBufferSize) const override;
-
-    size_t getToStringBufferSize() const override;
-
-#ifdef FORTE_TRACE_CTF
-    void traceInstanceData() override;
-#endif
-
   protected:
-    /*! \brief Get the internal variable with given number
-     *
-     * Attention this function will not perform any range checks on the paVarIntNum parameter!
-     * @param paVarIntNum number of the internal variable starting with 0
-     * @return pointer to the internal variable
-     */
-    virtual CIEC_ANY *getVarInternal(size_t paVarIntNum) = 0;
-
-    const CIEC_ANY *getVarInternal(size_t paVarIntNum) const {
-      return const_cast<CBasicFB *>(this)->getVarInternal(paVarIntNum);
-    }
-
-    CIEC_STATE mECCState; //! the current state of the ecc. start value is 0 = initial state id
-    const SInternalVarsInformation *const cmVarInternals; //!< struct holding the information on the internal vars.
+    CBasicFB(forte::core::CFBContainer &paContainer,
+             const SFBInterfaceSpec &paInterfaceSpec,
+             CStringDictionary::TStringId paInstanceNameId,
+             const SInternalVarsInformation *const paVarInternals);
 
     void setInitialValues() override = 0;
 
-  private:
-    /*!\brief Get the pointer to a internal variable of the basic FB.
-     *
-     * \param paInternalName StringId of the internal variable name.
-     * \return Pointer to the internal variable or 0.
-     */
-    CIEC_ANY *getInternalVar(CStringDictionary::TStringId paInternalName);
+    CIEC_STATE mECCState; //! the current state of the ecc. start value is 0 = initial state id
 
 #ifdef FORTE_FMU
     friend class fmuInstance;
 #endif // FORTE_FMU
 };
-
-#endif /*_BASICFB_H_*/

--- a/src/core/simplefb.cpp
+++ b/src/core/simplefb.cpp
@@ -12,8 +12,7 @@
  *******************************************************************************/
 
 #include "simplefb.h"
-#include "basicfb.h"
 
 void CSimpleFB::setInitialValues() {
-  CBasicFB::setInitialValues();
+  CBaseFB::setInitialValues();
 }

--- a/src/core/simplefb.h
+++ b/src/core/simplefb.h
@@ -16,22 +16,18 @@
  *      - account for data type size in FB initialization
  *******************************************************************************/
 
-#ifndef SRC_CORE_SIMPLEFB_H_
-#define SRC_CORE_SIMPLEFB_H_
+#pragma once
 
-#include "basicfb.h"
+#include "basefb.h"
 
-class CSimpleFB : public CBasicFB {
-  public:
+class CSimpleFB : public CBaseFB {
+  protected:
     CSimpleFB(forte::core::CFBContainer &paContainer,
               const SFBInterfaceSpec &paInterfaceSpec,
               CStringDictionary::TStringId paInstanceNameId,
-              const SInternalVarsInformation *paVarInternals) :
-        CBasicFB(paContainer, paInterfaceSpec, paInstanceNameId, paVarInternals) {
+              const SInternalVarsInformation *const paVarInternals) :
+        CBaseFB(paContainer, paInterfaceSpec, paInstanceNameId, paVarInternals) {
     }
 
-  protected:
     void setInitialValues() override = 0;
 };
-
-#endif /* SRC_CORE_SIMPLEFB_H_ */


### PR DESCRIPTION
SimpleFBs and BasicFBs have internal vars. To clean-up the inheritence hierarchy a common base class, as it is done in 4diac IDE, is introduced.