### PR TITLE
Removed TimeStamp from Event Watches

### DIFF
--- a/src/core/monitoring.cpp
+++ b/src/core/monitoring.cpp
@@ -228,6 +228,18 @@ namespace {
     return retVal;
   }
 
+  void appendEventWatch(std::string &paResponse, CEventWatchEntry &paEventWatchEntry) {
+    appendPortTag(paResponse, paEventWatchEntry.getPortId());
+
+    CIEC_UDINT udint(paEventWatchEntry.mEventDataBuf);
+
+    paResponse += "<Data value=\""s;
+    char buf[21]; // the biggest number in an ulint is 18446744073709551616, TODO directly use paResponse
+    udint.toString(buf, sizeof(buf));
+    paResponse += buf;
+    paResponse += "\"/>\n</Port>"s;
+  }
+
 } // namespace
 
 void CDataWatchEntry::update(const CFunctionBlock &paFB) {
@@ -456,20 +468,4 @@ void CMonitoringHandler::updateMonitoringData() {
       eventWatch.update();
     }
   }
-}
-
-void CMonitoringHandler::appendEventWatch(std::string &paResponse, CEventWatchEntry &paEventWatchEntry) {
-  appendPortTag(paResponse, paEventWatchEntry.getPortId());
-
-  CIEC_UDINT udint(paEventWatchEntry.mEventDataBuf);
-  CIEC_ULINT ulint(mResource.getDevice()->getTimer().getForteTime());
-
-  paResponse += "<Data value=\""s;
-  char buf[21]; // the bigest number in an ulint is 18446744073709551616, TODO directly use paResponse
-  udint.toString(buf, sizeof(buf));
-  paResponse += buf;
-  paResponse += "\" time=\""s;
-  ulint.toString(buf, sizeof(buf));
-  paResponse += buf;
-  paResponse += "\"/>\n</Port>"s;
 }

--- a/src/core/monitoring.h
+++ b/src/core/monitoring.h
@@ -144,8 +144,6 @@ namespace forte::core {
 
       void updateMonitoringData();
 
-      void appendEventWatch(std::string &paResponse, internal::CEventWatchEntry &paEventWatchEntry);
-
       //! List storing all FBs which are currently monitored
       std::vector<internal::SFBMonitoringEntry> mFBMonitoringList;
       CResource &mResource; //!< The resource this monitoring handler manages


### PR DESCRIPTION
As we are only returning the most recent and a single event count the time stamp as it was original designed does not make sense any more. Furthermore it is not used in 4diac IDE. Furthermore, for accurate tracing of what is happening the monitoring infrastructure was never really helpfull and we have now other means. So removing improves monitoring perfmance without loosing any features.