### PR TITLE
Added reset method that allows to reset pins to their type default value

### DIFF
--- a/src/com/HTTP/httplayer.cpp
+++ b/src/com/HTTP/httplayer.cpp
@@ -23,6 +23,7 @@
 #include "basecommfb.h"
 #include "http_handler.h"
 #include "comtypes.h"
+#include "string_utils.h"
 
 using namespace forte::com_infra;
 using namespace std::string_literals;

--- a/src/com/modbus/modbuslayer.cpp
+++ b/src/com/modbus/modbuslayer.cpp
@@ -14,6 +14,7 @@
 #include "modbuslayer.h"
 #include "commfb.h"
 #include "modbusclientconnection.h"
+#include "string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/com/opc_ua/opcua_action_info.cpp
+++ b/src/com/opc_ua/opcua_action_info.cpp
@@ -15,6 +15,7 @@
 #include "opcua_action_info.h"
 #include "core/util/parameterParser.h"
 #include "core/cominfra/basecommfb.h"
+#include "string_utils.h"
 
 const char *const CActionInfo::mActionNames[] = {"READ",           "WRITE",         "CREATE_METHOD",   "CALL_METHOD",
                                                  "SUBSCRIBE",      "CREATE_OBJECT", "CREATE_VARIABLE", "DELETE_OBJECT",

--- a/src/com/opc_ua/opcua_client_information.cpp
+++ b/src/com/opc_ua/opcua_client_information.cpp
@@ -12,7 +12,7 @@
  *    Martin Melik Merkumians - Change CIEC_STRING to std::string
  *******************************************************************************/
 
-#include <forte_architecture_time.h>
+#include "forte_architecture_time.h"
 #include "opcua_client_information.h"
 #include <basecommfb.h>
 #include "opcua_handler_abstract.h" //for logger

--- a/src/com/opc_ua/opcua_helper.cpp
+++ b/src/com/opc_ua/opcua_helper.cpp
@@ -20,6 +20,7 @@
 #include "forte_date.h"
 #include "forte_struct.h"
 #include "forte_array.h"
+#include "string_utils.h"
 
 static const CIEC_DATE::TValueType internalToOPCUAEpochDifferenceInNanoseconds = 11644473600000000LL;
 

--- a/src/com/opc_ua/opcua_objectstruct_helper.cpp
+++ b/src/com/opc_ua/opcua_objectstruct_helper.cpp
@@ -22,6 +22,7 @@ USE_STRING_ID(OPCUA_Namespace);
 #include "opcua_local_handler.h"
 #include "core/util/parameterParser.h"
 #include <sstream>
+#include "string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/com/powerlink/EplXmlReader.cpp
+++ b/src/com/powerlink/EplXmlReader.cpp
@@ -17,11 +17,11 @@
 #include <iostream>
 #include <fstream>
 #include <string.h>
-
 #include "devlog.h"
-using namespace std;
-
+#include "string_utils.h"
 #include <tinyxml.h>
+
+using namespace std;
 
 CEplXmlReader::CEplXmlReader(CProcessImageMatrix *paIn, CProcessImageMatrix *paOut) {
   mProcImageIn = paIn;

--- a/src/core/basefb.cpp
+++ b/src/core/basefb.cpp
@@ -18,6 +18,7 @@
  *******************************************************************************/
 
 #include "basefb.h"
+#include "string_utils.h"
 
 TPortId SInternalVarsInformation::getVarId(CStringDictionary::TStringId paInternalName) const {
   for (TPortId i = 0; i < mNumIntVars; ++i) {

--- a/src/core/cominfra/commfb.cpp
+++ b/src/core/cominfra/commfb.cpp
@@ -21,6 +21,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "commfb.h"
+#include "comlayer.h"
+#include "comlayersmanager.h"
+#include "criticalregion.h"
+#include "string_utils.h"
 
 USE_STRING_ID(BOOL);
 USE_STRING_ID(CNF);
@@ -37,11 +41,6 @@ USE_STRING_ID(RSP);
 USE_STRING_ID(STATUS);
 USE_STRING_ID(STRING);
 USE_STRING_ID(WSTRING);
-
-#include "../resource.h"
-#include "comlayer.h"
-#include "comlayersmanager.h"
-#include "criticalregion.h"
 
 using namespace forte::com_infra;
 

--- a/src/core/cominfra/ipcomlayer.cpp
+++ b/src/core/cominfra/ipcomlayer.cpp
@@ -16,8 +16,9 @@
  *******************************************************************************/
 #include "ipcomlayer.h"
 #include "../../arch/devlog.h"
-#include "commfb.h"
+#include "basecommfb.h"
 #include <forte_thread.h>
+#include "string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/core/cominfra/structmembercomlayer.cpp
+++ b/src/core/cominfra/structmembercomlayer.cpp
@@ -11,12 +11,13 @@
  *    Mario Kastner, Alois Zoitl - initial implementation
  *******************************************************************************/
 
-#include "commfb.h"
+#include "basecommfb.h"
 #include "parameterParser.h"
 #include "structmembercomlayer.h"
 #include "typelib.h"
 #include <string>
 #include <errno.h>
+#include "string_utils.h"
 
 using namespace forte::com_infra;
 

--- a/src/core/datatypes/forte_any.h
+++ b/src/core/datatypes/forte_any.h
@@ -138,6 +138,10 @@ class CIEC_ANY {
       setValueSimple(paValue);
     }
 
+    /*! \brief Reset the value for to the default initial value
+     */
+    virtual void reset() = 0;
+
     /**
      * @brief Unwrap ANY value if inside a container
      * @return The unwrapped value or this value if not in a container

--- a/src/core/datatypes/forte_any_bit.h
+++ b/src/core/datatypes/forte_any_bit.h
@@ -20,13 +20,16 @@
 #define _ANY_BIT_H_
 
 #include "forte_any_elementary.h"
-#include <limits>
 
 /*!\ingroup COREDTS IIEC_ANY_BIT represents any bit data types according to IEC 61131.
  */
 class CIEC_ANY_BIT : public CIEC_ANY_ELEMENTARY {
   public:
     ~CIEC_ANY_BIT() override = default;
+
+    void reset() override {
+      setTUINT64(0);
+    }
 
   protected:
     CIEC_ANY_BIT() = default;

--- a/src/core/datatypes/forte_any_bit_variant.h
+++ b/src/core/datatypes/forte_any_bit_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -61,6 +60,10 @@ class CIEC_ANY_BIT_VARIANT : public CIEC_ANY_BIT, public TIecAnyBitVariantType {
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_char.h
+++ b/src/core/datatypes/forte_any_char.h
@@ -31,6 +31,10 @@ class CIEC_ANY_CHAR : public CIEC_ANY_CHARS {
       return CIEC_ANY::e_ANY;
     }
 
+    void reset() override {
+      setLargestInt(0);
+    }
+
   protected:
     CIEC_ANY_CHAR() = default;
 };

--- a/src/core/datatypes/forte_any_char_variant.h
+++ b/src/core/datatypes/forte_any_char_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -56,6 +55,10 @@ class CIEC_ANY_CHAR_VARIANT : public CIEC_ANY_CHAR, public TIecAnyCharVariantTyp
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_chars.h
+++ b/src/core/datatypes/forte_any_chars.h
@@ -15,7 +15,6 @@
 #define _ANY_CHARS_H_
 
 #include "forte_any_elementary.h"
-#include <string_utils.h>
 
 /*!\ingroup COREDTS CIEC_ANY_CHARS represents ANY_CHARS data types according to
  *  IEC 61131.

--- a/src/core/datatypes/forte_any_chars_variant.h
+++ b/src/core/datatypes/forte_any_chars_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -61,6 +60,10 @@ class CIEC_ANY_CHARS_VARIANT : public CIEC_ANY_CHARS, public TIecAnyCharsVariant
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_date.cpp
+++ b/src/core/datatypes/forte_any_date.cpp
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include "forte_any_date.h"
 
-#include <forte_architecture_time.h>
+#include "forte_architecture_time.h"
 
 TForteInt32 CIEC_ANY_DATE::smTimeZoneOffset = -1;
 

--- a/src/core/datatypes/forte_any_date.h
+++ b/src/core/datatypes/forte_any_date.h
@@ -25,6 +25,10 @@ class CIEC_ANY_DATE : public CIEC_ANY_ELEMENTARY {
 
     ~CIEC_ANY_DATE() override = default;
 
+    void reset() override {
+      setTUINT64(0);
+    }
+
     /*! Retrieve the current timezone
      *
      * Can be sed to adjust mktime()-related values

--- a/src/core/datatypes/forte_any_date_variant.h
+++ b/src/core/datatypes/forte_any_date_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -63,6 +62,10 @@ class CIEC_ANY_DATE_VARIANT : public CIEC_ANY_DATE, public TIecAnyDateVariantTyp
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_duration.h
+++ b/src/core/datatypes/forte_any_duration.h
@@ -104,6 +104,10 @@ class CIEC_ANY_DURATION : public CIEC_ANY_MAGNITUDE {
 
     ~CIEC_ANY_DURATION() override = default;
 
+    void reset() override {
+      setLargestInt(0);
+    }
+
     EDataTypeID getDataTypeID() const override {
       return CIEC_ANY::e_ANY;
     }

--- a/src/core/datatypes/forte_any_duration_variant.h
+++ b/src/core/datatypes/forte_any_duration_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -56,6 +55,10 @@ class CIEC_ANY_DURATION_VARIANT : public CIEC_ANY_DURATION, public TIecAnyDurati
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_elementary.cpp
+++ b/src/core/datatypes/forte_any_elementary.cpp
@@ -15,6 +15,19 @@
  *   Markus Meingast, Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte_any_elementary.h"
+#include "string_utils.h"
+#include <stdlib.h>
+#include <errno.h>
+#include "forte_sint.h"
+#include "forte_int.h"
+#include "forte_dint.h"
+#include "forte_usint.h"
+#include "forte_uint.h"
+#include "forte_udint.h"
+#include "forte_lint.h"
+#include "forte_ulint.h"
+#include <devlog.h>
+#include <map>
 
 USE_STRING_ID(ANY);
 USE_STRING_ID(BOOL);
@@ -53,54 +66,45 @@ USE_STRING_ID(WCHAR);
 USE_STRING_ID(WORD);
 USE_STRING_ID(WSTRING);
 
-#include <stdlib.h>
-#include <errno.h>
-#include "forte_sint.h"
-#include "forte_int.h"
-#include "forte_dint.h"
-#include "forte_usint.h"
-#include "forte_uint.h"
-#include "forte_udint.h"
-#include "forte_lint.h"
-#include "forte_ulint.h"
-
-const std::map<CStringDictionary::TStringId, CIEC_ANY::EDataTypeID> CIEC_ANY_ELEMENTARY::scm_StringToTypeId = {
-    {STRID(ANY), CIEC_ANY::e_ANY},
-    {STRID(BOOL), CIEC_ANY::e_BOOL},
-    {STRID(SINT), CIEC_ANY::e_SINT},
-    {STRID(INT), CIEC_ANY::e_INT},
-    {STRID(DINT), CIEC_ANY::e_DINT},
-    {STRID(LINT), CIEC_ANY::e_LINT},
-    {STRID(USINT), CIEC_ANY::e_USINT},
-    {STRID(UINT), CIEC_ANY::e_UINT},
-    {STRID(UDINT), CIEC_ANY::e_UDINT},
-    {STRID(ULINT), CIEC_ANY::e_ULINT},
-    {STRID(BYTE), CIEC_ANY::e_BYTE},
-    {STRID(WORD), CIEC_ANY::e_WORD},
-    {STRID(DWORD), CIEC_ANY::e_DWORD},
-    {STRID(LWORD), CIEC_ANY::e_LWORD},
-    {STRID(T), CIEC_ANY::e_TIME},
-    {STRID(TIME), CIEC_ANY::e_TIME},
-    {STRID(D), CIEC_ANY::e_DATE},
-    {STRID(DATE), CIEC_ANY::e_DATE},
-    {STRID(TOD), CIEC_ANY::e_TIME_OF_DAY},
-    {STRID(TIME_OF_DAY), CIEC_ANY::e_TIME_OF_DAY},
-    {STRID(DT), CIEC_ANY::e_DATE_AND_TIME},
-    {STRID(DATE_AND_TIME), CIEC_ANY::e_DATE_AND_TIME},
-    {STRID(LT), CIEC_ANY::e_LTIME},
-    {STRID(LTIME), CIEC_ANY::e_LTIME},
-    {STRID(LD), CIEC_ANY::e_LDATE},
-    {STRID(LDATE), CIEC_ANY::e_LDATE},
-    {STRID(LTOD), CIEC_ANY::e_LTIME_OF_DAY},
-    {STRID(LTIME_OF_DAY), CIEC_ANY::e_LTIME_OF_DAY},
-    {STRID(LDT), CIEC_ANY::e_LDATE_AND_TIME},
-    {STRID(LDATE_AND_TIME), CIEC_ANY::e_LDATE_AND_TIME},
-    {STRID(CHAR), CIEC_ANY::e_CHAR},
-    {STRID(WCHAR), CIEC_ANY::e_WCHAR},
-    {STRID(REAL), CIEC_ANY::e_REAL},
-    {STRID(LREAL), CIEC_ANY::e_LREAL},
-    {STRID(STRING), CIEC_ANY::e_STRING},
-    {STRID(WSTRING), CIEC_ANY::e_WSTRING}};
+namespace {
+  const std::map<CStringDictionary::TStringId, CIEC_ANY::EDataTypeID> scm_StringToTypeId = {
+      {STRID(ANY), CIEC_ANY::e_ANY},
+      {STRID(BOOL), CIEC_ANY::e_BOOL},
+      {STRID(SINT), CIEC_ANY::e_SINT},
+      {STRID(INT), CIEC_ANY::e_INT},
+      {STRID(DINT), CIEC_ANY::e_DINT},
+      {STRID(LINT), CIEC_ANY::e_LINT},
+      {STRID(USINT), CIEC_ANY::e_USINT},
+      {STRID(UINT), CIEC_ANY::e_UINT},
+      {STRID(UDINT), CIEC_ANY::e_UDINT},
+      {STRID(ULINT), CIEC_ANY::e_ULINT},
+      {STRID(BYTE), CIEC_ANY::e_BYTE},
+      {STRID(WORD), CIEC_ANY::e_WORD},
+      {STRID(DWORD), CIEC_ANY::e_DWORD},
+      {STRID(LWORD), CIEC_ANY::e_LWORD},
+      {STRID(T), CIEC_ANY::e_TIME},
+      {STRID(TIME), CIEC_ANY::e_TIME},
+      {STRID(D), CIEC_ANY::e_DATE},
+      {STRID(DATE), CIEC_ANY::e_DATE},
+      {STRID(TOD), CIEC_ANY::e_TIME_OF_DAY},
+      {STRID(TIME_OF_DAY), CIEC_ANY::e_TIME_OF_DAY},
+      {STRID(DT), CIEC_ANY::e_DATE_AND_TIME},
+      {STRID(DATE_AND_TIME), CIEC_ANY::e_DATE_AND_TIME},
+      {STRID(LT), CIEC_ANY::e_LTIME},
+      {STRID(LTIME), CIEC_ANY::e_LTIME},
+      {STRID(LD), CIEC_ANY::e_LDATE},
+      {STRID(LDATE), CIEC_ANY::e_LDATE},
+      {STRID(LTOD), CIEC_ANY::e_LTIME_OF_DAY},
+      {STRID(LTIME_OF_DAY), CIEC_ANY::e_LTIME_OF_DAY},
+      {STRID(LDT), CIEC_ANY::e_LDATE_AND_TIME},
+      {STRID(LDATE_AND_TIME), CIEC_ANY::e_LDATE_AND_TIME},
+      {STRID(CHAR), CIEC_ANY::e_CHAR},
+      {STRID(WCHAR), CIEC_ANY::e_WCHAR},
+      {STRID(REAL), CIEC_ANY::e_REAL},
+      {STRID(LREAL), CIEC_ANY::e_LREAL},
+      {STRID(STRING), CIEC_ANY::e_STRING},
+      {STRID(WSTRING), CIEC_ANY::e_WSTRING}};
+}
 
 void CIEC_ANY_ELEMENTARY::toString(std::string &paTargetBuf) const {
   TLargestUIntValueType divisor = 0;

--- a/src/core/datatypes/forte_any_elementary.h
+++ b/src/core/datatypes/forte_any_elementary.h
@@ -18,9 +18,6 @@
 #define _ANY_ELE_H_
 
 #include "forte_any.h"
-#include <ctype.h>
-#include "core/util/string_utils.h"
-#include <map>
 
 /*!\ingroup COREDTS IIEC_ANY_ELEMENTARY represents the elementary data types according to
  *  IEC 61131.
@@ -48,10 +45,6 @@ class CIEC_ANY_ELEMENTARY : public CIEC_ANY {
   private:
     bool isTypeSpecifier(const char *paValue, const char *paHashPosition) const;
     bool isCastable(CStringDictionary::TStringId paTypeNameId) const;
-
-    const static std::map<CStringDictionary::TStringId, CIEC_ANY::EDataTypeID> scm_StringToTypeId;
-
-    const static int scmMaxTypeNameLength = 13;
 };
 
 #endif /*_MANY_ELE_H_*/

--- a/src/core/datatypes/forte_any_elementary_variant.h
+++ b/src/core/datatypes/forte_any_elementary_variant.h
@@ -14,12 +14,9 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
-#include "forte_any_unique_ptr.h"
-#include "forte_array_common.h"
 #include "forte_bool.h"
 #include "forte_byte.h"
 #include "forte_char.h"
@@ -38,7 +35,6 @@
 #include "forte_real.h"
 #include "forte_sint.h"
 #include "forte_string.h"
-#include "forte_struct.h"
 #include "forte_time.h"
 #include "forte_time_of_day.h"
 #include "forte_udint.h"
@@ -119,6 +115,10 @@ class CIEC_ANY_ELEMENTARY_VARIANT : public CIEC_ANY_ELEMENTARY, public TIecAnyEl
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_int.h
+++ b/src/core/datatypes/forte_any_int.h
@@ -28,6 +28,10 @@ class CIEC_ANY_INT : public CIEC_ANY_NUM {
 
     ~CIEC_ANY_INT() override = default;
 
+    void reset() override {
+      setLargestInt(0);
+    }
+
     bool isSigned() const {
       return e_LINT >= getDataTypeID();
     }

--- a/src/core/datatypes/forte_any_int_variant.h
+++ b/src/core/datatypes/forte_any_int_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -71,6 +70,10 @@ class CIEC_ANY_INT_VARIANT : public CIEC_ANY_INT, public TIecAnyIntVariantType {
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_magnitude.h
+++ b/src/core/datatypes/forte_any_magnitude.h
@@ -16,7 +16,6 @@
 #define _ANY_MAG_H_
 
 #include "forte_any_elementary.h"
-#include "devlog.h"
 
 /*!\ingroup COREDTS CIEC_ANY_MAGNITUDE represents the magnitude data types according to
  *  IEC 61131.

--- a/src/core/datatypes/forte_any_magnitude_variant.h
+++ b/src/core/datatypes/forte_any_magnitude_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -81,6 +80,10 @@ class CIEC_ANY_MAGNITUDE_VARIANT : public CIEC_ANY_MAGNITUDE, public TIecAnyMagn
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_num_variant.h
+++ b/src/core/datatypes/forte_any_num_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -76,6 +75,10 @@ class CIEC_ANY_NUM_VARIANT : public CIEC_ANY_NUM, public TIecAnyNumVariantType {
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_real_variant.h
+++ b/src/core/datatypes/forte_any_real_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -57,6 +56,10 @@ class CIEC_ANY_REAL_VARIANT : public CIEC_ANY_REAL, public TIecAnyRealVariantTyp
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_signed_variant.h
+++ b/src/core/datatypes/forte_any_signed_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -63,6 +62,10 @@ class CIEC_ANY_SIGNED_VARIANT : public CIEC_ANY_SIGNED, public TIecAnySignedVari
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_string.cpp
+++ b/src/core/datatypes/forte_any_string.cpp
@@ -17,6 +17,7 @@
 #include <fortenew.h>
 #include "forte_any_string.h"
 #include "unicode_utils.h"
+#include "string_utils.h"
 #include <string.h>
 #include <stdlib.h>
 #include <devlog.h>

--- a/src/core/datatypes/forte_any_string.h
+++ b/src/core/datatypes/forte_any_string.h
@@ -38,6 +38,10 @@ class CIEC_ANY_STRING : public CIEC_ANY_CHARS {
       return *this;
     }
 
+    void reset() override {
+      clear();
+    }
+
     /*! \brief Get-Method for CIEC_ANY_STRING
      *
      *   With this command the value of the actual object can be read.

--- a/src/core/datatypes/forte_any_string_variant.h
+++ b/src/core/datatypes/forte_any_string_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -56,6 +55,10 @@ class CIEC_ANY_STRING_VARIANT : public CIEC_ANY_STRING, public TIecAnyStringVari
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_unsigned_variant.h
+++ b/src/core/datatypes/forte_any_unsigned_variant.h
@@ -14,15 +14,10 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
 #include "forte_any_unsigned.h"
-#include "forte_dint.h"
-#include "forte_int.h"
-#include "forte_lint.h"
-#include "forte_sint.h"
 #include "forte_udint.h"
 #include "forte_uint.h"
 #include "forte_ulint.h"
@@ -67,6 +62,10 @@ class CIEC_ANY_UNSIGNED_VARIANT : public CIEC_ANY_UNSIGNED, public TIecAnyUnsign
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_any_variant.h
+++ b/src/core/datatypes/forte_any_variant.h
@@ -14,7 +14,6 @@
  *******************************************************************************/
 #pragma once
 
-#include <memory>
 #include <variant>
 
 #include "forte_any.h"
@@ -122,6 +121,10 @@ class CIEC_ANY_VARIANT : public CIEC_ANY, public TIecAnyVariantType {
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      unwrap().reset();
+    }
 
     bool setDefaultValue(CIEC_ANY::EDataTypeID paDataTypeId);
 

--- a/src/core/datatypes/forte_array.cpp
+++ b/src/core/datatypes/forte_array.cpp
@@ -25,10 +25,9 @@
  *******************************************************************************/
 
 #include "forte_array.h"
+#include "forte_ulint.h"
 
 USE_STRING_ID(ARRAY);
-
-#include "forte_ulint.h"
 
 CStringDictionary::TStringId CIEC_ARRAY::getTypeNameID() const {
   return STRID(ARRAY);
@@ -37,6 +36,12 @@ CStringDictionary::TStringId CIEC_ARRAY::getTypeNameID() const {
 void CIEC_ARRAY::setValue(const CIEC_ANY &paValue) {
   if (paValue.getDataTypeID() == CIEC_ANY::e_ARRAY) {
     operator=(static_cast<const CIEC_ARRAY &>(paValue));
+  }
+}
+
+void CIEC_ARRAY::reset() {
+  for (intmax_t i = getLowerBound(), end = getUpperBound(); i <= end; ++i) {
+    operator[](i).reset();
   }
 }
 

--- a/src/core/datatypes/forte_array.h
+++ b/src/core/datatypes/forte_array.h
@@ -18,8 +18,6 @@
 #pragma once
 
 #include <stddef.h>
-#include <inttypes.h>
-#include <initializer_list>
 
 #include "forte_any_derived.h"
 #include "forte_any_int.h"
@@ -109,6 +107,8 @@ class CIEC_ARRAY : public CIEC_ANY_DERIVED {
     CStringDictionary::TStringId getTypeNameID() const override;
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override;
 
     [[nodiscard]] bool equals(const CIEC_ANY &paOther) const override {
       if (paOther.getDataTypeID() == CIEC_ANY::e_ARRAY) {

--- a/src/core/datatypes/forte_array_fixed.h
+++ b/src/core/datatypes/forte_array_fixed.h
@@ -20,8 +20,6 @@
 #include "forte_array_common.h"
 #include <array>
 #include <algorithm>
-#include "devlog.h"
-
 #include "forte_ulint.h"
 
 template<typename T>
@@ -114,6 +112,12 @@ class CIEC_ARRAY_FIXED : public CIEC_ARRAY_COMMON<T> {
              std::enable_if_t<std::is_assignable_v<T &, const U &>, bool> = true>
     CIEC_ARRAY_FIXED(const CIEC_ARRAY_FIXED<U, sourceLowerBound, sourceUpperBound> &paSource) {
       assign(paSource, sourceLowerBound, sourceUpperBound);
+    }
+
+    void reset() override {
+      for (iterator it = begin(); it != end(); ++it) {
+        it->reset();
+      }
     }
 
     /**
@@ -270,7 +274,7 @@ class CIEC_ARRAY_FIXED : public CIEC_ARRAY_COMMON<T> {
       return nRetVal;
     }
 
-    ~CIEC_ARRAY_FIXED() = default;
+    ~CIEC_ARRAY_FIXED() override = default;
 
   private:
     template<typename U>

--- a/src/core/datatypes/forte_char.cpp
+++ b/src/core/datatypes/forte_char.cpp
@@ -13,6 +13,7 @@
  *   Alois Zoitl - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte_char.h"
+#include "string_utils.h"
 
 USE_STRING_ID(CHAR);
 

--- a/src/core/datatypes/forte_char.h
+++ b/src/core/datatypes/forte_char.h
@@ -62,7 +62,7 @@ class CIEC_CHAR : public CIEC_ANY_CHAR {
 
     int fromString(const char *paValue) override;
 
-    EDataTypeID getDataTypeID() const override final {
+    EDataTypeID getDataTypeID() const final {
       return CIEC_ANY::e_CHAR;
     }
 };

--- a/src/core/datatypes/forte_date_and_time.cpp
+++ b/src/core/datatypes/forte_date_and_time.cpp
@@ -19,6 +19,8 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte_date_and_time.h"
+#include "forte_architecture_time.h"
+#include "string_utils.h"
 
 USE_STRING_ID(DATE_AND_TIME);
 

--- a/src/core/datatypes/forte_date_and_time.h
+++ b/src/core/datatypes/forte_date_and_time.h
@@ -21,7 +21,6 @@
 #define _FORTE_DATE_AND_TIME_H_
 
 #include "forte_any_date.h"
-#include <forte_architecture_time.h>
 
 /*!\ingroup COREDTS CIEC_DATE_AND_TIME represents the time data types according to IEC 61131.
  */

--- a/src/core/datatypes/forte_ldate.cpp
+++ b/src/core/datatypes/forte_ldate.cpp
@@ -22,7 +22,7 @@
 
 USE_STRING_ID(LDATE);
 
-#include <forte_architecture_time.h>
+#include "forte_architecture_time.h"
 
 DEFINE_FIRMWARE_DATATYPE(LDATE, STRID(LDATE))
 

--- a/src/core/datatypes/forte_ldate_and_time.cpp
+++ b/src/core/datatypes/forte_ldate_and_time.cpp
@@ -19,6 +19,8 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte_ldate_and_time.h"
+#include "forte_architecture_time.h"
+#include "string_utils.h"
 
 USE_STRING_ID(LDATE_AND_TIME);
 

--- a/src/core/datatypes/forte_ldate_and_time.h
+++ b/src/core/datatypes/forte_ldate_and_time.h
@@ -21,8 +21,6 @@
 #define _FORTE_LDATE_AND_TIME_H_
 
 #include "forte_any_date.h"
-#include <forte_architecture_time.h>
-
 #include "forte_date_and_time.h"
 
 /*!\ingroup COREDTS CIEC_DATE_AND_TIME represents the time data types according to IEC 61131.

--- a/src/core/datatypes/forte_lreal.cpp
+++ b/src/core/datatypes/forte_lreal.cpp
@@ -20,12 +20,13 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "forte_lreal.h"
-
-USE_STRING_ID(LREAL);
-
 #include "forte_real.h"
 #include "forte_lint.h"
 #include "forte_ulint.h"
+#include "forte_string.h"
+#include "forte_wstring.h"
+
+USE_STRING_ID(LREAL);
 
 DEFINE_FIRMWARE_DATATYPE(LREAL, STRID(LREAL))
 

--- a/src/core/datatypes/forte_lreal.h
+++ b/src/core/datatypes/forte_lreal.h
@@ -148,6 +148,10 @@ class CIEC_LREAL final : public CIEC_ANY_REAL {
 
     void setValue(const CIEC_ANY &paValue) override;
 
+    void reset() override {
+      setTDFLOAT(0.0);
+    }
+
     /*! \brief Converts string value to data type value
      *
      *   This command implements a conversion function from IEC 61131

--- a/src/core/datatypes/forte_ltime.cpp
+++ b/src/core/datatypes/forte_ltime.cpp
@@ -19,6 +19,7 @@
  *******************************************************************************/
 #include "forte_ltime.h"
 #include "forte_constants.h"
+#include "string_utils.h"
 
 USE_STRING_ID(LTIME);
 

--- a/src/core/datatypes/forte_ltime_of_day.cpp
+++ b/src/core/datatypes/forte_ltime_of_day.cpp
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte_ltime_of_day.h"
+#include "string_utils.h"
 
 USE_STRING_ID(LTIME_OF_DAY);
 

--- a/src/core/datatypes/forte_ltime_of_day.h
+++ b/src/core/datatypes/forte_ltime_of_day.h
@@ -22,7 +22,7 @@
 #define _FORTE_LTOD_H_
 
 #include "forte_any_date.h"
-#include <forte_architecture_time.h>
+#include "forte_architecture_time.h"
 
 #include "forte_time_of_day.h"
 

--- a/src/core/datatypes/forte_real.cpp
+++ b/src/core/datatypes/forte_real.cpp
@@ -21,12 +21,13 @@
 #include <cstdio>
 #include <format>
 #include "forte_real.h"
-
-USE_STRING_ID(REAL);
-
 #include "forte_lreal.h"
 #include "forte_lint.h"
 #include "forte_ulint.h"
+#include "forte_string.h"
+#include "forte_wstring.h"
+
+USE_STRING_ID(REAL);
 
 DEFINE_FIRMWARE_DATATYPE(REAL, STRID(REAL))
 

--- a/src/core/datatypes/forte_real.h
+++ b/src/core/datatypes/forte_real.h
@@ -24,8 +24,6 @@
 
 #include "forte_any_real.h"
 
-#include "forte_string.h"
-#include "forte_wstring.h"
 #include "forte_int.h"
 #include "forte_sint.h"
 #include "forte_uint.h"
@@ -112,6 +110,10 @@ class CIEC_REAL final : public CIEC_ANY_REAL {
     }
 
     void setValue(const CIEC_ANY &paValue) override;
+
+    void reset() override {
+      setTFLOAT(0.0f);
+    }
 
     EDataTypeID getDataTypeID() const override {
       return CIEC_ANY::e_REAL;

--- a/src/core/datatypes/forte_string.cpp
+++ b/src/core/datatypes/forte_string.cpp
@@ -20,14 +20,14 @@
 #include "forte_string.h"
 #include <cstddef>
 #include "datatype.h"
-
-USE_STRING_ID(STRING);
-
 #include <devlog.h>
 #include "unicode_utils.h"
 #include <string_view>
 #include <charconv>
 #include "../../arch/forte_fileio.h"
+#include "string_utils.h"
+
+USE_STRING_ID(STRING);
 
 using namespace std::string_literals;
 

--- a/src/core/datatypes/forte_struct.cpp
+++ b/src/core/datatypes/forte_struct.cpp
@@ -39,7 +39,7 @@ CIEC_ANY *CIEC_STRUCT::getMemberNamed(const char *paMemberName) {
 
 size_t CIEC_STRUCT::getMemberIndex(CStringDictionary::TStringId paMemberNameId) {
   const CStringDictionary::TStringId *punMemberNameIds = elementNames();
-  for (size_t i = 0; i < getStructSize(); ++i) {
+  for (size_t i = 0, structSize = getStructSize(); i < structSize; ++i) {
     if (punMemberNameIds[i] == paMemberNameId) {
       return i;
     }
@@ -51,11 +51,16 @@ void CIEC_STRUCT::setValue(const CIEC_ANY &paValue) {
   if (paValue.getDataTypeID() == e_STRUCT) {
     auto &otherStruct = static_cast<const CIEC_STRUCT &>(paValue);
     if (getStructTypeNameID() == otherStruct.getStructTypeNameID()) {
-      size_t structSize = getStructSize();
-      for (size_t i = 0; i < structSize; ++i) {
+      for (size_t i = 0, structSize = getStructSize(); i < structSize; ++i) {
         getMember(i)->setValue(*otherStruct.getMember(i));
       }
     }
+  }
+}
+
+void CIEC_STRUCT::reset() {
+  for (size_t i = 0, structSize = getStructSize(); i < structSize; ++i) {
+    getMember(i)->reset();
   }
 }
 
@@ -144,7 +149,7 @@ bool CIEC_STRUCT::equals(const CIEC_ANY &paOther) const {
   if (paOther.getDataTypeID() == CIEC_ANY::e_STRUCT) {
     auto &otherStruct = static_cast<const CIEC_STRUCT &>(paOther);
     if (getStructTypeNameID() == otherStruct.getStructTypeNameID()) {
-      for (size_t i = 0; i < getStructSize(); ++i) {
+      for (size_t i = 0, structSize = getStructSize(); i < structSize; ++i) {
         if (!getMember(i)->equals(*otherStruct.getMember(i))) {
           return false;
         }

--- a/src/core/datatypes/forte_struct.h
+++ b/src/core/datatypes/forte_struct.h
@@ -33,7 +33,7 @@ class CIEC_STRUCT : public CIEC_ANY_DERIVED {
 
   public:
     //! Indicator for invalid array member index positions
-    static constexpr size_t csmNIndex = -1;
+    static constexpr size_t csmNIndex = static_cast<size_t>(-1);
 
     CIEC_STRUCT() = default;
 
@@ -79,7 +79,9 @@ class CIEC_STRUCT : public CIEC_ANY_DERIVED {
 
     void setValue(const CIEC_ANY &paValue) override;
 
-    EDataTypeID getDataTypeID() const override final {
+    void reset() override;
+
+    EDataTypeID getDataTypeID() const final {
       return CIEC_ANY::e_STRUCT;
     }
 

--- a/src/core/datatypes/forte_time.cpp
+++ b/src/core/datatypes/forte_time.cpp
@@ -18,11 +18,11 @@
  *******************************************************************************/
 #include "forte_time.h"
 #include <string_view>
-
-USE_STRING_ID(TIME);
-
 #include "../../arch/timerha.h"
 #include "forte_constants.h"
+#include "string_utils.h"
+
+USE_STRING_ID(TIME);
 
 using namespace std::literals::string_literals;
 

--- a/src/core/datatypes/forte_time_of_day.cpp
+++ b/src/core/datatypes/forte_time_of_day.cpp
@@ -19,6 +19,8 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte_time_of_day.h"
+#include "forte_architecture_time.h"
+#include "string_utils.h"
 
 USE_STRING_ID(TIME_OF_DAY);
 

--- a/src/core/datatypes/forte_time_of_day.h
+++ b/src/core/datatypes/forte_time_of_day.h
@@ -23,7 +23,6 @@
 #define _FORTE_TOD_H_
 
 #include "forte_any_date.h"
-#include <forte_architecture_time.h>
 
 /*!\ingroup COREDTS CIEC_TIME_OF_DAY represents the time data types according to IEC 61131.
  */

--- a/src/core/datatypes/forte_wchar.cpp
+++ b/src/core/datatypes/forte_wchar.cpp
@@ -15,6 +15,7 @@
 #include "forte_wchar.h"
 #include <cstdint>
 #include <format>
+#include "string_utils.h"
 
 USE_STRING_ID(WCHAR);
 

--- a/src/core/datatypes/forte_wstring.h
+++ b/src/core/datatypes/forte_wstring.h
@@ -26,7 +26,6 @@
 #define _FORTE_WSTRING_H_
 
 #include "forte_any_string.h"
-#include "forte_string.h"
 #include "forte_wchar.h"
 
 #include <codecvt>

--- a/src/core/funcbloc.cpp
+++ b/src/core/funcbloc.cpp
@@ -31,6 +31,7 @@
 #include "adapter.h"
 #include "adapterconn.h"
 #include "device.h"
+#include "string_utils.h"
 
 using namespace std::string_literals;
 

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -32,6 +32,7 @@ USE_STRING_ID(START);
 #include "core/ecetFactory.h"
 #include "device.h"
 #include "negdataconn.h"
+#include "string_utils.h"
 
 #ifdef FORTE_DYNAMIC_TYPE_LOAD
 #include "lua/luaadaptertypeentry.h"

--- a/src/core/typelib.cpp
+++ b/src/core/typelib.cpp
@@ -20,6 +20,7 @@
 #include "adapterconn.h"
 #include "adapter.h"
 #include <stddef.h>
+#include "string_utils.h"
 
 USE_STRING_ID(ARRAY);
 

--- a/src/modules/IEC61131-3/Arithmetic/F_ADD_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_ADD_fbt.cpp
@@ -159,7 +159,7 @@ CDataConnection *FORTE_F_ADD::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_ADD::setInitialValues() {
-  var_IN1 = CIEC_ANY_MAGNITUDE_VARIANT();
-  var_IN2 = CIEC_ANY_MAGNITUDE_VARIANT();
-  var_OUT = CIEC_ANY_MAGNITUDE_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_DIVTIME_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_DIVTIME_fbt.cpp
@@ -148,6 +148,6 @@ CDataConnection *FORTE_F_DIVTIME::getDOConUnchecked(TPortId paIndex) {
 
 void FORTE_F_DIVTIME::setInitialValues() {
   var_IN1 = CIEC_TIME();
-  var_IN2 = CIEC_ANY_NUM_VARIANT();
+  var_IN2.reset();
   var_OUT = CIEC_TIME();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_DIV_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_DIV_fbt.cpp
@@ -156,7 +156,7 @@ CDataConnection *FORTE_F_DIV::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_DIV::setInitialValues() {
-  var_IN1 = CIEC_ANY_NUM_VARIANT();
-  var_IN2 = CIEC_ANY_NUM_VARIANT();
-  var_OUT = CIEC_ANY_NUM_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_EXPT_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_EXPT_fbt.cpp
@@ -147,7 +147,7 @@ CDataConnection *FORTE_F_EXPT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_EXPT::setInitialValues() {
-  var_IN1 = CIEC_ANY_REAL_VARIANT();
-  var_IN2 = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_MOD_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MOD_fbt.cpp
@@ -157,7 +157,7 @@ CDataConnection *FORTE_F_MOD::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_MOD::setInitialValues() {
-  var_IN1 = CIEC_ANY_INT_VARIANT();
-  var_IN2 = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_NUM_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_MOVE_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MOVE_fbt.cpp
@@ -139,6 +139,6 @@ CDataConnection *FORTE_F_MOVE::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_MOVE::setInitialValues() {
-  var_IN = CIEC_ANY_VARIANT();
-  var_OUT = CIEC_ANY_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_MULTIME_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MULTIME_fbt.cpp
@@ -149,6 +149,6 @@ CDataConnection *FORTE_F_MULTIME::getDOConUnchecked(TPortId paIndex) {
 
 void FORTE_F_MULTIME::setInitialValues() {
   var_IN1 = CIEC_TIME();
-  var_IN2 = CIEC_ANY_NUM_VARIANT();
+  var_IN2.reset();
   var_OUT = CIEC_TIME();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_MUL_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_MUL_fbt.cpp
@@ -156,7 +156,7 @@ CDataConnection *FORTE_F_MUL::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_MUL::setInitialValues() {
-  var_IN1 = CIEC_ANY_NUM_VARIANT();
-  var_IN2 = CIEC_ANY_NUM_VARIANT();
-  var_OUT = CIEC_ANY_NUM_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_SUB_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_SUB_fbt.cpp
@@ -157,7 +157,7 @@ CDataConnection *FORTE_F_SUB::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_SUB::setInitialValues() {
-  var_IN1 = CIEC_ANY_MAGNITUDE_VARIANT();
-  var_IN2 = CIEC_ANY_MAGNITUDE_VARIANT();
-  var_OUT = CIEC_ANY_MAGNITUDE_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Arithmetic/F_TRUNC_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/F_TRUNC_fbt.cpp
@@ -147,6 +147,6 @@ CDataConnection *FORTE_F_TRUNC::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_TRUNC::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_INT_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
@@ -17,6 +17,8 @@
  *******************************************************************************/
 
 #include "GEN_ADD_fbt.h"
+#include "ifSpecBuilder.h"
+#include "string_utils.h"
 
 USE_STRING_ID(ANY_MAGNITUDE);
 USE_STRING_ID(CNF);
@@ -24,11 +26,6 @@ USE_STRING_ID(Event);
 USE_STRING_ID(GEN_ADD);
 USE_STRING_ID(OUT);
 USE_STRING_ID(REQ);
-
-#include <ctype.h>
-#include <stdio.h>
-#include "ifSpecBuilder.h"
-#include "forte_printer.h"
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_ADD, STRID(GEN_ADD))
 

--- a/src/modules/IEC61131-3/BitwiseOperators/F_AND_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_AND_fbt.cpp
@@ -146,7 +146,7 @@ CDataConnection *FORTE_F_AND::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_AND::setInitialValues() {
-  var_IN1 = CIEC_ANY_BIT_VARIANT();
-  var_IN2 = CIEC_ANY_BIT_VARIANT();
-  var_OUT = CIEC_ANY_BIT_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_NOT_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_NOT_fbt.cpp
@@ -139,6 +139,6 @@ CDataConnection *FORTE_F_NOT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_NOT::setInitialValues() {
-  var_IN = CIEC_ANY_BIT_VARIANT();
-  var_OUT = CIEC_ANY_BIT_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_OR_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_OR_fbt.cpp
@@ -146,7 +146,7 @@ CDataConnection *FORTE_F_OR::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_OR::setInitialValues() {
-  var_IN1 = CIEC_ANY_BIT_VARIANT();
-  var_IN2 = CIEC_ANY_BIT_VARIANT();
-  var_OUT = CIEC_ANY_BIT_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_ROL_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_ROL_fbt.cpp
@@ -155,7 +155,7 @@ CDataConnection *FORTE_F_ROL::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_ROL::setInitialValues() {
-  var_IN = CIEC_ANY_BIT_VARIANT();
-  var_N = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_BIT_VARIANT();
+  var_IN.reset();
+  var_N.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_ROR_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_ROR_fbt.cpp
@@ -155,7 +155,7 @@ CDataConnection *FORTE_F_ROR::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_ROR::setInitialValues() {
-  var_IN = CIEC_ANY_BIT_VARIANT();
-  var_N = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_BIT_VARIANT();
+  var_IN.reset();
+  var_N.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_SHL_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_SHL_fbt.cpp
@@ -155,7 +155,7 @@ CDataConnection *FORTE_F_SHL::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_SHL::setInitialValues() {
-  var_IN = CIEC_ANY_BIT_VARIANT();
-  var_N = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_BIT_VARIANT();
+  var_IN.reset();
+  var_N.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_SHR_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_SHR_fbt.cpp
@@ -155,7 +155,7 @@ CDataConnection *FORTE_F_SHR::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_SHR::setInitialValues() {
-  var_IN = CIEC_ANY_BIT_VARIANT();
-  var_N = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_BIT_VARIANT();
+  var_IN.reset();
+  var_N.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/BitwiseOperators/F_XOR_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/F_XOR_fbt.cpp
@@ -146,7 +146,7 @@ CDataConnection *FORTE_F_XOR::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_XOR::setInitialValues() {
-  var_IN1 = CIEC_ANY_BIT_VARIANT();
-  var_IN2 = CIEC_ANY_BIT_VARIANT();
-  var_OUT = CIEC_ANY_BIT_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -15,15 +15,13 @@
  *     - add generic readInputData and writeOutputData
  *******************************************************************************/
 #include "genbitbase_fbt.h"
+#include "forte_printer.h"
+#include "string_utils.h"
 
 USE_STRING_ID(ANY_BIT);
 USE_STRING_ID(CNF);
 USE_STRING_ID(OUT);
 USE_STRING_ID(REQ);
-
-#include <ctype.h>
-#include <stdio.h>
-#include "forte_printer.h"
 
 const CStringDictionary::TStringId CGenBitBase::scmDataOutputNames[] = {STRID(OUT)};
 const CStringDictionary::TStringId CGenBitBase::scmDataOutputTypeIds[] = {STRID(ANY_BIT)};

--- a/src/modules/IEC61131-3/CharacterString/F_CONCAT_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_CONCAT_fbt.cpp
@@ -157,7 +157,7 @@ CDataConnection *FORTE_F_CONCAT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_CONCAT::setInitialValues() {
-  var_IN1 = CIEC_ANY_STRING_VARIANT();
-  var_IN2 = CIEC_ANY_STRING_VARIANT();
-  var_OUT = CIEC_ANY_STRING_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/CharacterString/F_DELETE_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_DELETE_fbt.cpp
@@ -156,8 +156,8 @@ CDataConnection *FORTE_F_DELETE::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_DELETE::setInitialValues() {
-  var_IN = CIEC_ANY_STRING_VARIANT();
-  var_L = CIEC_ANY_INT_VARIANT();
-  var_P = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_STRING_VARIANT();
+  var_IN.reset();
+  var_L.reset();
+  var_P.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/CharacterString/F_FIND_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_FIND_fbt.cpp
@@ -163,7 +163,7 @@ CDataConnection *FORTE_F_FIND::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_FIND::setInitialValues() {
-  var_IN1 = CIEC_ANY_STRING_VARIANT();
-  var_IN2 = CIEC_ANY_STRING_VARIANT();
-  var_OUT = CIEC_ANY_INT_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/CharacterString/F_INSERT_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_INSERT_fbt.cpp
@@ -166,8 +166,8 @@ CDataConnection *FORTE_F_INSERT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_INSERT::setInitialValues() {
-  var_IN1 = CIEC_ANY_STRING_VARIANT();
-  var_IN2 = CIEC_ANY_STRING_VARIANT();
-  var_P = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_STRING_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_P.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/CharacterString/F_LEFT_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_LEFT_fbt.cpp
@@ -148,7 +148,7 @@ CDataConnection *FORTE_F_LEFT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_LEFT::setInitialValues() {
-  var_IN = CIEC_ANY_STRING_VARIANT();
-  var_L = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_STRING_VARIANT();
+  var_IN.reset();
+  var_L.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/CharacterString/F_LEN_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_LEN_fbt.cpp
@@ -142,6 +142,6 @@ CDataConnection *FORTE_F_LEN::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_LEN::setInitialValues() {
-  var_IN = CIEC_ANY_STRING_VARIANT();
-  var_OUT = CIEC_ANY_INT_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/CharacterString/F_MID_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_MID_fbt.cpp
@@ -155,8 +155,8 @@ CDataConnection *FORTE_F_MID::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_MID::setInitialValues() {
-  var_IN = CIEC_ANY_STRING_VARIANT();
-  var_L = CIEC_ANY_INT_VARIANT();
-  var_P = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_STRING_VARIANT();
+  var_IN.reset();
+  var_L.reset();
+  var_P.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/CharacterString/F_REPLACE_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_REPLACE_fbt.cpp
@@ -172,9 +172,9 @@ CDataConnection *FORTE_F_REPLACE::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_REPLACE::setInitialValues() {
-  var_IN1 = CIEC_ANY_STRING_VARIANT();
-  var_IN2 = CIEC_ANY_STRING_VARIANT();
-  var_L = CIEC_ANY_INT_VARIANT();
-  var_P = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_STRING_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_L.reset();
+  var_P.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/CharacterString/F_RIGHT_fbt.cpp
+++ b/src/modules/IEC61131-3/CharacterString/F_RIGHT_fbt.cpp
@@ -148,7 +148,7 @@ CDataConnection *FORTE_F_RIGHT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_RIGHT::setInitialValues() {
-  var_IN = CIEC_ANY_STRING_VARIANT();
-  var_L = CIEC_ANY_INT_VARIANT();
-  var_OUT = CIEC_ANY_STRING_VARIANT();
+  var_IN.reset();
+  var_L.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Comparison/F_EQ_fbt.cpp
+++ b/src/modules/IEC61131-3/Comparison/F_EQ_fbt.cpp
@@ -145,7 +145,7 @@ CDataConnection *FORTE_F_EQ::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_EQ::setInitialValues() {
-  var_IN1 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN2 = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
   var_OUT = CIEC_BOOL(0);
 }

--- a/src/modules/IEC61131-3/Comparison/F_GE_fbt.cpp
+++ b/src/modules/IEC61131-3/Comparison/F_GE_fbt.cpp
@@ -145,7 +145,7 @@ CDataConnection *FORTE_F_GE::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_GE::setInitialValues() {
-  var_IN1 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN2 = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
   var_OUT = CIEC_BOOL(0);
 }

--- a/src/modules/IEC61131-3/Comparison/F_GT_fbt.cpp
+++ b/src/modules/IEC61131-3/Comparison/F_GT_fbt.cpp
@@ -145,7 +145,7 @@ CDataConnection *FORTE_F_GT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_GT::setInitialValues() {
-  var_IN1 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN2 = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
   var_OUT = CIEC_BOOL(0);
 }

--- a/src/modules/IEC61131-3/Comparison/F_LE_fbt.cpp
+++ b/src/modules/IEC61131-3/Comparison/F_LE_fbt.cpp
@@ -145,7 +145,7 @@ CDataConnection *FORTE_F_LE::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_LE::setInitialValues() {
-  var_IN1 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN2 = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
   var_OUT = CIEC_BOOL(0);
 }

--- a/src/modules/IEC61131-3/Comparison/F_LT_fbt.cpp
+++ b/src/modules/IEC61131-3/Comparison/F_LT_fbt.cpp
@@ -145,7 +145,7 @@ CDataConnection *FORTE_F_LT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_LT::setInitialValues() {
-  var_IN1 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN2 = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
   var_OUT = CIEC_BOOL(0);
 }

--- a/src/modules/IEC61131-3/Comparison/F_NE_fbt.cpp
+++ b/src/modules/IEC61131-3/Comparison/F_NE_fbt.cpp
@@ -145,7 +145,7 @@ CDataConnection *FORTE_F_NE::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_NE::setInitialValues() {
-  var_IN1 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN2 = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
   var_OUT = CIEC_BOOL(0);
 }

--- a/src/modules/IEC61131-3/Conversion/F_ANY_AS_STRING_fbt.cpp
+++ b/src/modules/IEC61131-3/Conversion/F_ANY_AS_STRING_fbt.cpp
@@ -72,7 +72,7 @@ FORTE_F_ANY_AS_STRING::FORTE_F_ANY_AS_STRING(const CStringDictionary::TStringId 
 }
 
 void FORTE_F_ANY_AS_STRING::setInitialValues() {
-  var_IN = CIEC_ANY_VARIANT();
+  var_IN.reset();
   var_OUT = ""_STRING;
 }
 

--- a/src/modules/IEC61131-3/Numerical/F_ABS_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_ABS_fbt.cpp
@@ -140,6 +140,6 @@ CDataConnection *FORTE_F_ABS::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_ABS::setInitialValues() {
-  var_IN = CIEC_ANY_NUM_VARIANT();
-  var_OUT = CIEC_ANY_NUM_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_ACOS_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_ACOS_fbt.cpp
@@ -140,6 +140,6 @@ CDataConnection *FORTE_F_ACOS::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_ACOS::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_ASIN_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_ASIN_fbt.cpp
@@ -140,6 +140,6 @@ CDataConnection *FORTE_F_ASIN::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_ASIN::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_ATAN_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_ATAN_fbt.cpp
@@ -140,6 +140,6 @@ CDataConnection *FORTE_F_ATAN::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_ATAN::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_COS_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_COS_fbt.cpp
@@ -139,6 +139,6 @@ CDataConnection *FORTE_F_COS::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_COS::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_EXP_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_EXP_fbt.cpp
@@ -139,6 +139,6 @@ CDataConnection *FORTE_F_EXP::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_EXP::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_LN_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_LN_fbt.cpp
@@ -139,6 +139,6 @@ CDataConnection *FORTE_F_LN::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_LN::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_LOG_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_LOG_fbt.cpp
@@ -139,6 +139,6 @@ CDataConnection *FORTE_F_LOG::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_LOG::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_SIN_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_SIN_fbt.cpp
@@ -139,6 +139,6 @@ CDataConnection *FORTE_F_SIN::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_SIN::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_SQRT_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_SQRT_fbt.cpp
@@ -140,6 +140,6 @@ CDataConnection *FORTE_F_SQRT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_SQRT::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Numerical/F_TAN_fbt.cpp
+++ b/src/modules/IEC61131-3/Numerical/F_TAN_fbt.cpp
@@ -139,6 +139,6 @@ CDataConnection *FORTE_F_TAN::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_TAN::setInitialValues() {
-  var_IN = CIEC_ANY_REAL_VARIANT();
-  var_OUT = CIEC_ANY_REAL_VARIANT();
+  var_IN.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Selection/F_LIMIT_fbt.cpp
+++ b/src/modules/IEC61131-3/Selection/F_LIMIT_fbt.cpp
@@ -152,8 +152,8 @@ CDataConnection *FORTE_F_LIMIT::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_LIMIT::setInitialValues() {
-  var_MN = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_MX = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_OUT = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_MN.reset();
+  var_IN.reset();
+  var_MX.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Selection/F_MAX_fbt.cpp
+++ b/src/modules/IEC61131-3/Selection/F_MAX_fbt.cpp
@@ -144,7 +144,7 @@ CDataConnection *FORTE_F_MAX::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_MAX::setInitialValues() {
-  var_IN1 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN2 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_OUT = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Selection/F_MIN_fbt.cpp
+++ b/src/modules/IEC61131-3/Selection/F_MIN_fbt.cpp
@@ -144,7 +144,7 @@ CDataConnection *FORTE_F_MIN::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_MIN::setInitialValues() {
-  var_IN1 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_IN2 = CIEC_ANY_ELEMENTARY_VARIANT();
-  var_OUT = CIEC_ANY_ELEMENTARY_VARIANT();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Selection/F_MUX_2_fbt.cpp
+++ b/src/modules/IEC61131-3/Selection/F_MUX_2_fbt.cpp
@@ -164,8 +164,8 @@ CDataConnection *FORTE_F_MUX_2::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_F_MUX_2::setInitialValues() {
-  var_K = CIEC_ANY_INT_VARIANT();
-  var_IN1 = CIEC_ANY_VARIANT();
-  var_IN2 = CIEC_ANY_VARIANT();
-  var_OUT = CIEC_ANY_VARIANT();
+  var_K.reset();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }

--- a/src/modules/IEC61131-3/Selection/F_SEL_fbt.cpp
+++ b/src/modules/IEC61131-3/Selection/F_SEL_fbt.cpp
@@ -152,7 +152,7 @@ CDataConnection *FORTE_F_SEL::getDOConUnchecked(TPortId paIndex) {
 
 void FORTE_F_SEL::setInitialValues() {
   var_G = CIEC_BOOL(0);
-  var_IN0 = CIEC_ANY_VARIANT();
-  var_IN1 = CIEC_ANY_VARIANT();
-  var_OUT = CIEC_ANY_VARIANT();
+  var_IN0.reset();
+  var_IN1.reset();
+  var_OUT.reset();
 }

--- a/src/modules/rt_events/RT_Bridge_fbt.cpp
+++ b/src/modules/rt_events/RT_Bridge_fbt.cpp
@@ -14,6 +14,7 @@
 #include "RT_Bridge_fbt.h"
 #include "ifSpecBuilder.h"
 #include "criticalregion.h"
+#include "string_utils.h"
 
 USE_STRING_ID(ANY);
 USE_STRING_ID(Event);

--- a/src/modules/utils/GEN_ARRAY2ARRAY_fbt.cpp
+++ b/src/modules/utils/GEN_ARRAY2ARRAY_fbt.cpp
@@ -16,6 +16,7 @@
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
 #include "GEN_ARRAY2ARRAY_fbt.h"
+#include "string_utils.h"
 
 USE_STRING_ID(ARRAY);
 USE_STRING_ID(CNF);
@@ -24,7 +25,6 @@ USE_STRING_ID(GEN_ARRAY2ARRAY);
 USE_STRING_ID(IN);
 USE_STRING_ID(OUT);
 USE_STRING_ID(REQ);
-
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_ARRAY2ARRAY, STRID(GEN_ARRAY2ARRAY))
 

--- a/src/modules/utils/GEN_ARRAY2VALUES_fbt.cpp
+++ b/src/modules/utils/GEN_ARRAY2VALUES_fbt.cpp
@@ -17,6 +17,8 @@
  *     - add generic readInputData and writeOutputData
  *******************************************************************************/
 #include "GEN_ARRAY2VALUES_fbt.h"
+#include "forte_printer.h"
+#include "string_utils.h"
 
 USE_STRING_ID(ARRAY);
 USE_STRING_ID(CNF);
@@ -24,9 +26,6 @@ USE_STRING_ID(Event);
 USE_STRING_ID(GEN_ARRAY2VALUES);
 USE_STRING_ID(IN);
 USE_STRING_ID(REQ);
-
-#include <stdio.h>
-#include "forte_printer.h"
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_ARRAY2VALUES, STRID(GEN_ARRAY2VALUES))
 

--- a/src/modules/utils/GEN_CSV_WRITER_fbt.cpp
+++ b/src/modules/utils/GEN_CSV_WRITER_fbt.cpp
@@ -17,6 +17,7 @@
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
 #include "GEN_CSV_WRITER_fbt.h"
+#include "string_utils.h"
 
 USE_STRING_ID(BOOL);
 USE_STRING_ID(CNF);

--- a/src/modules/utils/GEN_F_MUX_fbt.cpp
+++ b/src/modules/utils/GEN_F_MUX_fbt.cpp
@@ -16,6 +16,8 @@
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
 #include "GEN_F_MUX_fbt.h"
+#include "forte_printer.h"
+#include "string_utils.h"
 
 USE_STRING_ID(ANY);
 USE_STRING_ID(BOOL);
@@ -23,11 +25,6 @@ USE_STRING_ID(EO);
 USE_STRING_ID(Event);
 USE_STRING_ID(GEN_F_MUX);
 USE_STRING_ID(WSTRING);
-
-#include <ctype.h>
-#include <stdio.h>
-
-#include "forte_printer.h"
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_F_MUX, STRID(GEN_F_MUX));
 

--- a/src/modules/utils/GEN_VALUES2ARRAY_fbt.cpp
+++ b/src/modules/utils/GEN_VALUES2ARRAY_fbt.cpp
@@ -17,6 +17,8 @@
  *     - add generic readInputData and writeOutputData
  *******************************************************************************/
 #include "GEN_VALUES2ARRAY_fbt.h"
+#include "forte_printer.h"
+#include "string_utils.h"
 
 USE_STRING_ID(ARRAY);
 USE_STRING_ID(CNF);
@@ -24,9 +26,6 @@ USE_STRING_ID(Event);
 USE_STRING_ID(GEN_VALUES2ARRAY);
 USE_STRING_ID(OUT);
 USE_STRING_ID(REQ);
-
-#include <stdio.h>
-#include "forte_printer.h"
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_VALUES2ARRAY, STRID(GEN_VALUES2ARRAY))
 

--- a/src/modules/utils/GET_AT_INDEX_fbt.cpp
+++ b/src/modules/utils/GET_AT_INDEX_fbt.cpp
@@ -166,8 +166,8 @@ CDataConnection *FORTE_GET_AT_INDEX::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_GET_AT_INDEX::setInitialValues() {
-  var_IN_ARRAY = CIEC_ANY_VARIANT();
+  var_IN_ARRAY.reset();
   var_INDEX = 0_UINT;
   var_QO = false_BOOL;
-  var_OUT = CIEC_ANY_VARIANT();
+  var_OUT.reset();
 }

--- a/src/modules/utils/GET_STRUCT_VALUE_fbt.cpp
+++ b/src/modules/utils/GET_STRUCT_VALUE_fbt.cpp
@@ -186,8 +186,8 @@ CDataConnection *FORTE_GET_STRUCT_VALUE::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_GET_STRUCT_VALUE::setInitialValues() {
-  var_in_struct = CIEC_ANY_VARIANT();
+  var_in_struct.reset();
   var_member = "s"_STRING;
   var_QO = false_BOOL;
-  var_output = CIEC_ANY_VARIANT();
+  var_output.reset();
 }

--- a/src/modules/utils/OUT_ANY_CONSOLE_fbt.cpp
+++ b/src/modules/utils/OUT_ANY_CONSOLE_fbt.cpp
@@ -164,6 +164,6 @@ CDataConnection *FORTE_OUT_ANY_CONSOLE::getDOConUnchecked(TPortId paIndex) {
 void FORTE_OUT_ANY_CONSOLE::setInitialValues() {
   var_QI = false_BOOL;
   var_LABEL = ""_STRING;
-  var_IN = CIEC_ANY_VARIANT();
+  var_IN.reset();
   var_QO = false_BOOL;
 }

--- a/src/modules/utils/SET_AT_INDEX_fbt.cpp
+++ b/src/modules/utils/SET_AT_INDEX_fbt.cpp
@@ -175,9 +175,9 @@ CDataConnection *FORTE_SET_AT_INDEX::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_SET_AT_INDEX::setInitialValues() {
-  var_IN_ARRAY = CIEC_ANY_VARIANT();
+  var_IN_ARRAY.reset();
   var_INDEX = 0_UINT;
-  var_VALUE = CIEC_ANY_VARIANT();
+  var_VALUE.reset();
   var_QO = false_BOOL;
-  var_OUT_ARRAY = CIEC_ANY_VARIANT();
+  var_OUT_ARRAY.reset();
 }

--- a/src/modules/utils/SET_STRUCT_VALUE_fbt.cpp
+++ b/src/modules/utils/SET_STRUCT_VALUE_fbt.cpp
@@ -191,8 +191,8 @@ CDataConnection *FORTE_SET_STRUCT_VALUE::getDOConUnchecked(TPortId paIndex) {
 }
 
 void FORTE_SET_STRUCT_VALUE::setInitialValues() {
-  var_in_struct = CIEC_ANY_VARIANT();
+  var_in_struct.reset();
   var_member = ""_STRING;
-  var_element_value = CIEC_ANY_VARIANT();
-  var_out_struct = CIEC_ANY_VARIANT();
+  var_element_value.reset();
+  var_out_struct.reset();
 }

--- a/src/modules/utils/selection/F_SEL_E_2_fbt.cpp
+++ b/src/modules/utils/selection/F_SEL_E_2_fbt.cpp
@@ -72,9 +72,9 @@ FORTE_F_SEL_E_2::FORTE_F_SEL_E_2(const CStringDictionary::TStringId paInstanceNa
     conn_OUT(*this, 0, var_OUT) {};
 
 void FORTE_F_SEL_E_2::setInitialValues() {
-  var_IN0 = CIEC_ANY_VARIANT();
-  var_IN1 = CIEC_ANY_VARIANT();
-  var_OUT = CIEC_ANY_VARIANT();
+  var_IN0.reset();
+  var_IN1.reset();
+  var_OUT.reset();
 }
 
 void FORTE_F_SEL_E_2::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {

--- a/src/modules/utils/selection/F_SEL_E_3_fbt.cpp
+++ b/src/modules/utils/selection/F_SEL_E_3_fbt.cpp
@@ -76,10 +76,10 @@ FORTE_F_SEL_E_3::FORTE_F_SEL_E_3(const CStringDictionary::TStringId paInstanceNa
     conn_OUT(*this, 0, var_OUT) {};
 
 void FORTE_F_SEL_E_3::setInitialValues() {
-  var_IN0 = CIEC_ANY_VARIANT();
-  var_IN1 = CIEC_ANY_VARIANT();
-  var_IN2 = CIEC_ANY_VARIANT();
-  var_OUT = CIEC_ANY_VARIANT();
+  var_IN0.reset();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_OUT.reset();
 }
 
 void FORTE_F_SEL_E_3::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {

--- a/src/modules/utils/selection/F_SEL_E_4_fbt.cpp
+++ b/src/modules/utils/selection/F_SEL_E_4_fbt.cpp
@@ -83,11 +83,11 @@ FORTE_F_SEL_E_4::FORTE_F_SEL_E_4(const CStringDictionary::TStringId paInstanceNa
     conn_OUT(*this, 0, var_OUT) {};
 
 void FORTE_F_SEL_E_4::setInitialValues() {
-  var_IN0 = CIEC_ANY_VARIANT();
-  var_IN1 = CIEC_ANY_VARIANT();
-  var_IN2 = CIEC_ANY_VARIANT();
-  var_IN3 = CIEC_ANY_VARIANT();
-  var_OUT = CIEC_ANY_VARIANT();
+  var_IN0.reset();
+  var_IN1.reset();
+  var_IN2.reset();
+  var_IN3.reset();
+  var_OUT.reset();
 }
 
 void FORTE_F_SEL_E_4::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {

--- a/src/stdfblib/events/GEN_E_DEMUX_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_DEMUX_fbt.cpp
@@ -16,15 +16,13 @@
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
 #include "GEN_E_DEMUX_fbt.h"
+#include "string_utils.h"
 
 USE_STRING_ID(EI);
 USE_STRING_ID(Event);
 USE_STRING_ID(GEN_E_DEMUX);
 USE_STRING_ID(K);
 USE_STRING_ID(UINT);
-
-#include <stdio.h>
-
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_E_DEMUX, STRID(GEN_E_DEMUX))
 

--- a/src/stdfblib/events/GEN_E_MUX_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_MUX_fbt.cpp
@@ -18,20 +18,13 @@
  *....Franz Höpfinger - Update it to represent latest Generation Format from 4diac IDE. no Functional Changes.
  *******************************************************************************/
 #include "GEN_E_MUX_fbt.h"
+#include "string_utils.h"
 
 USE_STRING_ID(EO);
 USE_STRING_ID(Event);
 USE_STRING_ID(GEN_E_MUX);
 USE_STRING_ID(K);
 USE_STRING_ID(UINT);
-
-#include <stdio.h>
-
-#include "iec61131_functions.h"
-#include "forte_array_common.h"
-#include "forte_array.h"
-#include "forte_array_fixed.h"
-#include "forte_array_variable.h"
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_E_MUX, STRID(GEN_E_MUX));
 

--- a/src/stdfblib/events/GEN_E_SPLIT_fbt.cpp
+++ b/src/stdfblib/events/GEN_E_SPLIT_fbt.cpp
@@ -13,15 +13,10 @@
  *******************************************************************************/
 
 #include "GEN_E_SPLIT_fbt.h"
+#include "string_utils.h"
 
 USE_STRING_ID(EI);
 USE_STRING_ID(GEN_E_SPLIT);
-
-#include "iec61131_functions.h"
-#include "forte_array_common.h"
-#include "forte_array.h"
-#include "forte_array_fixed.h"
-#include "forte_array_variable.h"
 
 DEFINE_GENERIC_FIRMWARE_FB(GEN_E_SPLIT, STRID(GEN_E_SPLIT))
 

--- a/src/stdfblib/ita/OPCUA_MGR.h
+++ b/src/stdfblib/ita/OPCUA_MGR.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include <string>
+#include <map>
 
 class CDevice;
 

--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -104,6 +104,18 @@ CFBTestFixtureBase::~CFBTestFixtureBase() {
   getGenInterfaceSpec() = {};
 }
 
+namespace {
+  void checkVars(CIEC_ANY &paTestVar, CIEC_ANY &paFreshVar) {
+    if (paFreshVar.getDataTypeID() == CIEC_ANY::e_ANY) {
+      if (auto tempVar = std::unique_ptr<CIEC_ANY>(paTestVar.unwrap().clone(nullptr))) {
+        tempVar->reset(); // reset the CIEC_ANY not the unique_ptr
+        paFreshVar.setValue(*tempVar);
+      }
+    }
+    BOOST_TEST(paTestVar.equals(paFreshVar));
+  }
+} // namespace
+
 void CFBTestFixtureBase::performFBResetTests() {
   const SFBInterfaceSpec &interfaceSpec(mFBUnderTest->getFBInterfaceSpec());
 
@@ -118,10 +130,11 @@ void CFBTestFixtureBase::performFBResetTests() {
   }
 
   for (size_t i = 0; i < interfaceSpec.mNumDIs; ++i) {
-    BOOST_TEST(mFBUnderTest->getDI(i)->equals(*freshInstance->getDI(i)));
+    checkVars(*mFBUnderTest->getDI(i), *freshInstance->getDI(i));
   }
+
   for (size_t i = 0; i < interfaceSpec.mNumDOs; ++i) {
-    BOOST_TEST(mFBUnderTest->getDO(i)->equals(*freshInstance->getDO(i)));
+    checkVars(*mFBUnderTest->getDO(i), *freshInstance->getDO(i));
   }
 
   BOOST_CHECK(CTypeLib::deleteFB(freshInstance));


### PR DESCRIPTION
As part of this work also for all variant resets this is used.

Furthermore the include files for all data types have been cleand. This should improve compilation a bit.

Currently the FB tests are failing for FBs with generic in or outputs. The reason is that the FB test is creating a fresh instance and checks if the the reseted Test FBs has the same io values. With the new reset of variants this is not holding anymore. I'm not sure how to best solve this problem. 