### PR TITLE
Marked CSinglyLinkedListNode as Deprecated

### DIFF
--- a/src/com/mqtt_paho/MQTTHandler.h
+++ b/src/com/mqtt_paho/MQTTHandler.h
@@ -19,7 +19,6 @@
 #define MQTTHANDLER_H_
 
 #include <extevhan.h>
-#include <fortelist.h>
 #include <MQTTComLayer.h>
 #include <forte_sync.h>
 #include <forte_thread.h>

--- a/src/core/conn.h
+++ b/src/core/conn.h
@@ -18,8 +18,6 @@
 #include <memory>
 #include <type_traits>
 
-#include <vector>
-#include "fortelist.h"
 #include "mgmcmd.h"
 #include "mgmcmdstruct.h"
 #include "stringdict.h"

--- a/src/core/eventconn.h
+++ b/src/core/eventconn.h
@@ -14,6 +14,7 @@
 #ifndef _EVENCONN_H_
 #define _EVENCONN_H_
 
+#include <vector>
 #include "conn.h"
 
 class CEventChainExecutionThread;

--- a/src/core/fbcontainer.h
+++ b/src/core/fbcontainer.h
@@ -17,7 +17,6 @@
 #define _FBCONTAINER_H_
 
 #include "conn.h"
-#include "fortelist.h"
 #include "stringdict.h"
 #include "mgmcmdstruct.h"
 #include <vector>

--- a/src/core/fortelist.h
+++ b/src/core/fortelist.h
@@ -27,7 +27,7 @@
  */
 
 template<typename T, typename Container = CSinglyLinkedListNode<T>>
-class CSinglyLinkedList {
+class [[deprecated("Use STL containers instead. Preferably std::vector")]] CSinglyLinkedList {
   private:
     friend class CIterator<T, Container>;
 

--- a/src/core/monitoring.h
+++ b/src/core/monitoring.h
@@ -18,7 +18,6 @@
 #include <functional>
 #include "funcbloc.h"
 #include "mgmcmdstruct.h"
-#include "fortelist.h"
 #include "conn.h"
 #include "stringdict.h"
 


### PR DESCRIPTION
With good C++ support on all of our platforms doing containers by ourself is not sensible anymore. Now code should therefor not use our CSinglyLinkedListNode. Also existing code should be gradualy moved to STL containers.

As part of this fix not used includes of this class.