### PR TITLE
position detection for Wago 750-636, update supported IOs

### DIFF
--- a/src/modules/wagokbus/WagoDeviceController.cpp
+++ b/src/modules/wagokbus/WagoDeviceController.cpp
@@ -105,14 +105,12 @@ WagoDeviceController::createIOHandle(forte::core::io::IODeviceController::Handle
       inputOffset = mTerminalInfos[desc.mSlaveIndex].OffsetInput_bits + (2 * desc.mChannel);
       break;
     case CIEC_ANY::e_DWORD:
-      outputOffset = mTerminalInfos[desc.mSlaveIndex].OffsetOutput_bits + (4 * desc.mChannel);
-      inputOffset = mTerminalInfos[desc.mSlaveIndex].OffsetInput_bits + (4 * desc.mChannel);
+      outputOffset = (mTerminalInfos[desc.mSlaveIndex].OffsetOutput_bits + desc.mChannel) / 8;
+      inputOffset = (mTerminalInfos[desc.mSlaveIndex].OffsetInput_bits + desc.mChannel) / 8;
       break;
     default: return 0;
   }
-
-  return new WagoHandle(this, desc.mType, desc.mDirection, mAppDevInterface, mTaskId, mKBusDeviceId, outputOffset,
-                        inputOffset);
+  return new WagoHandle(this, desc.mType, desc.mDirection, mAppDevInterface, mTaskId, mKBusDeviceId, outputOffset, inputOffset);
 }
 
 void WagoDeviceController::deInit() {

--- a/src/modules/wagokbus/WagoHandle.cpp
+++ b/src/modules/wagokbus/WagoHandle.cpp
@@ -93,13 +93,13 @@ void WagoHandle::getBoolean(CIEC_BOOL &paState) {
 void WagoHandle::getWord(CIEC_WORD &paState) {
   TForteByte inDataWord[2];
   mAppDevInterface->ReadBytes(mKBusDeviceId, mTaskId, mInputOffset, 2, inDataWord);
-  paState = CIEC_WORD((inDataWord[1] << 8) & inDataWord[0]);
+  paState = CIEC_WORD((inDataWord[1] << 8) | inDataWord[0]);
 }
 
 void WagoHandle::getDWord(CIEC_DWORD &paState) {
   TForteByte inDataDWord[4];
   mAppDevInterface->ReadBytes(mKBusDeviceId, mTaskId, mInputOffset, 4, inDataDWord);
-  paState = CIEC_DWORD((inDataDWord[3] << 24) & (inDataDWord[2] << 16) & (inDataDWord[1] << 8) & inDataDWord[0]);
+  paState = CIEC_DWORD((inDataDWord[3] << 24) | (inDataDWord[2] << 16) | (inDataDWord[1] << 8) | inDataDWord[0]);
 }
 
 void WagoHandle::setBoolean(const CIEC_BOOL &paState) {

--- a/src/modules/wagokbus/types/Wago636_fbt.cpp
+++ b/src/modules/wagokbus/types/Wago636_fbt.cpp
@@ -15,7 +15,7 @@ USE_STRING_ID(BusAdapterOut);
 USE_STRING_ID(Busy);
 USE_STRING_ID(CurrentPosition);
 USE_STRING_ID(Event);
-USE_STRING_ID(ExtendedInfoOn);
+USE_STRING_ID(OnTarget);
 USE_STRING_ID(IND);
 USE_STRING_ID(LimitSwitchN);
 USE_STRING_ID(LimitSwitchP);
@@ -23,10 +23,12 @@ USE_STRING_ID(MAP);
 USE_STRING_ID(MAPO);
 USE_STRING_ID(MotorN);
 USE_STRING_ID(MotorP);
+USE_STRING_ID(OptimizeOnZInput);
 USE_STRING_ID(OptimizeOn);
 USE_STRING_ID(Positioning);
 USE_STRING_ID(Preset);
-USE_STRING_ID(PresetInputEnabled);
+USE_STRING_ID(PresetInput);
+USE_STRING_ID(PresetInputEnable);
 USE_STRING_ID(QI);
 USE_STRING_ID(QO);
 USE_STRING_ID(QuitErrors);
@@ -46,16 +48,18 @@ using namespace forte::core::io;
 DEFINE_FIRMWARE_FB(FORTE_Wago636, STRID(Wago636))
 
 const CStringDictionary::TStringId FORTE_Wago636::scmDataInputNames[] = {
-    STRID(QI),         STRID(Busy),           STRID(LimitSwitchN), STRID(LimitSwitchP),    STRID(PresetInputEnabled),
-    STRID(OptimizeOn), STRID(ExtendedInfoOn), STRID(ReferenceOk),  STRID(CurrentPosition), STRID(TargetPosition),
-    STRID(MotorN),     STRID(MotorP),         STRID(Positioning),  STRID(Preset),          STRID(QuitErrors)};
+    STRID(QI),                STRID(Busy),     STRID(LimitSwitchN), STRID(LimitSwitchP),    STRID(PresetInput),
+    STRID(OptimizeOnZInput),  STRID(OnTarget), STRID(ReferenceOk),  STRID(CurrentPosition), STRID(TargetPosition),
+    STRID(MotorN),            STRID(MotorP),   STRID(Positioning),  STRID(OptimizeOn),          STRID(Preset),
+    STRID(PresetInputEnable), STRID(QuitErrors)};
 const CStringDictionary::TStringId FORTE_Wago636::scmDataInputTypeIds[] = {
     STRID(BOOL),   STRID(STRING), STRID(STRING), STRID(STRING), STRID(STRING),
     STRID(STRING), STRID(STRING), STRID(STRING), STRID(STRING), STRID(STRING),
-    STRID(STRING), STRID(STRING), STRID(STRING), STRID(STRING), STRID(STRING)};
+    STRID(STRING), STRID(STRING), STRID(STRING), STRID(STRING), STRID(STRING),
+    STRID(STRING), STRID(STRING)};
 const CStringDictionary::TStringId FORTE_Wago636::scmDataOutputNames[] = {STRID(QO), STRID(STATUS)};
 const CStringDictionary::TStringId FORTE_Wago636::scmDataOutputTypeIds[] = {STRID(BOOL), STRID(WSTRING)};
-const TDataIOID FORTE_Wago636::scmEIWith[] = {3, 2, 0, 11, 10, 8, 9, 14, 12, 13, 1, 4, 5, 6, 7, scmWithListDelimiter};
+const TDataIOID FORTE_Wago636::scmEIWith[] = {3, 2, 0, 11, 10, 8, 9, 14, 12, 13, 1, 4, 5, 6, 7, 15, 16, scmWithListDelimiter};
 const TForteInt16 FORTE_Wago636::scmEIWithIndexes[] = {0};
 const CStringDictionary::TStringId FORTE_Wago636::scmEventInputNames[] = {STRID(MAP)};
 const CStringDictionary::TStringId FORTE_Wago636::scmEventInputTypeIds[] = {STRID(Event)};
@@ -75,7 +79,7 @@ const SFBInterfaceSpec FORTE_Wago636::scmFBInterfaceSpec = {1,
                                                             scmEventOutputTypeIds,
                                                             scmEOWith,
                                                             scmEOWithIndexes,
-                                                            15,
+                                                            17,
                                                             scmDataInputNames,
                                                             scmDataInputTypeIds,
                                                             2,
@@ -93,9 +97,9 @@ FORTE_Wago636::FORTE_Wago636(const CStringDictionary::TStringId paInstanceNameId
     var_Busy(""_STRING),
     var_LimitSwitchN(""_STRING),
     var_LimitSwitchP(""_STRING),
-    var_PresetInputEnabled(""_STRING),
-    var_OptimizeOn(""_STRING),
-    var_ExtendedInfoOn(""_STRING),
+    var_PresetInput(""_STRING),
+    var_OptimizeOnZInput(""_STRING),
+    var_OnTarget(""_STRING),
     var_ReferenceOk(""_STRING),
     var_CurrentPosition(""_STRING),
     var_TargetPosition(""_STRING),
@@ -103,6 +107,7 @@ FORTE_Wago636::FORTE_Wago636(const CStringDictionary::TStringId paInstanceNameId
     var_MotorP(""_STRING),
     var_Positioning(""_STRING),
     var_Preset(""_STRING),
+    var_PresetInputEnable(""_STRING),
     var_QuitErrors(""_STRING),
     var_QO(0_BOOL),
     var_STATUS(u""_WSTRING),
@@ -112,16 +117,18 @@ FORTE_Wago636::FORTE_Wago636(const CStringDictionary::TStringId paInstanceNameId
     conn_Busy(nullptr),
     conn_LimitSwitchN(nullptr),
     conn_LimitSwitchP(nullptr),
-    conn_PresetInputEnabled(nullptr),
-    conn_OptimizeOn(nullptr),
-    conn_ExtendedInfoOn(nullptr),
+    conn_PresetInput(nullptr),
+    conn_OptimizeOnZInput(nullptr),
+    conn_OnTarget(nullptr),
     conn_ReferenceOk(nullptr),
     conn_CurrentPosition(nullptr),
     conn_TargetPosition(nullptr),
     conn_MotorN(nullptr),
     conn_MotorP(nullptr),
     conn_Positioning(nullptr),
+    conn_OptimizeOn(nullptr),
     conn_Preset(nullptr),
+    conn_PresetInputEnable(nullptr),
     conn_QuitErrors(nullptr),
     conn_QO(*this, 0, var_QO),
     conn_STATUS(*this, 1, var_STATUS) {};
@@ -131,16 +138,18 @@ void FORTE_Wago636::setInitialValues() {
   var_Busy = ""_STRING;
   var_LimitSwitchN = ""_STRING;
   var_LimitSwitchP = ""_STRING;
-  var_PresetInputEnabled = ""_STRING;
-  var_OptimizeOn = ""_STRING;
-  var_ExtendedInfoOn = ""_STRING;
+  var_PresetInput = ""_STRING;
+  var_OptimizeOnZInput = ""_STRING;
+  var_OnTarget = ""_STRING;
   var_ReferenceOk = ""_STRING;
   var_CurrentPosition = ""_STRING;
   var_TargetPosition = ""_STRING;
   var_MotorN = ""_STRING;
   var_MotorP = ""_STRING;
   var_Positioning = ""_STRING;
+  var_OptimizeOn = ""_STRING;
   var_Preset = ""_STRING;
+  var_PresetInputEnable = ""_STRING;
   var_QuitErrors = ""_STRING;
   var_QO = 0_BOOL;
   var_STATUS = u""_WSTRING;
@@ -153,17 +162,19 @@ void FORTE_Wago636::readInputData(const TEventID paEIID) {
       readData(1, var_Busy, conn_Busy);
       readData(2, var_LimitSwitchN, conn_LimitSwitchN);
       readData(3, var_LimitSwitchP, conn_LimitSwitchP);
-      readData(4, var_PresetInputEnabled, conn_PresetInputEnabled);
-      readData(5, var_OptimizeOn, conn_OptimizeOn);
-      readData(6, var_ExtendedInfoOn, conn_ExtendedInfoOn);
+      readData(4, var_PresetInput, conn_PresetInput);
+      readData(5, var_OptimizeOnZInput, conn_OptimizeOnZInput);
+      readData(6, var_OnTarget, conn_OnTarget);
       readData(7, var_ReferenceOk, conn_ReferenceOk);
       readData(8, var_CurrentPosition, conn_CurrentPosition);
       readData(9, var_TargetPosition, conn_TargetPosition);
       readData(10, var_MotorN, conn_MotorN);
       readData(11, var_MotorP, conn_MotorP);
       readData(12, var_Positioning, conn_Positioning);
-      readData(13, var_Preset, conn_Preset);
-      readData(14, var_QuitErrors, conn_QuitErrors);
+      readData(13, var_OptimizeOn, conn_OptimizeOn);
+      readData(14, var_Preset, conn_Preset);
+      readData(15, var_PresetInputEnable, conn_PresetInputEnable);
+      readData(16, var_QuitErrors, conn_QuitErrors);
       break;
     }
     default: break;
@@ -191,17 +202,19 @@ CIEC_ANY *FORTE_Wago636::getDI(const size_t paIndex) {
     case 1: return &var_Busy;
     case 2: return &var_LimitSwitchN;
     case 3: return &var_LimitSwitchP;
-    case 4: return &var_PresetInputEnabled;
-    case 5: return &var_OptimizeOn;
-    case 6: return &var_ExtendedInfoOn;
+    case 4: return &var_PresetInput;
+    case 5: return &var_OptimizeOnZInput;
+    case 6: return &var_OnTarget;
     case 7: return &var_ReferenceOk;
     case 8: return &var_CurrentPosition;
     case 9: return &var_TargetPosition;
     case 10: return &var_MotorN;
     case 11: return &var_MotorP;
     case 12: return &var_Positioning;
-    case 13: return &var_Preset;
-    case 14: return &var_QuitErrors;
+    case 13: return &var_OptimizeOn;
+    case 14: return &var_Preset;
+    case 15: return &var_PresetInputEnable;
+    case 16: return &var_QuitErrors;
   }
   return nullptr;
 }
@@ -228,17 +241,19 @@ CDataConnection **FORTE_Wago636::getDIConUnchecked(const TPortId paIndex) {
     case 1: return &conn_Busy;
     case 2: return &conn_LimitSwitchN;
     case 3: return &conn_LimitSwitchP;
-    case 4: return &conn_PresetInputEnabled;
-    case 5: return &conn_OptimizeOn;
-    case 6: return &conn_ExtendedInfoOn;
+    case 4: return &conn_PresetInput;
+    case 5: return &conn_OptimizeOnZInput;
+    case 6: return &conn_OnTarget;
     case 7: return &conn_ReferenceOk;
     case 8: return &conn_CurrentPosition;
     case 9: return &conn_TargetPosition;
     case 10: return &conn_MotorN;
     case 11: return &conn_MotorP;
     case 12: return &conn_Positioning;
-    case 13: return &conn_Preset;
-    case 14: return &conn_QuitErrors;
+    case 13: return &conn_OptimizeOn;
+    case 14: return &conn_Preset;
+    case 15: return &conn_PresetInputEnable;
+    case 16: return &conn_QuitErrors;
   }
   return nullptr;
 }
@@ -259,12 +274,12 @@ void FORTE_Wago636::initHandlesBase(size_t paNumberOfBoolInputs,
 
   if (paNumberOfBoolInputs == 7) {
     initWagoHandle(offset, 3, CIEC_ANY::e_BOOL, IOMapper::In); // busy - Status-Byte 0 Bit 3
-    initWagoHandle(offset + 1, 14, CIEC_ANY::e_BOOL, IOMapper::In); // switch negative - Status-Byte 1 Bit 6
-    initWagoHandle(offset + 2, 15, CIEC_ANY::e_BOOL, IOMapper::In); // switch positive - Status-Byte 1 Bit 7
-    initWagoHandle(offset + 3, 8, CIEC_ANY::e_BOOL, IOMapper::In); // preset input enabled - Status-Byte 1 Bit 0
-    initWagoHandle(offset + 4, 9, CIEC_ANY::e_BOOL, IOMapper::In); // optimize on - Status-Byte 1 Bit 1
-    initWagoHandle(offset + 5, 10, CIEC_ANY::e_BOOL, IOMapper::In); // extended info on - Status-Byte 1 Bit 2
-    initWagoHandle(offset + 6, 5, CIEC_ANY::e_BOOL, IOMapper::In); // reference ok - Status-Byte 0 Bit 5
+    initWagoHandle(1 + offset, 14, CIEC_ANY::e_BOOL, IOMapper::In); // limit switch negative (Hardware pin) - Status-Byte 1 Bit 6
+    initWagoHandle(2 + offset, 15, CIEC_ANY::e_BOOL, IOMapper::In); // limit switch positive (Hardware pin) - Status-Byte 1 Bit 7
+    initWagoHandle(3 + offset, 13, CIEC_ANY::e_BOOL, IOMapper::In); // preset input (Hardware pin) - Status-Byte 1 Bit 0
+    initWagoHandle(4 + offset, 9, CIEC_ANY::e_BOOL, IOMapper::In); // optimize on / z input (Hardware pin) - Status-Byte 1 Bit 1
+    initWagoHandle(5 + offset, 2, CIEC_ANY::e_BOOL, IOMapper::In); // on target - Status-Byte 0 Bit 2
+    initWagoHandle(6 + offset, 5, CIEC_ANY::e_BOOL, IOMapper::In); // reference ok - Status-Byte 0 Bit 5
   } else {
     DEVLOG_ERROR("[Wago636] only supports 7 BOOL inputs, but got %d.\n", paNumberOfBoolInputs);
   }
@@ -287,13 +302,15 @@ void FORTE_Wago636::initHandlesBase(size_t paNumberOfBoolInputs,
 
   offset += paNumberOfAnalogOutputs;
 
-  if (paNumberOfBoolOutputs == 5) {
+  if (paNumberOfBoolOutputs == 7) {
     initWagoHandle(offset, 0, CIEC_ANY::e_BOOL, IOMapper::Out); // motor negative - Control-Byte 0 Bit 0
-    initWagoHandle(offset + 1, 1, CIEC_ANY::e_BOOL, IOMapper::Out); // motor positive - Control-Byte 0 Bit 1
-    initWagoHandle(offset + 2, 2, CIEC_ANY::e_BOOL, IOMapper::Out); // positioning - Control-Byte 0 Bit 2
-    initWagoHandle(offset + 3, 3, CIEC_ANY::e_BOOL, IOMapper::Out); // preset - Control-Byte 0 Bit 3
-    initWagoHandle(offset + 4, 15, CIEC_ANY::e_BOOL, IOMapper::Out); // quit error Control-Byte 1 Bit 7
+    initWagoHandle(1 + offset, 1, CIEC_ANY::e_BOOL, IOMapper::Out); // motor positive - Control-Byte 0 Bit 1
+    initWagoHandle(2 + offset, 2, CIEC_ANY::e_BOOL, IOMapper::Out); // positioning - Control-Byte 0 Bit 2
+    initWagoHandle(3 + offset, 9, CIEC_ANY::e_BOOL, IOMapper::Out); // optimize on - Control-Byte 1 Bit 1
+    initWagoHandle(4 + offset, 3, CIEC_ANY::e_BOOL, IOMapper::Out); // preset - Control-Byte 0 Bit 3
+    initWagoHandle(5 + offset, 8, CIEC_ANY::e_BOOL, IOMapper::Out); // preset input enable - Control-Byte 1 Bit 0
+    initWagoHandle(6 + offset, 15, CIEC_ANY::e_BOOL, IOMapper::Out); // quit error Control-Byte 1 Bit 7
   } else {
-    DEVLOG_ERROR("[Wago636] only supports 5 BOOL outputs, but got %d.\n", paNumberOfBoolOutputs);
+    DEVLOG_ERROR("[Wago636] only supports 7 BOOL outputs, but got %d.\n", paNumberOfBoolOutputs);
   }
 }

--- a/src/modules/wagokbus/types/Wago636_fbt.h
+++ b/src/modules/wagokbus/types/Wago636_fbt.h
@@ -50,7 +50,7 @@ class FORTE_Wago636 final : public WagoSlaveBase {
                          size_t paNumberOfBoolOutputs,
                          size_t paNumberOfAnalogInputs,
                          size_t paNumberOfAnalogOutputs);
-    INIT_HANDLES(7, 5, 1, 1)
+    INIT_HANDLES(7, 7, 1, 1)
 
   public:
     FORTE_Wago636(const CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);
@@ -60,16 +60,18 @@ class FORTE_Wago636 final : public WagoSlaveBase {
     CIEC_STRING var_Busy;
     CIEC_STRING var_LimitSwitchN;
     CIEC_STRING var_LimitSwitchP;
-    CIEC_STRING var_PresetInputEnabled;
-    CIEC_STRING var_OptimizeOn;
-    CIEC_STRING var_ExtendedInfoOn;
+    CIEC_STRING var_PresetInput;
+    CIEC_STRING var_OptimizeOnZInput;
+    CIEC_STRING var_OnTarget;
     CIEC_STRING var_ReferenceOk;
     CIEC_STRING var_CurrentPosition;
     CIEC_STRING var_TargetPosition;
     CIEC_STRING var_MotorN;
     CIEC_STRING var_MotorP;
     CIEC_STRING var_Positioning;
+    CIEC_STRING var_OptimizeOn;
     CIEC_STRING var_Preset;
+    CIEC_STRING var_PresetInputEnable;
     CIEC_STRING var_QuitErrors;
 
     CIEC_BOOL var_QO;
@@ -82,16 +84,18 @@ class FORTE_Wago636 final : public WagoSlaveBase {
     CDataConnection *conn_Busy;
     CDataConnection *conn_LimitSwitchN;
     CDataConnection *conn_LimitSwitchP;
-    CDataConnection *conn_PresetInputEnabled;
-    CDataConnection *conn_OptimizeOn;
-    CDataConnection *conn_ExtendedInfoOn;
+    CDataConnection *conn_PresetInput;
+    CDataConnection *conn_OptimizeOnZInput;
+    CDataConnection *conn_OnTarget;
     CDataConnection *conn_ReferenceOk;
     CDataConnection *conn_CurrentPosition;
     CDataConnection *conn_TargetPosition;
     CDataConnection *conn_MotorN;
     CDataConnection *conn_MotorP;
     CDataConnection *conn_Positioning;
+    CDataConnection *conn_OptimizeOn;
     CDataConnection *conn_Preset;
+    CDataConnection *conn_PresetInputEnable;
     CDataConnection *conn_QuitErrors;
 
     COutDataConnection<CIEC_BOOL> conn_QO;
@@ -114,16 +118,18 @@ class FORTE_Wago636 final : public WagoSlaveBase {
                  const CIEC_STRING &paBusy,
                  const CIEC_STRING &paLimitSwitchN,
                  const CIEC_STRING &paLimitSwitchP,
-                 const CIEC_STRING &paPresetInputEnabled,
-                 const CIEC_STRING &paOptimizeOn,
-                 const CIEC_STRING &paExtendedInfoOn,
+                 const CIEC_STRING &paPresetInput,
+                 const CIEC_STRING &paOptimizeOnZInput,
+                 const CIEC_STRING &paOnTarget,
                  const CIEC_STRING &paReferenceOk,
                  const CIEC_STRING &paCurrentPosition,
                  const CIEC_STRING &paTargetPosition,
                  const CIEC_STRING &paMotorN,
                  const CIEC_STRING &paMotorP,
                  const CIEC_STRING &paPositioning,
+                 const CIEC_STRING &paOptimizeOn,
                  const CIEC_STRING &paPreset,
+                 const CIEC_STRING &paPresetInputEnable,
                  const CIEC_STRING &paQuitErrors,
                  CIEC_BOOL &paQO,
                  CIEC_WSTRING &paSTATUS) {
@@ -131,16 +137,18 @@ class FORTE_Wago636 final : public WagoSlaveBase {
       var_Busy = paBusy;
       var_LimitSwitchN = paLimitSwitchN;
       var_LimitSwitchP = paLimitSwitchP;
-      var_PresetInputEnabled = paPresetInputEnabled;
-      var_OptimizeOn = paOptimizeOn;
-      var_ExtendedInfoOn = paExtendedInfoOn;
+      var_PresetInput = paPresetInput;
+      var_OptimizeOnZInput = paOptimizeOnZInput;
+      var_OnTarget = paOnTarget;
       var_ReferenceOk = paReferenceOk;
       var_CurrentPosition = paCurrentPosition;
       var_TargetPosition = paTargetPosition;
       var_MotorN = paMotorN;
       var_MotorP = paMotorP;
       var_Positioning = paPositioning;
+      var_OptimizeOn = paOptimizeOn;
       var_Preset = paPreset;
+      var_PresetInputEnable = paPresetInputEnable;
       var_QuitErrors = paQuitErrors;
       executeEvent(scmEventMAPID, nullptr);
       paQO = var_QO;
@@ -151,21 +159,23 @@ class FORTE_Wago636 final : public WagoSlaveBase {
                     const CIEC_STRING &paBusy,
                     const CIEC_STRING &paLimitSwitchN,
                     const CIEC_STRING &paLimitSwitchP,
-                    const CIEC_STRING &paPresetInputEnabled,
-                    const CIEC_STRING &paOptimizeOn,
-                    const CIEC_STRING &paExtendedInfoOn,
+                    const CIEC_STRING &paPresetInput,
+                    const CIEC_STRING &paOptimizeOnZInput,
+                    const CIEC_STRING &paOnTarget,
                     const CIEC_STRING &paReferenceOk,
                     const CIEC_STRING &paCurrentPosition,
                     const CIEC_STRING &paTargetPosition,
                     const CIEC_STRING &paMotorN,
                     const CIEC_STRING &paMotorP,
                     const CIEC_STRING &paPositioning,
+                    const CIEC_STRING &paOptimizeOn,
                     const CIEC_STRING &paPreset,
+                    const CIEC_STRING &paPresetInputEnable,
                     const CIEC_STRING &paQuitErrors,
                     CIEC_BOOL &paQO,
                     CIEC_WSTRING &paSTATUS) {
-      evt_MAP(paQI, paBusy, paLimitSwitchN, paLimitSwitchP, paPresetInputEnabled, paOptimizeOn, paExtendedInfoOn,
-              paReferenceOk, paCurrentPosition, paTargetPosition, paMotorN, paMotorP, paPositioning, paPreset,
-              paQuitErrors, paQO, paSTATUS);
+      evt_MAP(paQI, paBusy, paLimitSwitchN, paLimitSwitchP, paPresetInput, paOptimizeOnZInput, paOnTarget,
+              paReferenceOk, paCurrentPosition, paTargetPosition, paMotorN, paMotorP, paPositioning, paOptimizeOn,
+              paPreset, paPresetInputEnable, paQuitErrors, paQO, paSTATUS);
     }
 };

--- a/src/modules/wagokbus/types/WagoBusAdapter.cpp
+++ b/src/modules/wagokbus/types/WagoBusAdapter.cpp
@@ -105,9 +105,9 @@ void FORTE_WagoBusAdapter::writeOutputData(const TEventID paEIID) {
   if (isSocket()) {
     switch (paEIID) {
       case scmEventINITID: {
-        writeData(scmFBInterfaceSpec.mNumDIs + 2, *mDOs[2], mDOConns[2]);
-        writeData(scmFBInterfaceSpec.mNumDIs + 1, *mDOs[1], mDOConns[1]);
-        writeData(scmFBInterfaceSpec.mNumDIs + 0, *mDOs[0], mDOConns[0]);
+        writeData(scmFBInterfaceSpecSocket.mNumDIs + 2, *mDOs[2], mDOConns[2]);
+        writeData(scmFBInterfaceSpecSocket.mNumDIs + 1, *mDOs[1], mDOConns[1]);
+        writeData(scmFBInterfaceSpecSocket.mNumDIs + 0, *mDOs[0], mDOConns[0]);
         break;
       }
       default: break;
@@ -115,7 +115,7 @@ void FORTE_WagoBusAdapter::writeOutputData(const TEventID paEIID) {
   } else {
     switch (paEIID) {
       case scmEventINITOID: {
-        writeData(scmFBInterfaceSpec.mNumDIs + 0, *mDOs[0], mDOConns[0]);
+        writeData(scmFBInterfaceSpecPlug.mNumDIs + 0, *mDOs[0], mDOConns[0]);
         break;
       }
       default: break;


### PR DESCRIPTION
This PR fixes the current and target position of 750-636, that did not work within the previous PR. It relates to https://github.com/eclipse-4diac/4diac-ide/pull/1278 

There seems to be a problem with the adapters for the modular IOs, during compiling I get:
```
[01m[K/.../forte/src/modules/wagokbus/types/WagoBusAdapter.cpp:108:19:[m[K [01;31m[Kerror: [m[K'[01m[KscmFBInterfaceSpec[m[K' was not declared in this scope; did you mean '[01m[KSFBInterfaceSpec[m[K'?
  108 |         writeData([01;31m[KscmFBInterfaceSpec[m[K.mNumDIs + 2, *mDOs[2], mDOConns[2]);
      |                   [01;31m[K^~~~~~[m[K
      |                   [32m[KSFBInterfaceSpec[m[K
```

at least revolution pi and wago seem to use _scmFBInterfaceSpec_ within the cpp but within the header there is _scmFBInterfaceSpecSocket_ and _scmFBInterfaceSpecPlug_. Not sure if this should be changed within this PR or there should be a separate one.