### PR TITLE
Silence C++20 codecvt facets deprecation warnings on MSVC

### DIFF
--- a/src/arch/win32/CMakeLists.txt
+++ b/src/arch/win32/CMakeLists.txt
@@ -75,6 +75,7 @@ if("${FORTE_ARCHITECTURE}" STREQUAL "Win32")
   elseif(MSVC)
     forte_add_definition("-wd4595")  #warning 4595: 'operator delete/delete[]': non-member operator new or delete functions may not be declared inline
     forte_add_definition("-wd4290")  #warning 4290: C++ exception specification ignored except to indicate a function is not __declspec(nothrow). A function is declared using exception specification, which Visual C++ accepts but does not implement. (from new/delete warning)
+    forte_add_definition("-D_SILENCE_CXX20_CODECVT_FACETS_DEPRECATION_WARNING") # silence C++20 codecvt facets deprecation warnings until a viable replacement is found to prevent repeated warnings during builds
     forte_add_definition("-DNOMINMAX")  #needed that windows.h is not adding macros for MIN and MAX
   endif()
   


### PR DESCRIPTION
The codecvt facets have been deprecated in C++20 and there is currently no viable replacement in the standard library.
    
This silences the deprecation warnings on MSVC to prevent unnecessary repeated warnings during builds until we can find a viable replacement.