### PR TITLE
Remove SinglyListLink usage from opcua layer

### DIFF
--- a/src/com/opc_ua/opcua_ac_layer.cpp
+++ b/src/com/opc_ua/opcua_ac_layer.cpp
@@ -181,12 +181,12 @@ UA_StatusCode COPC_UA_AC_Layer::createOPCUAObjectNode(UA_Server *paServer,
   }
 
   COPC_UA_Local_Handler *localHandler = static_cast<COPC_UA_Local_Handler *>(mHandler);
-  CSinglyLinkedList<UA_NodeId *> referencedNodes;
+  std::vector<UA_NodeId *> referencedNodes;
   paBrowsePath = COPC_UA_ObjectStruct_Helper::getMemberBrowsePath(paPathToInstance, instanceNameStr);
   UA_StatusCode status = localHandler->splitAndCreateFolders(
       paBrowsePath, instanceNameStr,
       referencedNodes); // Overwrites instanceNameStr to the same value as before, but we get the OPC UA folders
-  if (status != UA_STATUSCODE_GOOD || referencedNodes.isEmpty()) {
+  if (status != UA_STATUSCODE_GOOD || referencedNodes.empty()) {
     DEVLOG_ERROR("[OPC UA A&C LAYER]: Creating OPC UA Folders failed, Browsepath: %s, StatusCode: %s\n",
                  paBrowsePath.c_str(), UA_StatusCode_name(status));
     return UA_STATUSCODE_BAD;
@@ -194,7 +194,7 @@ UA_StatusCode COPC_UA_AC_Layer::createOPCUAObjectNode(UA_Server *paServer,
 
   char *instanceName = getNameFromString(instanceNameStr);
   char *browsePath = getNameFromString(paBrowsePath);
-  const UA_NodeId *parentNodeId = *referencedNodes.back();
+  const UA_NodeId *parentNodeId = referencedNodes.back();
   mConditionSourceId = UA_NODEID_STRING(1, browsePath); // TODO Change 1 to namespaceIndex
   UA_ObjectAttributes attr = UA_ObjectAttributes_default;
   attr.eventNotifier = UA_EVENTNOTIFIER_SUBSCRIBE_TO_EVENT;
@@ -215,9 +215,8 @@ UA_StatusCode COPC_UA_AC_Layer::createOPCUAObjectNode(UA_Server *paServer,
     DEVLOG_ERROR("[OPC UA A&C LAYER]: Adding reference to Object Node failed. StatusCode %s\n",
                  UA_StatusCode_name(status));
   }
-  for (CSinglyLinkedList<UA_NodeId *>::Iterator itReferencedNodes = referencedNodes.begin();
-       itReferencedNodes != referencedNodes.end(); ++itReferencedNodes) {
-    UA_NodeId_delete(*itReferencedNodes);
+  for (auto referenceNode : referencedNodes) {
+    UA_NodeId_delete(referenceNode);
   }
   return status;
 }
@@ -326,7 +325,7 @@ COPC_UA_AC_Layer::addOPCUATypeProperties(UA_Server *paServer, const std::string 
     UA_StatusCode status = addVariableNode(paServer, paTypeName, propertyName, apoDataPorts[i]->unwrap());
     if (status != UA_STATUSCODE_GOOD) {
       DEVLOG_ERROR("[OPC UA A&C LAYER]: Failed to add OPCUA AlarmType Property for FB %s, Port: %s, Status: %s\n",
-                   getCommFB()->getInstanceName(), dataPortName, UA_StatusCode_name(status));
+                   getCommFB()->getInstanceName(), dataPortName.c_str(), UA_StatusCode_name(status));
       return e_InitTerminated;
     }
   }
@@ -378,8 +377,8 @@ std::string COPC_UA_AC_Layer::getPortNameFromConnection(CStringDictionary::TStri
   const CDataConnection *portConnection =
       paIsPublisher ? getCommFB()->getDIConnection(paPortNameId) : getCommFB()->getDOConnection(paPortNameId);
   const CConnectionPoint connectionPoint = portConnection->getSourceId();
-  TPortId portId = connectionPoint.mPortId;
-  return std::string(CStringDictionary::get(connectionPoint.mFB->getFBInterfaceSpec().mDINames[portId]));
+  TPortId portId = connectionPoint.getPortId();
+  return std::string(CStringDictionary::get(connectionPoint.getFB().getFBInterfaceSpec().mDINames[portId]));
 }
 
 std::string COPC_UA_AC_Layer::getFBNameFromConnection(bool paIsPublisher) {
@@ -392,7 +391,7 @@ std::string COPC_UA_AC_Layer::getFBNameFromConnection(bool paIsPublisher) {
     return std::string();
   }
   const CConnectionPoint connectionPoint = portConnection->getSourceId();
-  return std::string(connectionPoint.mFB->getInstanceName());
+  return std::string(connectionPoint.getFB().getInstanceName());
 }
 
 char *COPC_UA_AC_Layer::getNameFromString(const std::string &paName) {

--- a/src/com/opc_ua/opcua_client_information.cpp
+++ b/src/com/opc_ua/opcua_client_information.cpp
@@ -17,6 +17,8 @@
 #include <basecommfb.h>
 #include "opcua_handler_abstract.h" //for logger
 #include "opcua_client_config_parser.h"
+
+#include <algorithm>
 #include <stdio.h>
 
 std::string gOpcuaClientConfigFile;
@@ -68,11 +70,10 @@ bool CUA_ClientInformation::configureClientFromFile(UA_ClientConfig &paConfig) {
 
 void CUA_ClientInformation::uninitializeClient() {
   DEVLOG_INFO("[OPC UA CLIENT]: Uninitializing client %s\n", mEndpointUrl.c_str());
-  mActionsToBeInitialized.clearAll();
-  for (CSinglyLinkedList<CActionInfo *>::Iterator itReferencingActions = mActionsReferencingIt.begin();
-       itReferencingActions != mActionsReferencingIt.end(); ++itReferencingActions) {
-    uninitializeAction(**itReferencingActions);
-    mActionsToBeInitialized.pushBack(*itReferencingActions);
+  mActionsToBeInitialized.clear();
+  for (auto actionReferencingIt : mActionsReferencingIt) {
+    uninitializeAction(*actionReferencingIt);
+    mActionsToBeInitialized.push_back(actionReferencingIt);
   }
   if (mClient) {
     UA_Client_disconnect(mClient);
@@ -270,22 +271,21 @@ UA_StatusCode CUA_ClientInformation::executeCallMethod(CActionInfo &paActionInfo
 }
 
 void CUA_ClientInformation::addAction(CActionInfo &paActionInfo) {
-  mActionsReferencingIt.pushBack(&paActionInfo);
-  mActionsToBeInitialized.pushBack(&paActionInfo);
+  mActionsReferencingIt.push_back(&paActionInfo);
+  mActionsToBeInitialized.push_back(&paActionInfo);
   mWaitToInitializeActions = false;
 }
 
 void CUA_ClientInformation::removeAction(CActionInfo &paActionInfo) {
   uninitializeAction(paActionInfo);
-  mActionsReferencingIt.erase(&paActionInfo);
+  std::erase(mActionsReferencingIt, &paActionInfo);
 }
 
 bool CUA_ClientInformation::isActionInitialized(const CActionInfo &paActionInfo) {
   CCriticalRegion clientRegion(mClientMutex);
   bool retVal = true;
-  for (CSinglyLinkedList<CActionInfo *>::Iterator itClientInformation = mActionsToBeInitialized.begin();
-       itClientInformation != mActionsToBeInitialized.end(); ++itClientInformation) {
-    if ((*itClientInformation) == &paActionInfo) {
+  for (auto actionToBeInitialized : mActionsToBeInitialized) {
+    if (actionToBeInitialized == &paActionInfo) {
       retVal = false;
       break;
     }
@@ -305,23 +305,14 @@ bool CUA_ClientInformation::connectClient() {
 bool CUA_ClientInformation::initializeAllActions() {
   bool somethingFailed = false;
 
-  CSinglyLinkedList<CActionInfo *> initializedActions;
-  for (CSinglyLinkedList<CActionInfo *>::Iterator itActionInfo = mActionsToBeInitialized.begin();
-       itActionInfo != mActionsToBeInitialized.end(); ++itActionInfo) {
+  for (auto itActionInfo = mActionsToBeInitialized.begin(); itActionInfo != mActionsToBeInitialized.end();) {
 
     if (!initializeAction(**itActionInfo)) {
-      initializedActions.pushBack(*itActionInfo);
+      mSomeActionWasInitialized = true;
+      itActionInfo = mActionsToBeInitialized.erase(itActionInfo);
     } else {
       somethingFailed = true;
-    }
-  }
-
-  if (!initializedActions
-           .isEmpty()) { // if one action (FB) related to the client was initialized, copy it to the main thread
-    mSomeActionWasInitialized = true;
-    for (CSinglyLinkedList<CActionInfo *>::Iterator itActionInfo = initializedActions.begin();
-         itActionInfo != initializedActions.end(); ++itActionInfo) {
-      mActionsToBeInitialized.erase(*itActionInfo);
+      itActionInfo++;
     }
   }
 
@@ -422,49 +413,32 @@ bool CUA_ClientInformation::initializeSubscription(CActionInfo &paActionInfo) {
   bool somethingFailed = false;
   if (CActionInfo::eSubscribe == paActionInfo.getAction() && createSubscription()) {
 
-    size_t itemsAddedToList = 0;
+    std::vector<std::unique_ptr<UA_MonitoringItemInfo>> newMonitoredInfos;
+    auto &nodePairInfos = paActionInfo.getNodePairInfo();
+    for (size_t i = 0; i < nodePairInfos.size(); i++) {
+      auto monitoringItemInfo = std::make_unique<UA_MonitoringItemInfo>(UA_SubscribeContext_Handle(paActionInfo, i));
 
-    auto itFirstNewMonitoringItemInfo = mSubscriptionInfo.mMonitoredItems.end();
-
-    for (size_t i = 0; i < paActionInfo.getNoOfNodePairs(); i++) {
-      UA_MonitoringItemInfo monitoringItemInfo(UA_SubscribeContext_Handle(paActionInfo, itemsAddedToList));
-      mSubscriptionInfo.mMonitoredItems.pushBack(monitoringItemInfo);
-      if (itFirstNewMonitoringItemInfo == mSubscriptionInfo.mMonitoredItems.end()) { // store the first added item
-        itFirstNewMonitoringItemInfo = mSubscriptionInfo.mMonitoredItems.back();
-      }
-      itemsAddedToList++;
-    }
-
-    auto itNodePairInfo = paActionInfo.getNodePairInfo().begin();
-    size_t itemsAddedToLibrary = 0;
-
-    CSinglyLinkedList<UA_MonitoringItemInfo>::Iterator itAddedMonitoringItemInfo = itFirstNewMonitoringItemInfo;
-
-    for (itemsAddedToLibrary = 0; itemsAddedToLibrary < itemsAddedToList;
-         ++itAddedMonitoringItemInfo, ++itNodePairInfo) {
-      if (!addMonitoringItem(*itAddedMonitoringItemInfo, *itNodePairInfo->getNodeId())) {
+      if (!addMonitoringItem(*monitoringItemInfo, *nodePairInfos[i].getNodeId())) {
         somethingFailed = true;
         break;
       }
-      itemsAddedToLibrary++;
+      newMonitoredInfos.push_back(std::move(monitoringItemInfo));
     }
 
     if (!somethingFailed) {
+      for (auto &newMonitoredInfo : newMonitoredInfos) {
+        mSubscriptionInfo.mMonitoredItems.emplace_back(std::move(newMonitoredInfo));
+      }
       addAsyncCall();
     } else { // if something failed, remove added monitoring items and fail the whole action
 
-      for (size_t i = 0; i < itemsAddedToList; i++) {
-        if (i < itemsAddedToLibrary) { // remove items from the library
-          UA_StatusCode retVal = UA_Client_MonitoredItems_deleteSingle(
-              mClient, mSubscriptionInfo.mSubscriptionId, (*itFirstNewMonitoringItemInfo).mMonitoringItemId);
-          if (UA_STATUSCODE_GOOD != retVal) {
-            DEVLOG_ERROR("[OPC UA CLIENT]: Couldn't delete recently added monitored item %u. Error: %s\n",
-                         (*itFirstNewMonitoringItemInfo).mMonitoringItemId, UA_StatusCode_name(retVal));
-          }
+      for (auto &newMonitoredInfo : newMonitoredInfos) { // remove items from the library
+        UA_StatusCode retVal = UA_Client_MonitoredItems_deleteSingle(mClient, mSubscriptionInfo.mSubscriptionId,
+                                                                     newMonitoredInfo->mMonitoringItemId);
+        if (UA_STATUSCODE_GOOD != retVal) {
+          DEVLOG_ERROR("[OPC UA CLIENT]: Couldn't delete recently added monitored item %u. Error: %s\n",
+                       newMonitoredInfo->mMonitoringItemId, UA_StatusCode_name(retVal));
         }
-        itAddedMonitoringItemInfo = itFirstNewMonitoringItemInfo;
-        ++itFirstNewMonitoringItemInfo;
-        mSubscriptionInfo.mMonitoredItems.erase(*itAddedMonitoringItemInfo);
       }
     }
   }
@@ -498,12 +472,12 @@ bool CUA_ClientInformation::addMonitoringItem(UA_MonitoringItemInfo &paMonitorin
                                                 CUA_RemoteCallbackFunctions::subscriptionValueChangedCallback, nullptr);
   if (UA_STATUSCODE_GOOD == monResponse.statusCode) {
     DEVLOG_INFO("[OPC UA CLIENT]: Monitoring of FB %s at index %u succeeded. The monitoring item id is %u\n",
-                paMonitoringInfo.mVariableInfo.mActionInfo.getLayer().getCommFB()->getInstanceName(),
+                paMonitoringInfo.mVariableInfo.mActionInfo->getLayer().getCommFB()->getInstanceName(),
                 paMonitoringInfo.mVariableInfo.mPortIndex, monResponse.monitoredItemId);
     paMonitoringInfo.mMonitoringItemId = monResponse.monitoredItemId;
   } else {
     DEVLOG_ERROR("[OPC UA CLIENT]: Monitoring of FB %s at index %u failed. Error: %s\n",
-                 paMonitoringInfo.mVariableInfo.mActionInfo.getLayer().getCommFB()->getInstanceName(),
+                 paMonitoringInfo.mVariableInfo.mActionInfo->getLayer().getCommFB()->getInstanceName(),
                  paMonitoringInfo.mVariableInfo.mPortIndex, UA_StatusCode_name(monResponse.statusCode));
   }
 
@@ -519,32 +493,33 @@ void CUA_ClientInformation::removeAsyncCall() {
 }
 
 void CUA_ClientInformation::uninitializeAction(CActionInfo &paActionInfo) {
-  mActionsToBeInitialized.erase(&paActionInfo); // remove in case it is still not initialized
+  // remove in case it is still not initialized
+  std::erase(mActionsToBeInitialized, &paActionInfo);
+
   if (CActionInfo::eSubscribe == paActionInfo.getAction()) { // only subscription has something to release
     uninitializeSubscribeAction(paActionInfo);
   }
 }
 
 void CUA_ClientInformation::uninitializeSubscribeAction(const CActionInfo &paActionInfo) {
-  CSinglyLinkedList<UA_MonitoringItemInfo> toDelete;
   for (auto itMonitoringItemInfo = mSubscriptionInfo.mMonitoredItems.begin();
-       itMonitoringItemInfo != mSubscriptionInfo.mMonitoredItems.end(); ++itMonitoringItemInfo) {
-    if (&(*itMonitoringItemInfo).mVariableInfo.mActionInfo == &paActionInfo) {
-      toDelete.pushBack(*itMonitoringItemInfo);
+       itMonitoringItemInfo != mSubscriptionInfo.mMonitoredItems.end();) {
+    if ((*itMonitoringItemInfo)->mVariableInfo.mActionInfo == &paActionInfo) {
+      UA_StatusCode retVal = UA_Client_MonitoredItems_deleteSingle(mClient, mSubscriptionInfo.mSubscriptionId,
+                                                                   (*itMonitoringItemInfo)->mMonitoringItemId);
+      if (UA_STATUSCODE_GOOD != retVal) {
+        DEVLOG_ERROR(
+            "[OPC UA CLIENT]: Couldn't delete monitored item %u. No further actions will be taken. Error: %s\n",
+            (*itMonitoringItemInfo)->mMonitoringItemId, UA_StatusCode_name(retVal));
+      }
+
+      itMonitoringItemInfo = mSubscriptionInfo.mMonitoredItems.erase(itMonitoringItemInfo);
+    } else {
+      itMonitoringItemInfo++;
     }
   }
-  for (auto itMonitoringItemInfo = toDelete.begin(); itMonitoringItemInfo != toDelete.end(); ++itMonitoringItemInfo) {
-    UA_StatusCode retVal = UA_Client_MonitoredItems_deleteSingle(mClient, mSubscriptionInfo.mSubscriptionId,
-                                                                 (*itMonitoringItemInfo).mMonitoringItemId);
-    if (UA_STATUSCODE_GOOD != retVal) {
-      DEVLOG_ERROR("[OPC UA CLIENT]: Couldn't delete monitored item %u. No further actions will be taken. Error: %s\n",
-                   (*itMonitoringItemInfo).mMonitoringItemId, UA_StatusCode_name(retVal));
-    }
 
-    mSubscriptionInfo.mMonitoredItems.erase(*itMonitoringItemInfo);
-  }
-
-  if (mSubscriptionInfo.mMonitoredItems.isEmpty()) {
+  if (mSubscriptionInfo.mMonitoredItems.empty()) {
     resetSubscription(true);
   }
 }
@@ -757,12 +732,12 @@ void CUA_ClientInformation::CUA_RemoteCallbackFunctions::subscriptionValueChange
     handleRecv.mOffset = variableContextHandle->mPortIndex;
 
     forte::com_infra::EComResponse retVal =
-        variableContextHandle->mActionInfo.getLayer().recvData(static_cast<const void *>(&handleRecv), 0);
+        variableContextHandle->mActionInfo->getLayer().recvData(static_cast<const void *>(&handleRecv), 0);
 
     if (forte::com_infra::e_Nothing != retVal) {
-      variableContextHandle->mActionInfo.getLayer().getCommFB()->interruptCommFB(
-          &variableContextHandle->mActionInfo.getLayer());
-      variableContextHandle->mActionInfo.getLayer().triggerNewEvent();
+      variableContextHandle->mActionInfo->getLayer().getCommFB()->interruptCommFB(
+          &variableContextHandle->mActionInfo->getLayer());
+      variableContextHandle->mActionInfo->getLayer().triggerNewEvent();
     }
   }
 }

--- a/src/com/opc_ua/opcua_client_information.cpp
+++ b/src/com/opc_ua/opcua_client_information.cpp
@@ -727,8 +727,7 @@ void CUA_ClientInformation::CUA_RemoteCallbackFunctions::subscriptionValueChange
 
     COPC_UA_Helper::UA_RecvVariable_handle handleRecv;
 
-    const UA_Variant *value = &paData->value;
-    handleRecv.mData.push_back(value);
+    handleRecv.mData.emplace_back(&paData->value);
     handleRecv.mOffset = variableContextHandle->mPortIndex;
 
     forte::com_infra::EComResponse retVal =

--- a/src/com/opc_ua/opcua_client_information.h
+++ b/src/com/opc_ua/opcua_client_information.h
@@ -16,9 +16,11 @@
 #define SRC_MODULES_OPC_UA_OPCUA_CLIENT_INFORMATION_H_
 
 #include "opcua_action_info.h"
-#include "fortelist.h"
+
 #include "forte_sync.h"
+
 #include <string>
+#include <vector>
 
 /**
  * Contains all the information needed for a client to execute remote calls. It's the only class tha access
@@ -73,7 +75,7 @@ class CUA_ClientInformation {
      * @return True if an action is present in the client, false otherwise
      */
     bool hasActions() const {
-      return !mActionsReferencingIt.isEmpty();
+      return !mActionsReferencingIt.empty();
     }
 
     /**
@@ -203,17 +205,17 @@ class CUA_ClientInformation {
      */
     struct UA_SubscribeContext_Handle {
         UA_SubscribeContext_Handle(CActionInfo &paActionInfo, size_t paPortIndex) :
-            mActionInfo(paActionInfo),
+            mActionInfo(&paActionInfo),
             mPortIndex(paPortIndex) {
         }
 
         // default copy constructor should be enough
 
         bool operator==(UA_SubscribeContext_Handle const &paRightObject) const {
-          return (&mActionInfo == &paRightObject.mActionInfo && mPortIndex == paRightObject.mPortIndex);
+          return (mActionInfo == paRightObject.mActionInfo && mPortIndex == paRightObject.mPortIndex);
         }
 
-        CActionInfo &mActionInfo;
+        CActionInfo *mActionInfo;
         size_t mPortIndex;
     };
 
@@ -245,7 +247,7 @@ class CUA_ClientInformation {
         }
 
         UA_UInt32 mSubscriptionId;
-        CSinglyLinkedList<UA_MonitoringItemInfo> mMonitoredItems;
+        std::vector<std::unique_ptr<UA_MonitoringItemInfo>> mMonitoredItems;
     };
 
     /**
@@ -394,12 +396,12 @@ class CUA_ClientInformation {
     /**
      * List of actions that use this client
      */
-    CSinglyLinkedList<CActionInfo *> mActionsReferencingIt;
+    std::vector<CActionInfo *> mActionsReferencingIt;
 
     /**
      * List of actions that need to be initialized
      */
-    CSinglyLinkedList<CActionInfo *> mActionsToBeInitialized;
+    std::vector<CActionInfo *> mActionsToBeInitialized;
 
     /**
      * Indicates if the client should wait scmConnectionRetryTimeoutNano before trying to reconnect. This is true when

--- a/src/com/opc_ua/opcua_local_handler.cpp
+++ b/src/com/opc_ua/opcua_local_handler.cpp
@@ -223,12 +223,9 @@ void COPC_UA_Local_Handler::referencedNodesIncrement(const std::vector<UA_NodeId
       }
     }
     if (!found) {
-      nodesReferencedByActions newRef;
       UA_NodeId *newNode = UA_NodeId_new();
       UA_NodeId_copy(node, newNode);
-      newRef.mNodeId = newNode;
-      newRef.mActionsReferencingIt.push_back(&paActionInfo);
-      mNodesReferences.push_back(newRef);
+      mNodesReferences.emplace_back(newNode, std::vector<CActionInfo *>{&paActionInfo});
     }
   }
 }
@@ -772,9 +769,7 @@ UA_StatusCode COPC_UA_Local_Handler::handleExistingMethod(CActionInfo &paActionI
     if (UA_STATUSCODE_GOOD == retVal) {
       retVal = UA_Server_setNodeContext(mUaServer, *it->getNodeId(), this);
       if (UA_STATUSCODE_GOOD == retVal) {
-        UA_ParentNodeHandler parentNodeContext(paParentNode, it->getNodeId(),
-                                               static_cast<CLocalMethodInfo &>(paActionInfo));
-        mMethodsContexts.push_back(parentNodeContext);
+        mMethodsContexts.emplace_back(paParentNode, it->getNodeId(), static_cast<CLocalMethodInfo &>(paActionInfo));
       } else {
         DEVLOG_ERROR("[OPC UA LOCAL]: Could not set context function for method at %s. Error: %s\n",
                      paActionInfo.getLayer().getCommFB()->getInstanceName(), UA_StatusCode_name(retVal));
@@ -866,8 +861,7 @@ UA_StatusCode COPC_UA_Local_Handler::createMethodNode(CCreateMethodInfo &paCreat
       UA_NodeId_copy(paCreateMethodInfo.mReturnedNodeId, *paNodeId);
     }
 
-    UA_ParentNodeHandler parentNodeContext(parentNodeId, *paNodeId, paCreateMethodInfo.mLocalMethodInfo);
-    mMethodsContexts.push_back(parentNodeContext);
+    mMethodsContexts.emplace_back(parentNodeId, *paNodeId, paCreateMethodInfo.mLocalMethodInfo);
   } else {
     DEVLOG_ERROR("[OPC UA LOCAL]: OPC UA could not create method at %s. Error: %s\n",
                  paCreateMethodInfo.mLocalMethodInfo.getLayer().getCommFB()->getInstanceName(),
@@ -1455,7 +1449,7 @@ COPC_UA_Local_Handler::CLocalMethodCall &
 COPC_UA_Local_Handler::addMethodCall(CLocalMethodInfo &paActionInfo,
                                      COPC_UA_Helper::UA_SendVariable_handle &paHandleRecv) {
   CCriticalRegion criticalRegion(mMethodCallsMutex);
-  mMethodCalls.push_back(CLocalMethodCall(paActionInfo, paHandleRecv));
+  mMethodCalls.emplace_back(paActionInfo, paHandleRecv);
   return mMethodCalls.back();
 }
 

--- a/src/com/opc_ua/opcua_local_handler.cpp
+++ b/src/com/opc_ua/opcua_local_handler.cpp
@@ -211,21 +211,21 @@ void COPC_UA_Local_Handler::configureUAServer(UA_ServerStrings &paServerStrings,
   }
 }
 
-void COPC_UA_Local_Handler::referencedNodesIncrement(const CSinglyLinkedList<UA_NodeId *> &paNodes,
+void COPC_UA_Local_Handler::referencedNodesIncrement(const std::vector<UA_NodeId *> &paNodes,
                                                      CActionInfo &paActionInfo) {
-  for (CSinglyLinkedList<UA_NodeId *>::Iterator iterNode = paNodes.begin(); iterNode != paNodes.end(); ++iterNode) {
+  for (auto node : paNodes) {
     bool found = false;
-    for (auto iterRef = mNodesReferences.begin(); iterRef != mNodesReferences.end(); ++iterRef) {
-      if (UA_NodeId_equal(iterRef->mNodeId, (*iterNode))) {
+    for (auto &reference : mNodesReferences) {
+      if (UA_NodeId_equal(reference.mNodeId, node)) {
         found = true;
-        iterRef->mActionsReferencingIt.push_back(&paActionInfo);
+        reference.mActionsReferencingIt.push_back(&paActionInfo);
         break;
       }
     }
     if (!found) {
       nodesReferencedByActions newRef;
       UA_NodeId *newNode = UA_NodeId_new();
-      UA_NodeId_copy((*iterNode), newNode);
+      UA_NodeId_copy(node, newNode);
       newRef.mNodeId = newNode;
       newRef.mActionsReferencingIt.push_back(&paActionInfo);
       mNodesReferences.push_back(newRef);
@@ -399,12 +399,12 @@ UA_StatusCode COPC_UA_Local_Handler::initializeVariable(CActionInfo &paActionInf
   UA_StatusCode retVal = UA_STATUSCODE_GOOD;
 
   size_t indexOfNodePair = 0;
-  CSinglyLinkedList<UA_NodeId *> referencedNodes;
+  std::vector<UA_NodeId *> referencedNodes;
   const CIEC_ANY *const *variables = paWrite ? paActionInfo.getDataToSend() : paActionInfo.getDataToReceive();
   for (auto itMain = paActionInfo.getNodePairInfo().begin();
        itMain != paActionInfo.getNodePairInfo().end() && UA_STATUSCODE_GOOD == retVal; ++itMain, indexOfNodePair++) {
 
-    CSinglyLinkedList<UA_NodeId *> presentNodes;
+    std::vector<UA_NodeId *> presentNodes;
     bool nodeExists = false;
     retVal = getNode(*itMain, presentNodes, &nodeExists);
 
@@ -430,9 +430,8 @@ UA_StatusCode COPC_UA_Local_Handler::initializeVariable(CActionInfo &paActionInf
     referencedNodesDecrement(paActionInfo);
   }
 
-  for (CSinglyLinkedList<UA_NodeId *>::Iterator itRerencedNodes = referencedNodes.begin();
-       itRerencedNodes != referencedNodes.end(); ++itRerencedNodes) {
-    UA_NodeId_delete(*itRerencedNodes);
+  for (auto referenceNode : referencedNodes) {
+    UA_NodeId_delete(referenceNode);
   }
   return retVal;
 }
@@ -443,11 +442,11 @@ UA_StatusCode COPC_UA_Local_Handler::initializeObjectStructMemberVariable(std::s
   UA_StatusCode retVal = UA_STATUSCODE_GOOD;
 
   size_t indexOfNodePair = 0;
-  CSinglyLinkedList<UA_NodeId *> referencedNodes;
+  std::vector<UA_NodeId *> referencedNodes;
   for (auto itMain = paActionInfo->getNodePairInfo().begin();
        itMain != paActionInfo->getNodePairInfo().end() && UA_STATUSCODE_GOOD == retVal; ++itMain, indexOfNodePair++) {
 
-    CSinglyLinkedList<UA_NodeId *> presentNodes;
+    std::vector<UA_NodeId *> presentNodes;
     bool nodeExists = false;
     retVal = getNode(*itMain, presentNodes, &nodeExists);
 
@@ -467,9 +466,8 @@ UA_StatusCode COPC_UA_Local_Handler::initializeObjectStructMemberVariable(std::s
   if (UA_STATUSCODE_GOOD != retVal) {
     referencedNodesDecrement(*paActionInfo);
   }
-  for (CSinglyLinkedList<UA_NodeId *>::Iterator itRerencedNodes = referencedNodes.begin();
-       itRerencedNodes != referencedNodes.end(); ++itRerencedNodes) {
-    UA_NodeId_delete(*itRerencedNodes);
+  for (auto referenceNode : referencedNodes) {
+    UA_NodeId_delete(referenceNode);
   }
   return retVal;
 }
@@ -529,14 +527,14 @@ UA_StatusCode COPC_UA_Local_Handler::handleNonExistingVariable(CActionInfo &paAc
                                                                CActionInfo::CNodePairInfo &paNodePairInfo,
                                                                const CIEC_ANY &paVariable,
                                                                size_t paIndexOfNodePair,
-                                                               CSinglyLinkedList<UA_NodeId *> &paReferencedNodes,
+                                                               std::vector<UA_NodeId *> &paReferencedNodes,
                                                                bool paWrite) {
 
   std::string nodeName;
   UA_StatusCode retVal = splitAndCreateFolders(paNodePairInfo.getBrowsePath(), nodeName, paReferencedNodes);
   if (UA_STATUSCODE_GOOD == retVal) {
     CCreateVariableInfo variableInformation;
-    initializeCreateInfo(nodeName, paNodePairInfo, paReferencedNodes.isEmpty() ? nullptr : *(paReferencedNodes.back()),
+    initializeCreateInfo(nodeName, paNodePairInfo, paReferencedNodes.empty() ? nullptr : paReferencedNodes.back(),
                          variableInformation);
 
     variableInformation.mTypeConvert = COPC_UA_Helper::getOPCUATypeFromAny(paVariable);
@@ -550,7 +548,7 @@ UA_StatusCode COPC_UA_Local_Handler::handleNonExistingVariable(CActionInfo &paAc
     if (UA_STATUSCODE_GOOD == retVal) {
       UA_NodeId *tmp = UA_NodeId_new();
       UA_NodeId_copy(variableInformation.mReturnedNodeId, tmp);
-      paReferencedNodes.pushBack(tmp);
+      paReferencedNodes.push_back(tmp);
       if (!paWrite) {
         retVal = registerVariableCallBack(*variableInformation.mReturnedNodeId, paActionInfo, paIndexOfNodePair);
       }
@@ -653,15 +651,14 @@ UA_StatusCode COPC_UA_Local_Handler::registerVariableCallBack(const UA_NodeId &p
   UA_StatusCode retVal = UA_Server_setVariableNode_valueCallback(mUaServer, paNodeId, writeCallback);
   if (UA_STATUSCODE_GOOD == retVal) {
 
-    UA_VariableContext_Handle variableContext(paActionInfo, paPortIndex);
-    mNodeCallbackHandles.pushFront(variableContext);
-    CSinglyLinkedList<UA_VariableContext_Handle>::Iterator contextIterator = mNodeCallbackHandles.begin();
+    auto nodeContext = std::make_unique<UA_VariableContext_Handle>(paActionInfo, paPortIndex);
 
-    retVal = UA_Server_setNodeContext(mUaServer, paNodeId, &(*contextIterator));
+    retVal = UA_Server_setNodeContext(mUaServer, paNodeId, nodeContext.get());
     if (UA_STATUSCODE_GOOD != retVal) {
       DEVLOG_ERROR("[OPC UA LOCAL]: Could not set callback context for node. Error: %s\n", UA_StatusCode_name(retVal));
-      mNodeCallbackHandles.popFront();
       retVal = UA_STATUSCODE_BADUNEXPECTEDERROR;
+    } else {
+      mNodeCallbackHandles.emplace_back(std::move(nodeContext));
     }
   } else {
     DEVLOG_ERROR("[OPC UA LOCAL]: Could not set callback function for node. Error: %s\n", UA_StatusCode_name(retVal));
@@ -681,8 +678,8 @@ UA_StatusCode COPC_UA_Local_Handler::addWritePermission(const UA_NodeId &paNodeI
 
 UA_StatusCode COPC_UA_Local_Handler::initializeCreateMethod(CActionInfo &paActionInfo) {
 
-  CSinglyLinkedList<UA_NodeId *> referencedNodes;
-  CSinglyLinkedList<UA_NodeId *> presentNodes;
+  std::vector<UA_NodeId *> referencedNodes;
+  std::vector<UA_NodeId *> presentNodes;
 
   auto itMethodNodePairInfo = paActionInfo.getNodePairInfo().begin();
 
@@ -695,11 +692,10 @@ UA_StatusCode COPC_UA_Local_Handler::initializeCreateMethod(CActionInfo &paActio
       UA_NodeId parent = UA_NODEID_NUMERIC(0, UA_NS0ID_ROOTFOLDER);
 
       // look for parent object
-      for (CSinglyLinkedList<UA_NodeId *>::Iterator itPresentNodes = presentNodes.begin();
-           itPresentNodes != presentNodes.end();) {
-        CSinglyLinkedList<UA_NodeId *>::Iterator currentIterator = itPresentNodes;
+      for (auto itPresentNodes = presentNodes.begin(); itPresentNodes != presentNodes.end();) {
+        auto currentIterator = itPresentNodes;
         ++itPresentNodes;
-        if (itPresentNodes == presentNodes.back()) {
+        if (*itPresentNodes == presentNodes.back()) {
           parent = **currentIterator;
           break;
         }
@@ -716,7 +712,7 @@ UA_StatusCode COPC_UA_Local_Handler::initializeCreateMethod(CActionInfo &paActio
       if (UA_STATUSCODE_GOOD == retVal) {
         CCreateMethodInfo methodInformation(static_cast<CLocalMethodInfo &>(paActionInfo));
         initializeCreateInfo(nodeName, *itMethodNodePairInfo,
-                             referencedNodes.isEmpty() ? nullptr : *(referencedNodes.back()), methodInformation);
+                             referencedNodes.empty() ? nullptr : referencedNodes.back(), methodInformation);
 
         methodInformation.mOutputSize = paActionInfo.getSendSize();
         methodInformation.mInputSize = paActionInfo.getReceiveSize();
@@ -729,7 +725,7 @@ UA_StatusCode COPC_UA_Local_Handler::initializeCreateMethod(CActionInfo &paActio
           itMethodNodePairInfo->setNodeId(result);
           UA_NodeId *tmp = UA_NodeId_new();
           UA_NodeId_copy(methodInformation.mReturnedNodeId, tmp);
-          referencedNodes.pushBack(tmp);
+          referencedNodes.push_back(tmp);
         }
       }
     }
@@ -744,9 +740,8 @@ UA_StatusCode COPC_UA_Local_Handler::initializeCreateMethod(CActionInfo &paActio
     referencedNodesDecrement(paActionInfo);
   }
 
-  for (CSinglyLinkedList<UA_NodeId *>::Iterator itRerencedNodes = referencedNodes.begin();
-       itRerencedNodes != referencedNodes.end(); ++itRerencedNodes) {
-    UA_NodeId_delete(*itRerencedNodes);
+  for (auto referenceNode : referencedNodes) {
+    UA_NodeId_delete(referenceNode);
   }
   return retVal;
 }
@@ -758,10 +753,9 @@ UA_StatusCode COPC_UA_Local_Handler::handleExistingMethod(CActionInfo &paActionI
   DEVLOG_INFO("[OPC UA LOCAL]: Adding a callback for an existing method at %s\n", it->getBrowsePath().c_str());
 
   // check if the method was already referenced by another FB
-  for (CSinglyLinkedList<UA_ParentNodeHandler>::Iterator iter = mMethodsContexts.begin();
-       iter != mMethodsContexts.end(); ++iter) {
-    if (UA_NodeId_equal(&paParentNode, (*iter).mParentNodeId) &&
-        UA_NodeId_equal(it->getNodeId(), (*iter).mMethodNodeId)) {
+  for (auto &methodContext : mMethodsContexts) {
+    if (UA_NodeId_equal(&paParentNode, methodContext.mParentNodeId) &&
+        UA_NodeId_equal(it->getNodeId(), methodContext.mMethodNodeId)) {
       DEVLOG_ERROR("[OPC UA LOCAL]: The FB %s is trying to reference a local method at %s which has already a FB who "
                    "is referencing it. Cannot add another one\n",
                    paActionInfo.getLayer().getCommFB()->getInstanceName(), it->getBrowsePath().c_str());
@@ -780,7 +774,7 @@ UA_StatusCode COPC_UA_Local_Handler::handleExistingMethod(CActionInfo &paActionI
       if (UA_STATUSCODE_GOOD == retVal) {
         UA_ParentNodeHandler parentNodeContext(paParentNode, it->getNodeId(),
                                                static_cast<CLocalMethodInfo &>(paActionInfo));
-        mMethodsContexts.pushBack(parentNodeContext);
+        mMethodsContexts.push_back(parentNodeContext);
       } else {
         DEVLOG_ERROR("[OPC UA LOCAL]: Could not set context function for method at %s. Error: %s\n",
                      paActionInfo.getLayer().getCommFB()->getInstanceName(), UA_StatusCode_name(retVal));
@@ -873,7 +867,7 @@ UA_StatusCode COPC_UA_Local_Handler::createMethodNode(CCreateMethodInfo &paCreat
     }
 
     UA_ParentNodeHandler parentNodeContext(parentNodeId, *paNodeId, paCreateMethodInfo.mLocalMethodInfo);
-    mMethodsContexts.pushBack(parentNodeContext);
+    mMethodsContexts.push_back(parentNodeContext);
   } else {
     DEVLOG_ERROR("[OPC UA LOCAL]: OPC UA could not create method at %s. Error: %s\n",
                  paCreateMethodInfo.mLocalMethodInfo.getLayer().getCommFB()->getInstanceName(),
@@ -943,7 +937,7 @@ UA_StatusCode COPC_UA_Local_Handler::executeStructWrite(CActionInfo &paActionInf
     retVal = updateNodeValue(*it->getNodeId(), &paMember);
     if (UA_STATUSCODE_GOOD != retVal) {
       DEVLOG_ERROR("[OPC UA LOCAL]: Could not convert value to write for node %s at FB %s. Error: %s\n",
-                   (*paActionInfo.getNodePairInfo().begin()).getBrowsePath(),
+                   (*paActionInfo.getNodePairInfo().begin()).getBrowsePath().c_str(),
                    paActionInfo.getLayer().getCommFB()->getInstanceName(), UA_StatusCode_name(retVal));
       return retVal;
     }
@@ -959,11 +953,11 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateMethod(CActionInfo &paActionIn
   if (localMethodCall) {
     const CIEC_ANY *const *dataToSend = paActionInfo.getDataToSend();
     // copy SD values to output
-    for (size_t i = 0; i < localMethodCall->mSendHandle.mData.size(); i++) {
-      COPC_UA_Helper::fillVariant(*localMethodCall->mSendHandle.mData[i], *dataToSend[i]);
+    for (size_t i = 0; i < localMethodCall->mSendHandle->mData.size(); i++) {
+      COPC_UA_Helper::fillVariant(*localMethodCall->mSendHandle->mData[i], *dataToSend[i]);
     }
 
-    localMethodCall->mActionInfo.getResultReady().inc();
+    localMethodCall->mActionInfo->getResultReady().inc();
     retVal = UA_STATUSCODE_GOOD;
   } else {
     DEVLOG_ERROR("[OPC UA LOCAL]: The method being returned hasn't been called before of FB %s\n",
@@ -984,7 +978,7 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateObject(CActionInfo &paActionIn
     auto itInstance = paActionInfo.getNodePairInfo().begin();
     ++itInstance;
 
-    CSinglyLinkedList<UA_NodeId *> referencedNodes;
+    std::vector<UA_NodeId *> referencedNodes;
     bool nodeExists = false;
     // check if an instance is already present
     retVal = getNode(*itInstance, referencedNodes, &nodeExists);
@@ -997,7 +991,7 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateObject(CActionInfo &paActionIn
         if (UA_STATUSCODE_GOOD == retVal) {
           CCreateObjectInfo createInformation;
 
-          initializeCreateInfo(nodeName, *itInstance, referencedNodes.isEmpty() ? nullptr : *(referencedNodes.back()),
+          initializeCreateInfo(nodeName, *itInstance, referencedNodes.empty() ? nullptr : referencedNodes.back(),
                                createInformation);
           createInformation.mTypeNodeId = itTypeNodePairInfo->getNodeId();
 
@@ -1006,7 +1000,7 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateObject(CActionInfo &paActionIn
           if (UA_STATUSCODE_GOOD == retVal) {
             UA_NodeId *tmp = UA_NodeId_new();
             UA_NodeId_copy(createInformation.mReturnedNodeId, tmp);
-            referencedNodes.pushBack(tmp);
+            referencedNodes.push_back(tmp);
           }
         }
       } else {
@@ -1025,9 +1019,8 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateObject(CActionInfo &paActionIn
       referencedNodesDecrement(paActionInfo);
     }
 
-    for (CSinglyLinkedList<UA_NodeId *>::Iterator itRerencedNodes = referencedNodes.begin();
-         itRerencedNodes != referencedNodes.end(); ++itRerencedNodes) {
-      UA_NodeId_delete(*itRerencedNodes);
+    for (auto referenceNode : referencedNodes) {
+      UA_NodeId_delete(referenceNode);
     }
 
   } else {
@@ -1097,7 +1090,7 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateVariable(CActionInfo &paAction
 
       auto &nodePair = paActionInfo.getNodePairInfo().back();
 
-      CSinglyLinkedList<UA_NodeId *> referencedNodes;
+      std::vector<UA_NodeId *> referencedNodes;
       bool nodeExists = false;
       // check if a nodePair is already present
       retVal = getNode(nodePair, referencedNodes, &nodeExists);
@@ -1110,7 +1103,7 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateVariable(CActionInfo &paAction
           if (UA_STATUSCODE_GOOD == retVal) {
             CCreateVariableInfo createInformation;
 
-            initializeCreateInfo(nodeName, nodePair, referencedNodes.isEmpty() ? nullptr : *(referencedNodes.back()),
+            initializeCreateInfo(nodeName, nodePair, referencedNodes.empty() ? nullptr : referencedNodes.back(),
                                  createInformation);
             createInformation.mVariableTypeNodeId = itVariableTypeNodePairInfo->getNodeId();
             const UA_NodeId *dataValueTypeNodeId = itDataValueTypeNodePairInfo->getNodeId();
@@ -1123,7 +1116,7 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateVariable(CActionInfo &paAction
             if (UA_STATUSCODE_GOOD == retVal) {
               UA_NodeId *tmp = UA_NodeId_new();
               UA_NodeId_copy(createInformation.mReturnedNodeId, tmp);
-              referencedNodes.pushBack(tmp);
+              referencedNodes.push_back(tmp);
             }
           }
         } else {
@@ -1142,9 +1135,8 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateVariable(CActionInfo &paAction
         referencedNodesDecrement(paActionInfo);
       }
 
-      for (CSinglyLinkedList<UA_NodeId *>::Iterator itRerencedNodes = referencedNodes.begin();
-           itRerencedNodes != referencedNodes.end(); ++itRerencedNodes) {
-        UA_NodeId_delete(*itRerencedNodes);
+      for (auto referenceNode : referencedNodes) {
+        UA_NodeId_delete(referenceNode);
       }
     } else {
       DEVLOG_ERROR("[OPC UA LOCAL]: The data value type of the variable to create could not be found at FB %s\n",
@@ -1160,17 +1152,16 @@ UA_StatusCode COPC_UA_Local_Handler::executeCreateVariable(CActionInfo &paAction
 
 bool COPC_UA_Local_Handler::isNodePresent(CActionInfo::CNodePairInfo &paNodePairInfo) {
   bool nodeExists = false;
-  CSinglyLinkedList<UA_NodeId *> referencedNodes;
+  std::vector<UA_NodeId *> referencedNodes;
 
   UA_StatusCode retVal = getNode(paNodePairInfo, referencedNodes, &nodeExists);
 
   if (UA_STATUSCODE_GOOD == retVal) {
     // we don't need the nodes from the type
-    for (CSinglyLinkedList<UA_NodeId *>::Iterator itPresentNodes = referencedNodes.begin();
-         itPresentNodes != referencedNodes.end(); ++itPresentNodes) {
-      UA_NodeId_delete(*itPresentNodes);
+    for (auto presentNode : referencedNodes) {
+      UA_NodeId_delete(presentNode);
     }
-    referencedNodes.clearAll();
+    referencedNodes.clear();
   }
   return nodeExists;
 }
@@ -1179,7 +1170,7 @@ UA_StatusCode COPC_UA_Local_Handler::executeDeleteObject(CActionInfo &paActionIn
 
   bool nodeExists = false;
   auto itInstance = paActionInfo.getNodePairInfo().begin();
-  CSinglyLinkedList<UA_NodeId *> referencedNodes;
+  std::vector<UA_NodeId *> referencedNodes;
 
   // look for instance
   UA_StatusCode retVal = getNode(*itInstance, referencedNodes, &nodeExists);
@@ -1193,11 +1184,10 @@ UA_StatusCode COPC_UA_Local_Handler::executeDeleteObject(CActionInfo &paActionIn
       retVal = UA_STATUSCODE_BADINTERNALERROR;
     }
 
-    for (CSinglyLinkedList<UA_NodeId *>::Iterator itPresendNodes = referencedNodes.begin();
-         itPresendNodes != referencedNodes.end(); ++itPresendNodes) {
-      UA_NodeId_delete(*itPresendNodes);
+    for (auto referenceNode : referencedNodes) {
+      UA_NodeId_delete(referenceNode);
     }
-    referencedNodes.clearAll();
+    referencedNodes.clear();
   }
 
   return retVal;
@@ -1215,7 +1205,7 @@ void COPC_UA_Local_Handler::initializeCreateInfo(std::string &paNodeName,
 }
 
 UA_StatusCode COPC_UA_Local_Handler::getNode(CActionInfo::CNodePairInfo &paNodePairInfo,
-                                             CSinglyLinkedList<UA_NodeId *> &paFoundNodeIds,
+                                             std::vector<UA_NodeId *> &paFoundNodeIds,
                                              bool *paIsPresent) {
   UA_StatusCode retVal = UA_STATUSCODE_GOOD;
   *paIsPresent = false;
@@ -1225,27 +1215,27 @@ UA_StatusCode COPC_UA_Local_Handler::getNode(CActionInfo::CNodePairInfo &paNodeP
     size_t pathCount = 0;
     size_t firstNonExistingNode = 0;
 
-    CSinglyLinkedList<UA_NodeId *> existingNodeIds;
+    std::vector<UA_NodeId *> existingNodeIds;
     retVal = translateBrowseNameAndStore(paNodePairInfo.getBrowsePath().c_str(), &browsePaths, &pathCount,
                                          &firstNonExistingNode, existingNodeIds);
     if (UA_STATUSCODE_GOOD == retVal) {
       if (firstNonExistingNode == pathCount) { // all nodes exist
         *paIsPresent = true;
         if (paNodePairInfo.getNodeId() != nullptr) { // nodeID was provided
-          if (!UA_NodeId_equal(paNodePairInfo.getNodeId(), *existingNodeIds.back())) {
+          if (!UA_NodeId_equal(paNodePairInfo.getNodeId(), existingNodeIds.back())) {
             *paIsPresent = false; // the found Node has not the same NodeId.
           }
         } else { // if no nodeID was provided, the found Node is stored in the nodePairInfo
           paNodePairInfo.setNodeId(UA_NodeId_new());
-          UA_NodeId_copy(*existingNodeIds.back(), paNodePairInfo.getNodeId());
+          UA_NodeId_copy(existingNodeIds.back(), paNodePairInfo.getNodeId());
         }
       }
 
-      for (CSinglyLinkedList<UA_NodeId *>::Iterator it = existingNodeIds.begin(); it != existingNodeIds.end(); ++it) {
+      for (auto existingNode : existingNodeIds) {
         if (!*paIsPresent) {
-          UA_NodeId_delete(*it);
+          UA_NodeId_delete(existingNode);
         } else {
-          paFoundNodeIds.pushBack(*it);
+          paFoundNodeIds.push_back(existingNode);
         }
       }
       COPC_UA_Helper::releaseBrowseArgument(*browsePaths, pathCount);
@@ -1265,13 +1255,13 @@ UA_StatusCode COPC_UA_Local_Handler::translateBrowseNameAndStore(const char *paB
                                                                  UA_BrowsePath **paBrowsePaths,
                                                                  size_t *paFoldercount,
                                                                  size_t *paFirstNonExistingNode,
-                                                                 CSinglyLinkedList<UA_NodeId *> &paFoundNodeIds) const {
+                                                                 std::vector<UA_NodeId *> &paFoundNodeIds) const {
 
   UA_StatusCode retVal = COPC_UA_Helper::prepareBrowseArgument(paBrowsePath, paBrowsePaths, paFoldercount);
 
   if (UA_STATUSCODE_GOOD == retVal) {
     UA_BrowsePathResult *browsePathsResults = nullptr;
-    CSinglyLinkedList<UA_NodeId *> storedNodeIds;
+    std::vector<UA_NodeId *> storedNodeIds;
 
     browsePathsResults =
         static_cast<UA_BrowsePathResult *>(UA_Array_new(*paFoldercount * 2, &UA_TYPES[UA_TYPES_BROWSEPATHRESULT]));
@@ -1280,11 +1270,11 @@ UA_StatusCode COPC_UA_Local_Handler::translateBrowseNameAndStore(const char *paB
     }
     retVal = storeAlreadyExistingNodes(browsePathsResults, *paFoldercount, paFirstNonExistingNode, storedNodeIds);
 
-    for (CSinglyLinkedList<UA_NodeId *>::Iterator it = storedNodeIds.begin(); it != storedNodeIds.end(); ++it) {
+    for (auto storedNodeId : storedNodeIds) {
       if (UA_STATUSCODE_GOOD != retVal) {
-        UA_NodeId_delete(*it);
+        UA_NodeId_delete(storedNodeId);
       } else {
-        paFoundNodeIds.pushBack(*it);
+        paFoundNodeIds.push_back(storedNodeId);
       }
     }
 
@@ -1297,7 +1287,7 @@ UA_StatusCode COPC_UA_Local_Handler::translateBrowseNameAndStore(const char *paB
 UA_StatusCode COPC_UA_Local_Handler::storeAlreadyExistingNodes(const UA_BrowsePathResult *paBrowsePathsResults,
                                                                size_t paFolderCnt,
                                                                size_t *paFirstNonExistingNode,
-                                                               CSinglyLinkedList<UA_NodeId *> &paCreatedNodeIds) const {
+                                                               std::vector<UA_NodeId *> &paCreatedNodeIds) const {
   size_t foundFolderOffset = 0;
   int retVal; // no unsigned, because we need to check for -1
   bool offsetFound = false;
@@ -1333,7 +1323,7 @@ UA_StatusCode COPC_UA_Local_Handler::storeAlreadyExistingNodes(const UA_BrowsePa
   for (int j = 0; j < retVal; j++) {
     UA_NodeId *tmp = UA_NodeId_new();
     UA_NodeId_copy(&paBrowsePathsResults[foundFolderOffset + j].targets[0].targetId.nodeId, tmp);
-    paCreatedNodeIds.pushBack(tmp);
+    paCreatedNodeIds.push_back(tmp);
   }
 
   *paFirstNonExistingNode = static_cast<size_t>(retVal);
@@ -1341,25 +1331,25 @@ UA_StatusCode COPC_UA_Local_Handler::storeAlreadyExistingNodes(const UA_BrowsePa
 }
 
 UA_StatusCode COPC_UA_Local_Handler::createFolders(const char *paFolders,
-                                                   CSinglyLinkedList<UA_NodeId *> &paCreatedNodeIds) const {
+                                                   std::vector<UA_NodeId *> &paCreatedNodeIds) const {
 
   UA_BrowsePath *browsePaths = nullptr;
   size_t folderCnt = 0;
   size_t firstNonExistingNode;
-  CSinglyLinkedList<UA_NodeId *> existingNodeIds;
+  std::vector<UA_NodeId *> existingNodeIds;
   UA_StatusCode retVal =
       translateBrowseNameAndStore(paFolders, &browsePaths, &folderCnt, &firstNonExistingNode, existingNodeIds);
 
   if (UA_STATUSCODE_GOOD == retVal) {
     UA_NodeId parentNodeId;
-    if (existingNodeIds.isEmpty()) {
+    if (existingNodeIds.empty()) {
       UA_NodeId objectsNode = UA_NODEID_NUMERIC(0, UA_NS0ID_ROOTFOLDER);
       UA_NodeId_copy(&objectsNode, &parentNodeId);
     } else {
-      UA_NodeId_copy(*existingNodeIds.back(), &parentNodeId);
+      UA_NodeId_copy(existingNodeIds.back(), &parentNodeId);
     }
 
-    CSinglyLinkedList<UA_NodeId *> createdNodeIds;
+    std::vector<UA_NodeId *> createdNodeIds;
 
     // create all the nodes on the way
     for (size_t j = firstNonExistingNode; j < folderCnt; j++) {
@@ -1385,24 +1375,24 @@ UA_StatusCode COPC_UA_Local_Handler::createFolders(const char *paFolders,
 
       UA_NodeId *tmp = UA_NodeId_new();
       UA_NodeId_copy(createInformation.mReturnedNodeId, tmp);
-      createdNodeIds.pushBack(tmp);
+      createdNodeIds.push_back(tmp);
 
       UA_NodeId_clear(&parentNodeId);
       UA_NodeId_copy(createInformation.mReturnedNodeId, &parentNodeId);
     }
 
     UA_NodeId_clear(&parentNodeId);
-    for (CSinglyLinkedList<UA_NodeId *>::Iterator it = existingNodeIds.begin(); it != existingNodeIds.end(); ++it) {
+    for (auto existingNode : existingNodeIds) {
       if (UA_STATUSCODE_GOOD != retVal) {
-        UA_NodeId_delete(*it);
+        UA_NodeId_delete(existingNode);
       } else {
-        paCreatedNodeIds.pushBack(*it);
+        paCreatedNodeIds.push_back(existingNode);
       }
     }
 
-    for (CSinglyLinkedList<UA_NodeId *>::Iterator it = createdNodeIds.begin(); it != createdNodeIds.end(); ++it) {
-      paCreatedNodeIds.pushBack(
-          *it); // store the NodeId because the object was created, and if the next fails, the node should be referenced
+    for (auto createdNode : createdNodeIds) {
+      paCreatedNodeIds.push_back(createdNode); // store the NodeId because the object was created, and if the next
+                                               // fails, the node should be referenced
     }
 
     COPC_UA_Helper::releaseBrowseArgument(*browsePaths, folderCnt);
@@ -1412,7 +1402,7 @@ UA_StatusCode COPC_UA_Local_Handler::createFolders(const char *paFolders,
 
 UA_StatusCode COPC_UA_Local_Handler::splitAndCreateFolders(const std::string &paBrowsePath,
                                                            std::string &paNodeName,
-                                                           CSinglyLinkedList<UA_NodeId *> &paRreferencedNodes) const {
+                                                           std::vector<UA_NodeId *> &paRreferencedNodes) const {
   std::string folders;
   UA_StatusCode retVal = UA_STATUSCODE_BADINTERNALERROR;
   if (splitFoldersFromNode(paBrowsePath, folders, paNodeName)) {
@@ -1449,15 +1439,14 @@ bool COPC_UA_Local_Handler::splitFoldersFromNode(const std::string &paOriginal,
   return retVal;
 }
 
-void COPC_UA_Local_Handler::handlePresentNodes(const CSinglyLinkedList<UA_NodeId *> &paPresentNodes,
-                                               CSinglyLinkedList<UA_NodeId *> &paReferencedNodes,
+void COPC_UA_Local_Handler::handlePresentNodes(const std::vector<UA_NodeId *> &paPresentNodes,
+                                               std::vector<UA_NodeId *> &paReferencedNodes,
                                                bool paFailed) const {
-  for (CSinglyLinkedList<UA_NodeId *>::Iterator itPresendNodes = paPresentNodes.begin();
-       itPresendNodes != paPresentNodes.end(); ++itPresendNodes) {
+  for (auto presentNodes : paPresentNodes) {
     if (paFailed) {
-      UA_NodeId_delete(*itPresendNodes);
+      UA_NodeId_delete(presentNodes);
     } else {
-      paReferencedNodes.pushBack(*itPresendNodes);
+      paReferencedNodes.push_back(presentNodes);
     }
   }
 }
@@ -1466,23 +1455,22 @@ COPC_UA_Local_Handler::CLocalMethodCall &
 COPC_UA_Local_Handler::addMethodCall(CLocalMethodInfo &paActionInfo,
                                      COPC_UA_Helper::UA_SendVariable_handle &paHandleRecv) {
   CCriticalRegion criticalRegion(mMethodCallsMutex);
-  mMethodCalls.pushBack(CLocalMethodCall(paActionInfo, paHandleRecv));
-  CSinglyLinkedList<CLocalMethodCall>::Iterator justPushed = mMethodCalls.back();
-  return *justPushed;
+  mMethodCalls.push_back(CLocalMethodCall(paActionInfo, paHandleRecv));
+  return mMethodCalls.back();
 }
 
 void COPC_UA_Local_Handler::removeMethodCall(const CLocalMethodCall &toRemove) {
   CCriticalRegion criticalRegion(mMethodCallsMutex);
-  mMethodCalls.erase(toRemove);
+  std::erase(mMethodCalls, toRemove);
 }
 
 COPC_UA_Local_Handler::CLocalMethodCall *
 COPC_UA_Local_Handler::getLocalMethodCall(const CLocalMethodInfo &paActionInfo) {
   CCriticalRegion criticalRegion(mMethodCallsMutex);
   CLocalMethodCall *retVal = nullptr;
-  for (CSinglyLinkedList<CLocalMethodCall>::Iterator it = mMethodCalls.begin(); it != mMethodCalls.end(); ++it) {
-    if (&(*it).mActionInfo == &paActionInfo) {
-      retVal = &(*it);
+  for (auto &methodCall : mMethodCalls) {
+    if (methodCall.mActionInfo == &paActionInfo) {
+      retVal = &methodCall;
       break;
     }
   }
@@ -1509,11 +1497,10 @@ COPC_UA_Local_Handler::CUA_LocalCallbackFunctions::onServerMethodCall( // We omi
   UA_StatusCode retVal = UA_STATUSCODE_BADUNEXPECTEDERROR;
   CLocalMethodInfo *localMethodHandle = nullptr;
   COPC_UA_Local_Handler *thisHandler = static_cast<COPC_UA_Local_Handler *>(paMethodContext);
-  for (CSinglyLinkedList<UA_ParentNodeHandler>::Iterator iter = thisHandler->mMethodsContexts.begin();
-       iter != thisHandler->mMethodsContexts.end(); ++iter) {
-    if (UA_NodeId_equal(paParentNodeId, (*iter).mParentNodeId) &&
-        UA_NodeId_equal(paMethodNodeId, (*iter).mMethodNodeId)) {
-      localMethodHandle = &(*iter).mActionInfo;
+  for (auto &methodContext : thisHandler->mMethodsContexts) {
+    if (UA_NodeId_equal(paParentNodeId, methodContext.mParentNodeId) &&
+        UA_NodeId_equal(paMethodNodeId, methodContext.mMethodNodeId)) {
+      localMethodHandle = &methodContext.mActionInfo;
       break;
     }
   }

--- a/src/com/opc_ua/opcua_local_handler.h
+++ b/src/com/opc_ua/opcua_local_handler.h
@@ -28,10 +28,11 @@
 #include <conn.h>
 #include <forte_sem.h>
 #include <forte_sync.h>
-#include "../../core/fortelist.h"
 #include "opcua_handler_abstract.h"
 #include "opcua_helper.h"
+
 #include <string>
+#include <vector>
 
 /**
  * Class to handle all action that are executed on a local OPC UA server
@@ -118,7 +119,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      */
     UA_StatusCode splitAndCreateFolders(const std::string &paBrowsePath,
                                         std::string &paNodeName,
-                                        CSinglyLinkedList<UA_NodeId *> &paRreferencedNodes) const;
+                                        std::vector<UA_NodeId *> &paRreferencedNodes) const;
 
     /**
      * Default value for the namespace of the browsename for all created nodes
@@ -229,7 +230,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      * @param paNodes Nodes being referenced by the action
      * @param paActionInfo Action referencing the nodes
      */
-    void referencedNodesIncrement(const CSinglyLinkedList<UA_NodeId *> &paNodes, CActionInfo &paActionInfo);
+    void referencedNodesIncrement(const std::vector<UA_NodeId *> &paNodes, CActionInfo &paActionInfo);
 
     /**
      * Removes the action from the references from all the nodes where it's present
@@ -378,7 +379,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
     /**
      * List for callback handles to be able to clean them up on destroy.
      */
-    CSinglyLinkedList<UA_VariableContext_Handle> mNodeCallbackHandles;
+    std::vector<std::unique_ptr<UA_VariableContext_Handle>> mNodeCallbackHandles;
 
     /**
      * Mutex used to avoid many threads (Resources) to access the server
@@ -436,7 +437,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
     /**
      * The list of parent/method information of the used methods
      */
-    CSinglyLinkedList<UA_ParentNodeHandler> mMethodsContexts;
+    std::vector<UA_ParentNodeHandler> mMethodsContexts;
 
     /**
      * Initialization of read and write of variables. It handles both existing and non-existing cases
@@ -490,7 +491,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
                                             CActionInfo::CNodePairInfo &paNodePairInfo,
                                             const CIEC_ANY &paVariable,
                                             size_t paIndexOfNodePair,
-                                            CSinglyLinkedList<UA_NodeId *> &paReferencedNodes,
+                                            std::vector<UA_NodeId *> &paReferencedNodes,
                                             bool paWrite);
 
     /**
@@ -640,7 +641,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      * @return UA_STATUSCODE_GOOD on success, other value otherwise
      */
     UA_StatusCode
-    getNode(CActionInfo::CNodePairInfo &paNodeInfo, CSinglyLinkedList<UA_NodeId *> &paFoundNodeIds, bool *paIsPresent);
+    getNode(CActionInfo::CNodePairInfo &paNodeInfo, std::vector<UA_NodeId *> &paFoundNodeIds, bool *paIsPresent);
 
     /**
      * Execute the TranslateBrowsePathToNodeIds service in the local OPC UA server from a string containing the path
@@ -655,7 +656,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
                                               UA_BrowsePath **paBrowsePaths,
                                               size_t *paFoldercount,
                                               size_t *paFirstNonExistingNode,
-                                              CSinglyLinkedList<UA_NodeId *> &paFoundNodeIds) const;
+                                              std::vector<UA_NodeId *> &paFoundNodeIds) const;
 
     /**
      * Store the existing node from a TranslateBrowsePathToNodeIds service in a list of node Ids
@@ -668,7 +669,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
     UA_StatusCode storeAlreadyExistingNodes(const UA_BrowsePathResult *paBrowsePathsResults,
                                             size_t paFolderCnt,
                                             size_t *paFirstNonExistingNode,
-                                            CSinglyLinkedList<UA_NodeId *> &paCreatedNodeIds) const;
+                                            std::vector<UA_NodeId *> &paCreatedNodeIds) const;
 
     /**
      * Create folder objects in the OPC UA server from the string. It's assumed that the end node is not present in the
@@ -677,7 +678,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      * @param paCreatedNodeIds Place to store the created nodeIds
      * @return UA_STATUSCODE_GOOD on success, other value otherwise
      */
-    UA_StatusCode createFolders(const char *paFolders, CSinglyLinkedList<UA_NodeId *> &paCreatedNodeIds) const;
+    UA_StatusCode createFolders(const char *paFolders, std::vector<UA_NodeId *> &paCreatedNodeIds) const;
 
     /**
      * Split a string into folders and node name. The provided place for store of the folder and node name are only
@@ -696,8 +697,8 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      * @param paReferencedNodes Place to store the NodeIds if paFailed is true
      * @param paFailed True if the NodeIds should be deleted, false if they need to be copied into paReferencedNodes
      */
-    void handlePresentNodes(const CSinglyLinkedList<UA_NodeId *> &paPresentNodes,
-                            CSinglyLinkedList<UA_NodeId *> &paReferencedNodes,
+    void handlePresentNodes(const std::vector<UA_NodeId *> &paPresentNodes,
+                            std::vector<UA_NodeId *> &paReferencedNodes,
                             bool paFailed) const;
 
     /**
@@ -710,8 +711,8 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      */
     struct CLocalMethodCall {
         CLocalMethodCall(CLocalMethodInfo &paActionInfo, COPC_UA_Helper::UA_SendVariable_handle &paSendHandle) :
-            mActionInfo(paActionInfo),
-            mSendHandle(paSendHandle) {
+            mActionInfo(&paActionInfo),
+            mSendHandle(&paSendHandle) {
         }
 
         // default copy constructor should be enough
@@ -720,8 +721,8 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
           return this == &rhs;
         }
 
-        CLocalMethodInfo &mActionInfo;
-        COPC_UA_Helper::UA_SendVariable_handle &mSendHandle;
+        CLocalMethodInfo *mActionInfo;
+        COPC_UA_Helper::UA_SendVariable_handle *mSendHandle;
     };
 
     /**
@@ -731,7 +732,7 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      * method call can be executed. Check if this is always true, and if yes, the following related functions and
      * variables aren't necessary, and only one CLocalMethodCall is necessary
      */
-    CSinglyLinkedList<CLocalMethodCall> mMethodCalls;
+    std::vector<CLocalMethodCall> mMethodCalls;
 
     /**
      * Mutex to access mMethodCalls

--- a/src/com/opc_ua/opcua_remote_handler.cpp
+++ b/src/com/opc_ua/opcua_remote_handler.cpp
@@ -53,8 +53,10 @@ void COPC_UA_Client_IterationList::addClient(CUA_ClientInformation &paClientInfo
 void COPC_UA_Client_IterationList::removeClient(CUA_ClientInformation &paClientInformation) {
   CCriticalRegion iterationListRegion(getIterationClientsMutex());
   CCriticalRegion newClientsRegion(getNewClientsMutex());
-  getNewClients().erase(&paClientInformation); // client could still be in the newList
-  getIterationClients().erase(&paClientInformation);
+
+  // client could still be in the newList
+  std::erase(getNewClients(), &paClientInformation);
+  std::erase(getIterationClients(), &paClientInformation);
 }
 
 void COPC_UA_Client_IterationList::run() {
@@ -79,29 +81,27 @@ void COPC_UA_Client_IterationList::resumeIterationLoop() {
 }
 
 void COPC_UA_Client_IterationList::addClientToList(CUA_ClientInformation &paClientInformation,
-                                                   CSinglyLinkedList<CUA_ClientInformation *> &paList) const {
+                                                   std::vector<CUA_ClientInformation *> &paList) const {
   bool elementAlreadyPresent = false;
-  for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = paList.begin();
-       itClientInformation != paList.end(); ++itClientInformation) {
-    if (&paClientInformation == (*itClientInformation)) {
+  for (auto clientInformation : paList) {
+    if (&paClientInformation == clientInformation) {
       elementAlreadyPresent = true;
       break;
     }
   }
 
   if (!elementAlreadyPresent) {
-    paList.pushBack(&paClientInformation);
+    paList.push_back(&paClientInformation);
   }
 }
 
 void COPC_UA_Client_IterationList::updateClientList() {
   CCriticalRegion iterationListRegion(getIterationClientsMutex());
   CCriticalRegion newClientsRegion(getNewClientsMutex());
-  for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = getNewClients().begin();
-       itClientInformation != getNewClients().end(); ++itClientInformation) {
-    addClientToList(**itClientInformation, getIterationClients());
+  for (auto clientInformation : getNewClients()) {
+    addClientToList(*clientInformation, getIterationClients());
   }
-  getNewClients().clearAll();
+  getNewClients().clear();
   mNewClientsPresent = false;
 }
 
@@ -193,13 +193,12 @@ UA_StatusCode COPC_UA_Remote_Handler::uninitializeAction(CActionInfo &paActionIn
 
 void COPC_UA_Remote_Handler::cleanResources() {
   CCriticalRegion criticalRegion(mAllClientListMutex);
-  for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = mAllClients.begin();
-       itClientInformation != mAllClients.end(); ++itClientInformation) {
-    mConnectionHandler.removeClient(**itClientInformation);
-    removeClient(**itClientInformation);
-    delete *itClientInformation;
+  for (auto clientInformation : mAllClients) {
+    mConnectionHandler.removeClient(*clientInformation);
+    removeClient(*clientInformation);
+    delete clientInformation;
   }
-  mAllClients.clearAll();
+  mAllClients.clear();
 }
 
 UA_StatusCode COPC_UA_Remote_Handler::getClientAndAddAction(CActionInfo &paActionInfo) {
@@ -216,17 +215,16 @@ CUA_ClientInformation *COPC_UA_Remote_Handler::getClient(const std::string &paEn
   CCriticalRegion allClientsRegion(mAllClientListMutex);
 
   CUA_ClientInformation *client = nullptr;
-  for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = mAllClients.begin();
-       itClientInformation != mAllClients.end(); ++itClientInformation) {
-    if ((*itClientInformation)->getEndpoint() == paEndpoint) {
-      client = (*itClientInformation);
+  for (auto clientInformation : mAllClients) {
+    if (clientInformation->getEndpoint() == paEndpoint) {
+      client = clientInformation;
       break;
     }
   }
   if (!client) {
     client = new CUA_ClientInformation(paEndpoint);
     if (client->configureClient()) {
-      mAllClients.pushBack(client);
+      mAllClients.push_back(client);
     } else {
       delete client;
       client = nullptr;
@@ -238,12 +236,11 @@ CUA_ClientInformation *COPC_UA_Remote_Handler::getClient(const std::string &paEn
 
 void COPC_UA_Remote_Handler::addActionToClient(CActionInfo &paActionInfo) {
   CCriticalRegion allClientsRegion(mAllClientListMutex);
-  for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = mAllClients.begin();
-       itClientInformation != mAllClients.end(); ++itClientInformation) {
-    CCriticalRegion clientRegion((*itClientInformation)->getMutex());
-    if ((*itClientInformation)->getEndpoint() == paActionInfo.getEndpoint()) {
-      (*itClientInformation)->addAction(paActionInfo);
-      addClientToConnectionHandler(**itClientInformation);
+  for (auto clientInformation : mAllClients) {
+    CCriticalRegion clientRegion(clientInformation->getMutex());
+    if (clientInformation->getEndpoint() == paActionInfo.getEndpoint()) {
+      clientInformation->addAction(paActionInfo);
+      addClientToConnectionHandler(*clientInformation);
       break;
     }
   }
@@ -253,12 +250,11 @@ void COPC_UA_Remote_Handler::removeActionFromClient(CActionInfo &paActionInfo) {
   CCriticalRegion allClientsRegion(mAllClientListMutex);
 
   CUA_ClientInformation *clientToDelete = nullptr;
-  for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = mAllClients.begin();
-       itClientInformation != mAllClients.end(); ++itClientInformation) {
-    CCriticalRegion clientRegion((*itClientInformation)->getMutex());
-    if ((*itClientInformation)->getEndpoint() == paActionInfo.getEndpoint()) {
-      (*itClientInformation)->removeAction(paActionInfo);
-      clientToDelete = *itClientInformation;
+  for (auto clientInformation : mAllClients) {
+    CCriticalRegion clientRegion(clientInformation->getMutex());
+    if (clientInformation->getEndpoint() == paActionInfo.getEndpoint()) {
+      clientInformation->removeAction(paActionInfo);
+      clientToDelete = clientInformation;
       break;
     }
   }
@@ -272,7 +268,7 @@ void COPC_UA_Remote_Handler::removeClientFromAllLists(CUA_ClientInformation &paC
   paClientInformation.setClientToInvalid();
   mConnectionHandler.removeClient(paClientInformation);
   removeClient(paClientInformation);
-  mAllClients.erase(&paClientInformation);
+  std::erase(mAllClients, &paClientInformation);
   delete &paClientInformation;
 }
 
@@ -283,16 +279,15 @@ void COPC_UA_Remote_Handler::addClientToConnectionHandler(CUA_ClientInformation 
 bool COPC_UA_Remote_Handler::handleClients() {
   CCriticalRegion iterationCriticalRegion(
       getIterationClientsMutex()); // this is needed because removing a client from the list could cause trouble
-  CSinglyLinkedList<CUA_ClientInformation *> failedClients;
+  std::vector<CUA_ClientInformation *> failedClients;
   bool asyncIsNeeded = false;
-  for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = getIterationClients().begin();
-       itClientInformation != getIterationClients().end(); ++itClientInformation) {
-    CCriticalRegion criticalRegionClienMutex((*itClientInformation)->getMutex());
-    if ((*itClientInformation)->isAsyncNeeded()) {
-      if (!(*itClientInformation)->executeAsyncCalls()) {
-        failedClients.pushBack(*itClientInformation);
+  for (auto clientInformation : getIterationClients()) {
+    CCriticalRegion criticalRegionClienMutex(clientInformation->getMutex());
+    if (clientInformation->isAsyncNeeded()) {
+      if (!clientInformation->executeAsyncCalls()) {
+        failedClients.push_back(clientInformation);
       } else {
-        asyncIsNeeded = (*itClientInformation)->isAsyncNeeded();
+        asyncIsNeeded = clientInformation->isAsyncNeeded();
       }
     }
     if (!isAlive()) {
@@ -300,20 +295,20 @@ bool COPC_UA_Remote_Handler::handleClients() {
     }
   }
 
-  if (isAlive() && !failedClients.isEmpty()) {
-    for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = failedClients.begin();
-         itClientInformation != failedClients.end(); ++itClientInformation) {
-      DEVLOG_ERROR("[OPC UA REMOTE]: There was a problem checking remote %s.\n",
-                   (*itClientInformation)->getEndpoint().c_str());
+  if (isAlive() && !failedClients.empty()) {
+    for (auto failedClient : failedClients) {
+      DEVLOG_ERROR("[OPC UA REMOTE]: There was a problem checking remote %s.\n", failedClient->getEndpoint().c_str());
 
       // we cannot use COPC_UA_Client_IterationList::remove here because it locks mIterationClientsMutex
       CCriticalRegion newClientsRegion(getNewClientsMutex());
-      CCriticalRegion criticalRegionClienMutex((*itClientInformation)->getMutex());
-      getIterationClients().erase(*itClientInformation);
-      getNewClients().erase(*itClientInformation); // client could still be in the newList
-      (*itClientInformation)->uninitializeClient(); // reset all in client and pass it back to the connection handler
-      (*itClientInformation)->configureClient();
-      addClientToConnectionHandler(**itClientInformation);
+      CCriticalRegion criticalRegionClienMutex(failedClient->getMutex());
+
+      std::erase(getIterationClients(), failedClient);
+      std::erase(getNewClients(), failedClient); // client could still be in the newList
+
+      failedClient->uninitializeClient(); // reset all in client and pass it back to the connection handler
+      failedClient->configureClient();
+      addClientToConnectionHandler(*failedClient);
     }
   }
   return asyncIsNeeded;
@@ -329,28 +324,26 @@ COPC_UA_Remote_Handler::UA_ConnectionHandler::~UA_ConnectionHandler() = default;
 
 bool COPC_UA_Remote_Handler::UA_ConnectionHandler::handleClients() {
   CCriticalRegion clientsClientsRegion(getIterationClientsMutex());
-  CSinglyLinkedList<CUA_ClientInformation *> clientsToRemove;
+  std::vector<CUA_ClientInformation *> clientsToRemove;
   bool needsRetry = false;
-  for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = getIterationClients().begin();
-       itClientInformation != getIterationClients().end(); ++itClientInformation) {
-    CCriticalRegion clientRegion((*itClientInformation)->getMutex());
-    if ((*itClientInformation)->handleClientState()) {
-      clientsToRemove.pushBack(*itClientInformation);
+  for (auto clientInformation : getIterationClients()) {
+    CCriticalRegion clientRegion(clientInformation->getMutex());
+    if (clientInformation->handleClientState()) {
+      clientsToRemove.push_back(clientInformation);
     } else {
       needsRetry = true;
     }
-    if ((*itClientInformation)->someActionWasInitialized()) {
-      mClientHandler.addClient(**itClientInformation);
+    if (clientInformation->someActionWasInitialized()) {
+      mClientHandler.addClient(*clientInformation);
     }
     if (!isAlive()) {
       break;
     }
   }
 
-  if (isAlive() && !clientsToRemove.isEmpty()) {
-    for (CSinglyLinkedList<CUA_ClientInformation *>::Iterator itClientInformation = clientsToRemove.begin();
-         itClientInformation != clientsToRemove.end(); ++itClientInformation) {
-      getIterationClients().erase(*itClientInformation);
+  if (isAlive() && !clientsToRemove.empty()) {
+    for (auto clientInformation : clientsToRemove) {
+      std::erase(getIterationClients(), clientInformation);
     }
   }
   return needsRetry;

--- a/src/com/opc_ua/opcua_remote_handler.h
+++ b/src/com/opc_ua/opcua_remote_handler.h
@@ -20,6 +20,7 @@
 #include "forte_config.h"
 #include "opcua_handler_abstract.h"
 #include "opcua_client_information.h"
+#include "fortelist.h"
 
 /**
  * Parent class used by the remote handler and the connection thread. They both iterate a list of clients and executed
@@ -87,7 +88,7 @@ class COPC_UA_Client_IterationList : public CThread {
      * @return mIterationClients
      */
 
-    CSinglyLinkedList<CUA_ClientInformation *> &getIterationClients() {
+    std::vector<CUA_ClientInformation *> &getIterationClients() {
       return mIterationClients;
     }
 
@@ -103,7 +104,7 @@ class COPC_UA_Client_IterationList : public CThread {
      * Access to private member mNewClients
      * @return mNewClients
      */
-    CSinglyLinkedList<CUA_ClientInformation *> &getNewClients() {
+    std::vector<CUA_ClientInformation *> &getNewClients() {
       return mNewClients;
     }
 
@@ -119,7 +120,7 @@ class COPC_UA_Client_IterationList : public CThread {
     /**
      * List of clients on which the iteration is done
      */
-    CSinglyLinkedList<CUA_ClientInformation *> mIterationClients;
+    std::vector<CUA_ClientInformation *> mIterationClients;
 
     /**
      * Mutex to access the list of clients which is iterated
@@ -129,7 +130,7 @@ class COPC_UA_Client_IterationList : public CThread {
     /**
      * List of new clients. It serves as a buffer that is latter added to the main iteration list
      */
-    CSinglyLinkedList<CUA_ClientInformation *> mNewClients;
+    std::vector<CUA_ClientInformation *> mNewClients;
 
     /**
      * Mutex to access the list of new clients
@@ -142,7 +143,7 @@ class COPC_UA_Client_IterationList : public CThread {
      * @param paList List where the client is added
      */
     void addClientToList(CUA_ClientInformation &paClientInformation,
-                         CSinglyLinkedList<CUA_ClientInformation *> &paList) const;
+                         std::vector<CUA_ClientInformation *> &paList) const;
 
     /**
      * Add the new clients to the main iteration list and clears the new clients list
@@ -295,7 +296,7 @@ class COPC_UA_Remote_Handler : public COPC_UA_HandlerAbstract, public COPC_UA_Cl
     /**
      * A list with all clients
      */
-    CSinglyLinkedList<CUA_ClientInformation *> mAllClients;
+    std::vector<CUA_ClientInformation *> mAllClients;
 
     /**
      *  Mutex to access the list with all clients


### PR DESCRIPTION
Some logic was also cleanup, mainly because there were memory problems which were easier to fix by cleaning up the logic.

Some things had to be changed to allow erasing elements from the vector, and to properly handle some pointers being passed to the library, some vector of objects had to be chaned to a vector of unique pointers