### PR TITLE
`IODeviceController` support for `IOHandle`s  which direction is not set at initialization + Update eLITeBoard

### DIFF
--- a/src/core/io/device/io_controller.cpp
+++ b/src/core/io/device/io_controller.cpp
@@ -66,13 +66,46 @@ void IODeviceController::addHandle(HandleDescriptor &paHandleDescriptor) {
                    paHandleDescriptor.mId.c_str());
     return;
   }
+  addHandle(paHandleDescriptor.mId, std::move(handle));
+}
 
-  switch (handle->getDirection()) {
-    case IOMapper::In: addHandle(mInputHandles, paHandleDescriptor.mId, std::move(handle)); break;
-    case IOMapper::Out: addHandle(mOutputHandles, paHandleDescriptor.mId, std::move(handle)); break;
+void IODeviceController::addHandle(std::string const &paId, std::unique_ptr<IOHandle> paHandle) {
+  switch (paHandle->getDirection()) {
+    case IOMapper::In: addHandle(mInputHandles, paId, std::move(paHandle)); break;
+    case IOMapper::Out: addHandle(mOutputHandles, paId, std::move(paHandle)); break;
+    case IOMapper::InOut: addHandle(mDiverseHandles, paId, std::move(paHandle)); break;
+    case IOMapper::UnknownDirection: addHandle(mDiverseHandles, paId, std::move(paHandle)); break;
     default: break;
   }
 }
+
+void IODeviceController::updateHandleList(std::string const &paId, IOHandle *paHandle) {
+  for (auto it = mDiverseHandles.begin(); it != mDiverseHandles.end(); ++it) {
+    if (it->get() == paHandle) {
+      auto handleDirection = (*it)->getDirection();
+      switch (handleDirection) {
+        case IOMapper::In: {
+          CCriticalRegion criticalRegion(mHandleMutex);
+          mInputHandles.push_back(std::move(*it));
+          mDiverseHandles.erase(it);
+          break;
+        }
+        case IOMapper::Out: {
+          CCriticalRegion criticalRegion(mHandleMutex);
+          mOutputHandles.push_back(std::move(*it));
+          mDiverseHandles.erase(it);
+          break;
+        }
+        default:
+          DEVLOG_ERROR("[updateHandleList] %s's direction is neither `In` nor `Out`.\r\n", paId.c_str());
+          break;
+      }
+      return;
+    }
+  }
+  DEVLOG_INFO("[updateHandleList] %s's is no member of mDiverseHandles.\r\n", paId.c_str());
+}
+
 
 void IODeviceController::fireIndicationEvent(IOObserver *paObserver) {
   startNewEventChain(static_cast<CProcessInterfaceFB *>(paObserver));
@@ -134,8 +167,13 @@ void IODeviceController::dropHandles() {
     mapper.deregisterHandle(*outputHandle);
   }
 
+  for (auto &diverseHandle : mDiverseHandles) {
+    mapper.deregisterHandle(*diverseHandle);
+  }
+
   mInputHandles.clear();
   mOutputHandles.clear();
+  mDiverseHandles.clear();
 }
 
 bool IODeviceController::isHandleValueEqual(IOHandle &) {

--- a/src/core/io/device/io_controller.cpp
+++ b/src/core/io/device/io_controller.cpp
@@ -80,32 +80,34 @@ void IODeviceController::addHandle(std::string const &paId, std::unique_ptr<IOHa
 }
 
 void IODeviceController::updateHandleList(std::string const &paId, IOHandle *paHandle) {
-  for (auto it = mDiverseHandles.begin(); it != mDiverseHandles.end(); ++it) {
+  for (auto it = mDiverseHandles.begin(); it != mDiverseHandles.end();) {
     if (it->get() == paHandle) {
       auto handleDirection = (*it)->getDirection();
       switch (handleDirection) {
         case IOMapper::In: {
           CCriticalRegion criticalRegion(mHandleMutex);
           mInputHandles.push_back(std::move(*it));
-          mDiverseHandles.erase(it);
+          it = mDiverseHandles.erase(it);
           break;
         }
         case IOMapper::Out: {
           CCriticalRegion criticalRegion(mHandleMutex);
           mOutputHandles.push_back(std::move(*it));
-          mDiverseHandles.erase(it);
+          it = mDiverseHandles.erase(it);
           break;
         }
         default:
           DEVLOG_ERROR("[updateHandleList] %s's direction is neither `In` nor `Out`.\r\n", paId.c_str());
+          ++it;
           break;
       }
       return;
+    } else {
+      ++it;
     }
   }
   DEVLOG_INFO("[updateHandleList] %s's is no member of mDiverseHandles.\r\n", paId.c_str());
 }
-
 
 void IODeviceController::fireIndicationEvent(IOObserver *paObserver) {
   startNewEventChain(static_cast<CProcessInterfaceFB *>(paObserver));

--- a/src/core/io/device/io_controller.h
+++ b/src/core/io/device/io_controller.h
@@ -103,6 +103,16 @@ namespace forte {
             return 0;
           }
 
+          /*! @brief Updates the current handle in the input or output handle list
+           *
+           * This method deletes the current handle in the device-specific input and
+           * output list and adds it again, according to its current direction.
+           *
+           * @param paId Handle ID of the IOHandle, which should be updated
+           * @param paHandle IOHandle which should be updated
+           */
+          virtual void updateHandleList(std::string const &paId, IOHandle *paHandle);
+
         protected:
           explicit IODeviceController(CDeviceExecution &paDeviceExecution);
 
@@ -162,10 +172,21 @@ namespace forte {
            */
           virtual void addHandle(HandleDescriptor &paHandleDescriptor);
 
+          /*! @brief Adds an IO handle to the controller
+           *
+           * This method is called by #addHandle or during the initialization, when a handler is already existing.
+           * The handle is automatically added to the correct list (#inputHandles and #outputHandles).
+           * The handle lists should be accessed by the controller to read and write IOs.
+           *
+           * @param paId Handler ID
+           * @param paHandle Already exisiting handler, which gets added to the correct list.
+           */
+          virtual void addHandle(std::string const &paId, std::unique_ptr<IOHandle> paHandle);
+
           /*! @brief Initializer for all IO handles.
            *
            * The method is called when a configuration fb adds an handle via the #addHandle method.
-           * It should return an handle instance based on the descriptor information.
+           * It should return a handle instance based on the descriptor information.
            *
            * @param paHandleDescriptor Descriptor of the handle
            */
@@ -204,6 +225,13 @@ namespace forte {
            * #dropHandles is called automatically during deinitialization.
            */
           THandleList mOutputHandles;
+
+          /*! @brief All other handles (nighter input or output) of the main controller
+           * The list contain handles of the main controller, which cannot be classified.
+           * The list is managed by the #addHandle and #dropHandles method.
+           * #dropHandles is called automatically during deinitialization.
+           */
+          THandleList mDiverseHandles;
 
         private:
           IOConfigFBController *mDelegate;

--- a/src/modules/eliteboard/CMakeLists.txt
+++ b/src/modules/eliteboard/CMakeLists.txt
@@ -8,28 +8,20 @@
 # 
 # Contributors:
 #   Jonathan Lainer - Initial implementation.
+#   Maximilian Scharf - Adaptations for event-triggered IOs, ADCs and DACs.
 # *******************************************************************************/
 
 if("${FORTE_ARCHITECTURE}" STREQUAL "FreeRTOSLwIP")
-forte_add_io(ELITEBOARD "Support for the eLITe-Board development board")
+  forte_add_io(ELITEBOARD "Support for the eLITe-Board development board")
 
-if(FORTE_IO_ELITEBOARD)
-forte_add_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+  if(FORTE_IO_ELITEBOARD)
+    forte_add_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-#############################################################################
-# eLITe-Borad specific fixes
-#############################################################################
+    forte_add_definition("-ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions -Wl,--gc-sections")
 
-forte_add_definition("-ffunction-sections -fdata-sections -fno-threadsafe-statics -fno-rtti -fno-exceptions -Wl,--gc-sections")
+    add_subdirectory(handle)
+    add_subdirectory(handler)
+    add_subdirectory(types)
 
-#############################################################################
-# Function Blocks
-#############################################################################
-
-add_subdirectory(handler)
-forte_add_sourcefile_hcpp(handle/PinHandle)
-forte_add_sourcefile_hcpp(types/EliteBoard)
-forte_add_sourcefile_hcpp(types/Port_fbt types/PortAdapter_adp)
-
-endif(FORTE_IO_ELITEBOARD)
+  endif(FORTE_IO_ELITEBOARD)
 endif("${FORTE_ARCHITECTURE}" STREQUAL "FreeRTOSLwIP")

--- a/src/modules/eliteboard/handle/CMakeLists.txt
+++ b/src/modules/eliteboard/handle/CMakeLists.txt
@@ -1,0 +1,14 @@
+#*******************************************************************************
+# Copyright (c) 2025 Maximilian Scharf
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#   Maximilian Scharf - Initial implementation.
+# *******************************************************************************/
+
+forte_add_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+forte_add_sourcefile_hcpp(PinHandle)

--- a/src/modules/eliteboard/handle/PinHandle.cpp
+++ b/src/modules/eliteboard/handle/PinHandle.cpp
@@ -12,17 +12,22 @@
 
 #include "PinHandle.h"
 #include <forte_bool.h>
+#include "extevhandlerhelper.h"
 
-IOHandleGPIO::IOHandleGPIO(EliteBoardDeviceController *paDeviceCtrl, GPIO_TypeDef *paGPIO_Port, uint16_t paGPIO_Pin) :
-    IOHandle(
-        static_cast<forte::core::io::IODeviceController *>(paDeviceCtrl), IOMapper::UnknownDirection, CIEC_ANY::e_BOOL),
-    mGPIO_Port(paGPIO_Port),
-    mGPIO_Pin(paGPIO_Pin) {
+IOHandleGPIO::IOHandleGPIO(EliteBoardDeviceController *paDeviceCtrl,
+  EliteBoardDeviceController::GPIODescriptor desc)
+    : IOHandle( static_cast<IODeviceController *>(paDeviceCtrl), desc.mDirection, CIEC_ANY::e_BOOL),
+      mGPIO_Port(desc.mGPIO_Port),
+      mGPIO_Pin(desc.mPin),
+      mId(desc.mId){
 }
 
 void IOHandleGPIO::onObserver(IOObserver *paObserver) {
   IOHandle::onObserver(paObserver);
   mDirection = paObserver->getDirection();
+
+  // Since the direction of the GPIO is set at this time, the controller-handle-list has to be updated
+  mController->updateHandleList(mId, this);
 
   GPIO_InitTypeDef initParams{.Pin = mGPIO_Pin,
                               .Mode = (mDirection == IOMapper::In) ? GPIO_MODE_INPUT : GPIO_MODE_OUTPUT_PP,

--- a/src/modules/eliteboard/handle/PinHandle.h
+++ b/src/modules/eliteboard/handle/PinHandle.h
@@ -15,8 +15,7 @@
 
 #include <core/io/mapper/io_handle.h>
 #include <core/io/mapper/io_observer.h>
-#include "../handler/EliteBoardDeviceController.h"
-#include <stdint.h>
+#include "EliteBoardDeviceController.h"
 
 #include "stm32h743xx.h"
 #include "stm32h7xx_hal_gpio.h"
@@ -29,7 +28,7 @@ class IOHandleGPIO : public forte::core::io::IOHandle {
     using IOMapper = forte::core::io::IOMapper;
 
   public:
-    IOHandleGPIO(EliteBoardDeviceController *paDeviceCtrl, GPIO_TypeDef *paGPIO_Port, uint16_t paGPIO_Pin);
+    IOHandleGPIO(EliteBoardDeviceController *paDeviceCtrl, EliteBoardDeviceController::GPIODescriptor desc);
     void get(CIEC_ANY &) override;
     void set(const CIEC_ANY &) override;
 
@@ -40,6 +39,7 @@ class IOHandleGPIO : public forte::core::io::IOHandle {
   private:
     GPIO_TypeDef *mGPIO_Port;
     uint16_t mGPIO_Pin;
+    std::string const mId;
 };
 
 #endif

--- a/src/modules/eliteboard/handler/EliteBoardDeviceController.cpp
+++ b/src/modules/eliteboard/handler/EliteBoardDeviceController.cpp
@@ -8,23 +8,55 @@
  *
  * Contributors:
  *   Jonathan Lainer - Initial implementation.
+ *   Maximilian Scharf - Adaptations for ADC, DAC and event-triggered IOs.
  *******************************************************************************/
 
 #include "EliteBoardDeviceController.h"
-#include "../handler/EliteBoardDeviceController.h"
-#include "../handle/PinHandle.h"
+#include "handle/PinHandle.h"
+
+#include "devlog.h"
+#include "forte_word.h"
+
+#define POLL_FREQUENCY_Hz     1000
+#define PA_POLL_INTERVAL_MS   1000/POLL_FREQUENCY_Hz
 
 DEFINE_HANDLER(EliteBoardDeviceController);
 
-EliteBoardDeviceController::EliteBoardDeviceController(CDeviceExecution &paDeviceExecution) :
-    forte::core::io::IODeviceController(paDeviceExecution) {
+EliteBoardDeviceController::EliteBoardDeviceController(CDeviceExecution& paDeviceExecution)
+    : forte::core::io::IODevicePollController(paDeviceExecution, PA_POLL_INTERVAL_MS){
 }
 
-EliteBoardDeviceController::~EliteBoardDeviceController() {
+EliteBoardDeviceController::~EliteBoardDeviceController() {}
+
+/* starts the loop thread (when it is not already running) which executes the `controllerPoll` function */
+void EliteBoardDeviceController::startThread() {
+  if (!isAlive()) {
+    EliteBoardDeviceController::start();
+    DEVLOG_DEBUG("[EliteBoardDeviceController] loop running at %3d Hz / %3d ms cycle time\r\n", POLL_FREQUENCY_Hz, PA_POLL_INTERVAL_MS);
+  }
 }
 
 EliteBoardDeviceController::IOHandle *EliteBoardDeviceController::createIOHandle(HandleDescriptor &paHandleDescriptor) {
-  auto desc = static_cast<EliteBoardHandleDescriptor &>(paHandleDescriptor);
-  IOHandle *handle = new IOHandleGPIO(this, desc.mGPIO_Port, desc.mPin);
+  auto desc_base = static_cast<EliteBoardDescriptor &>(paHandleDescriptor);
+  IOHandle *handle;
+
+  switch (desc_base.mIOType) {
+    case GPIO: {
+      auto desc = static_cast<GPIODescriptor &>(paHandleDescriptor);
+      handle = new IOHandleGPIO(this, desc);
+      break;
+    }
+    default:
+      break;
+  }
+  startThread();
   return static_cast<IOHandle *>(handle);
+}
+
+bool EliteBoardDeviceController::isHandleValueEqual(IOHandle &paHandle) {
+  return false;
+}
+
+void EliteBoardDeviceController::poll() {
+  checkForInputChanges();
 }

--- a/src/modules/eliteboard/handler/EliteBoardDeviceController.h
+++ b/src/modules/eliteboard/handler/EliteBoardDeviceController.h
@@ -8,61 +8,78 @@
  *
  * Contributors:
  *   Jonathan Lainer - Initial implementation.
+ *   Maximilian Scharf - Adaptations for ADC, DAC and event-triggered IOs.
  *******************************************************************************/
 
-#ifndef ELITEBOARD_DEVICE_CONTROLLER_H
-#define ELITEBOARD_DEVICE_CONTROLLER_H
+#pragma once
 
-#include "core/io/device/io_controller.h"
+#include "core/io/device/io_controller_poll.h"
 #include "core/io/mapper/io_handle.h"
 #include "extevhan.h"
 
 #include "stm32h743xx.h"
+#include <string>
+#include "CeSpec.h"
+
 #include "stm32h7xx_hal_gpio.h"
 
-#include <string>
+class EliteBoardDeviceController : public IODevicePollController {
+  DECLARE_HANDLER(EliteBoardDeviceController);
 
-class EliteBoardDeviceController : public forte::core::io::IODeviceController {
   public:
-    using HandleDescriptor = forte::core::io::IODeviceController::HandleDescriptor;
+    using HandleDescriptor = HandleDescriptor;
     using IOMapper = forte::core::io::IOMapper;
     using IOHandle = forte::core::io::IOHandle;
 
-    DECLARE_HANDLER(EliteBoardDeviceController);
+    enum EIOType {
+      GPIO = 10,
+      ADC  = 20,
+      DAC  = 30
+    };
 
-    class EliteBoardHandleDescriptor : public forte::core::io::IODeviceController::HandleDescriptor {
+    void addHandle(HandleDescriptor &paHandleDescriptor) override {
+      IODeviceController::addHandle(paHandleDescriptor);
+    }
+
+     void addHandle(std::string const &paId, std::unique_ptr<IOHandle> paHandle) override {
+       IODeviceController::addHandle(paId, std::move(paHandle));
+     }
+
+     void updateHandleList(std::string const &paId, IOHandle *paHandle) override {
+       IODeviceController::updateHandleList(paId, paHandle);
+     }
+
+    void setConfig(Config *paConfig) override {}
+
+    const char *init() override{
+      /* nullptr indicates no error */
+      return nullptr;
+    }
+
+    IOHandle *createIOHandle(HandleDescriptor &paHandleDescriptor) override;
+    bool isHandleValueEqual(IOHandle &paHandle) override;
+    void deInit() override {}
+    void poll() override;
+    void startThread();
+
+    class EliteBoardDescriptor : public HandleDescriptor {
+      public:
+        EIOType mIOType;
+        EliteBoardDescriptor(std::string paId, IOMapper::Direction paDirection, EIOType paIOType)
+          : HandleDescriptor(std::string(paId), paDirection), mIOType(paIOType) {}
+    };
+
+    class GPIODescriptor : public EliteBoardDescriptor {
       public:
         GPIO_TypeDef *mGPIO_Port;
         uint16_t mPin;
 
-        EliteBoardHandleDescriptor(CIEC_STRING const &paId,
-                                   forte::core::io::IOMapper::Direction paDirection,
-                                   GPIO_TypeDef *paGPIO_Port,
-                                   uint16_t paPin) :
-            HandleDescriptor(std::string(paId), IOMapper::UnknownDirection),
-            mGPIO_Port(paGPIO_Port),
-            mPin(paPin) {
-        }
+        GPIODescriptor(CIEC_STRING const &paId, IOMapper::Direction paDirection, GPIO_TypeDef* paGPIO_Port, uint16_t paPin)
+          : EliteBoardDescriptor(std::string(paId), paDirection, GPIO),
+            mGPIO_Port(paGPIO_Port), mPin(paPin) {}
 
-        EliteBoardHandleDescriptor(CIEC_STRING const &paId, GPIO_TypeDef *paGPIO_Port, uint16_t paPin) :
-            HandleDescriptor(std::string(paId), IOMapper::UnknownDirection),
-            mGPIO_Port(paGPIO_Port),
-            mPin(paPin) {
-        }
+        GPIODescriptor(CIEC_STRING const &paId, GPIO_TypeDef* paGPIO_Port, uint16_t paPin)
+          : EliteBoardDescriptor(std::string(paId), IOMapper::InOut, GPIO),
+            mGPIO_Port(paGPIO_Port), mPin(paPin) {}
     };
-
-    IOHandle *createIOHandle(HandleDescriptor &paHandleDescriptor);
-
-    void setConfig(Config *paConfig) {
-    }
-    const char *init() {
-      const char *x = "";
-      return x;
-    }
-    void runLoop() {
-    }
-    void deInit() {
-    }
 };
-
-#endif /* ifndef ELITEBOARD_DEVICE_CONTROLLER_H */

--- a/src/modules/eliteboard/types/CMakeLists.txt
+++ b/src/modules/eliteboard/types/CMakeLists.txt
@@ -1,0 +1,15 @@
+#*******************************************************************************
+# Copyright (c) 2025 Maximilian Scharf
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#   Maximilian Scharf - Initial implementation.
+# *******************************************************************************/
+
+forte_add_sourcefile_hcpp(EliteBoard_fbt)
+forte_add_sourcefile_hcpp(Port_fbt)
+forte_add_sourcefile_hcpp(PortAdapter_adp)

--- a/src/modules/eliteboard/types/EliteBoard_fbt.cpp
+++ b/src/modules/eliteboard/types/EliteBoard_fbt.cpp
@@ -10,7 +10,7 @@
  *   Jonathan Lainer - Initial implementation.
  *******************************************************************************/
 
-#include "EliteBoard.h"
+#include "EliteBoard_fbt.h"
 
 USE_STRING_ID(EliteBoard);
 USE_STRING_ID(MAP);
@@ -76,7 +76,8 @@ const SFBInterfaceSpec FORTE_EliteBoard::scmFBInterfaceSpec = {1,
 
 FORTE_EliteBoard::FORTE_EliteBoard(const CStringDictionary::TStringId paInstanceNameId,
                                    forte::core::CFBContainer &paContainer) :
-    CFunctionBlock(paContainer, scmFBInterfaceSpec, paInstanceNameId),
+    IOConfigFBController(paContainer, scmFBInterfaceSpec, paInstanceNameId),
+    mEventHandler{getExtEvHandler<EliteBoardDeviceController>(*this)},
     var_PortA(STRID(PortA), *this, true),
     var_PortB(STRID(PortB), *this, true),
     var_PortC(STRID(PortC), *this, true),
@@ -245,4 +246,9 @@ bool FORTE_EliteBoard::configurePortFB(int index, CEventChainExecutionThread *co
 
   sendAdapterEvent(index, FORTE_PortAdapter::scmEventMAPID, paECET);
   return true;
+}
+
+// IOConfigFBController
+IODeviceController *FORTE_EliteBoard::createDeviceController(CDeviceExecution &paDeviceExecution) {
+  return &mEventHandler;
 }

--- a/src/modules/eliteboard/types/EliteBoard_fbt.h
+++ b/src/modules/eliteboard/types/EliteBoard_fbt.h
@@ -22,8 +22,11 @@
 #include "forte_array_variable.h"
 
 #include "../handler/EliteBoardDeviceController.h"
+#include "core/io/configFB/io_configFB_controller.h"
 
-class FORTE_EliteBoard final : public CFunctionBlock {
+using namespace forte::core::io;
+
+class FORTE_EliteBoard final : public IOConfigFBController {
     DECLARE_FIRMWARE_FB(FORTE_EliteBoard)
 
   private:
@@ -59,6 +62,11 @@ class FORTE_EliteBoard final : public CFunctionBlock {
     FORTE_PortAdapter &getPortAdapterByIndex(int index);
     bool configurePortFB(int index, CEventChainExecutionThread *const paECET);
     int configPorts(CEventChainExecutionThread *const paECET);
+
+    // IOConfigFBController
+    EliteBoardDeviceController& mEventHandler;
+    IODeviceController *createDeviceController(CDeviceExecution &paDeviceExecution);
+    void setConfig() {}
 
   public:
     FORTE_EliteBoard(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paContainer);

--- a/src/modules/eliteboard/types/PortAdapter_adp.cpp
+++ b/src/modules/eliteboard/types/PortAdapter_adp.cpp
@@ -98,7 +98,7 @@ void FORTE_PortAdapter::writeOutputData(const TEventID paEIID) {
   if (isSocket()) {
     switch (paEIID) {
       case scmEventMAPID: {
-        writeData(scmFBInterfaceSpec.mNumDIs + 0, *mDOs[0], mDOConns[0]);
+        writeData(getFBInterfaceSpec().mNumDIs + 0, *mDOs[0], mDOConns[0]);
         break;
       }
       default: break;

--- a/src/modules/eliteboard/types/Port_fbt.cpp
+++ b/src/modules/eliteboard/types/Port_fbt.cpp
@@ -246,10 +246,10 @@ void FORTE_Port::register_handles() {
 
     // Create a GPIO pin handle using the port struct to identify the MMIO port and
     // a bit mask to identify the pin.
-    EliteBoardDeviceController::EliteBoardHandleDescriptor descr(*id, IOMapper::UnknownDirection, port,
+    EliteBoardDeviceController::GPIODescriptor descr(*id, IOMapper::UnknownDirection, port,
                                                                  uint16_t(1 << i));
     EliteBoardDeviceController &ctrl = getExtEvHandler<EliteBoardDeviceController>(*this);
 
-    IOMapper::getInstance().registerHandle(std::string(*id), ctrl.createIOHandle(descr));
+    ctrl.addHandle(descr);
   }
 }

--- a/src/modules/eliteboard/types/Port_fbt.h
+++ b/src/modules/eliteboard/types/Port_fbt.h
@@ -40,7 +40,7 @@ class FORTE_Port final : public CFunctionBlock {
     void writeOutputData(TEventID paEIID) override;
     void setInitialValues() override;
 
-    // The (maximum) number  of IO pins available on a GPIO port.
+    // The (maximum) number of IO pins available on a GPIO port.
     static constexpr size_t pin_cnt = 16;
     std::array<CIEC_STRING *, pin_cnt> mRegistered;
 


### PR DESCRIPTION
The current implementation of `IODeviceController` wraps the adds `IOHandle`s into a `std::unique_ptr` and adds them into the controllers `mInputHandles` or `mOutputHandles` std::vector. If the handles direction is neither set to  `IN` nor `OUT`, it will not getting added and the live-time of the unique-pointer expires, which causes a de-registration of the corresponding IO-handle.

To catch this, this PR introduces an additional std::vector. Objects with `UnknownDirection` or `InOut` are now temporarily stored into `mDiverseHandles`.
`IODeviceController::updateHandleList(std::string const &paId, IOHandle *paHandle)` makes it possible to move a handle from the list `mDiverseHandles` into the right vector, according to the currently set direction.

An example of the use is shown in the updated eLITeBoard module. GPIOs are initialized with `UnknownDirection`. After the observer is registered, the IOHandle (see `IOHandleGPIO::onObserver`) updates its direction and calls `updateHandleList`.