### PR TITLE
Add CMake presets for CI builds

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -30,15 +30,15 @@ jobs:
           - os: windows-latest
             c_compiler: cl
             cpp_compiler: cl
-            architecture: "Win32"
+            architecture: "windows"
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
-            architecture: "Posix"
+            architecture: "posix"
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
-            architecture: "Posix"
+            architecture: "posix"
         exclude:
           - os: windows-latest
             c_compiler: gcc
@@ -74,28 +74,7 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -S ${{ github.workspace }}
-        -DFORTE_ARCHITECTURE=${{ matrix.architecture }}
-        -DFORTE_DEVICE=RMT_DEV
-        -DFORTE_COM_ETH=ON
-        -DFORTE_COM_FBDK=ON
-        -DFORTE_COM_HTTP=ON
-        -DFORTE_COM_LOCAL=ON
-        -DFORTE_COM_RAW=ON
-        -DFORTE_COM_SER=ON
-        -DFORTE_COM_STRUCT_MEMBER=ON
-        -DFORTE_IO=ON
-        -DFORTE_MODULE_CONVERT=ON
-        -DFORTE_MODULE_IEC61131=ON
-        -DFORTE_MODULE_RECONFIGURATION=ON
-        -DFORTE_MODULE_RT_Events=ON
-        -DFORTE_MODULE_SIGNALPROCESSING=ON
-        -DFORTE_MODULE_UTILS=ON
-        -DFORTE_BUILD_STATIC_LIBRARY=ON
-        -DFORTE_BUILD_SHARED_LIBRARY=ON
-        -DFORTE_C_INTERFACE=ON
-        -DFORTE_TESTS=ON
-        -DFORTE_TEST_SANITIZE=ON
-        -DFORTE_TRACE_CTF=ON
+        --preset ${{ matrix.architecture }}-tests
         ${{ matrix.os == 'windows-latest' && format('-DFORTE_TESTS_INC_DIRS={0}/boost.1.84.0/lib/native/include', github.workspace) || '' }}
 
     - name: Build

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -31,27 +31,10 @@ jobs:
 
     - name: Configure CMake
       run: >
-        cmake -S ${{ steps.strings.outputs.source-dir }} -B ${{ steps.strings.outputs.build-dir }}
-        -DCMAKE_BUILD_TYPE=Debug
-        -DFORTE_ARCHITECTURE=Posix
-        -DFORTE_COM_ETH=ON
-        -DFORTE_COM_FBDK=ON
-        -DFORTE_COM_HTTP=ON
-        -DFORTE_COM_LOCAL=ON
-        -DFORTE_COM_RAW=ON
-        -DFORTE_COM_SER=ON
-        -DFORTE_COM_STRUCT_MEMBER=ON
-        -DFORTE_IO=ON
-        -DFORTE_MODULE_CONVERT=ON
-        -DFORTE_MODULE_IEC61131=ON
-        -DFORTE_MODULE_POWERLINK=ON
-        -DFORTE_MODULE_RECONFIGURATION=ON
-        -DFORTE_MODULE_RT_Events=ON
-        -DFORTE_MODULE_SIGNALPROCESSING=ON
-        -DFORTE_MODULE_UTILS=ON
-        -DFORTE_TESTS=ON
-        -DFORTE_SYSTEM_TESTS=ON
-        -DFORTE_TEST_SANITIZE=ON
+        cmake
+        -S ${{ steps.strings.outputs.source-dir }}
+        -B ${{ steps.strings.outputs.build-dir }}
+        --preset posix-systemtests
 
     - name: Build
       run: cmake --build ${{ steps.strings.outputs.build-dir }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,6 +21,45 @@
       }
     },
     {
+      "name": "base-tests",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "FORTE_COM_HTTP": "ON",
+        "FORTE_COM_RAW": "ON",
+        "FORTE_COM_SER": "ON",
+        "FORTE_COM_STRUCT_MEMBER": "ON",
+        "FORTE_IO": "ON",
+        "FORTE_MODULE_RECONFIGURATION": "ON",
+        "FORTE_MODULE_RT_Events": "ON",
+        "FORTE_MODULE_SIGNALPROCESSING": "ON",
+        "FORTE_TESTS": "ON",
+        "FORTE_TEST_SANITIZE": "ON"
+      }
+    },
+    {
+      "name": "tests",
+      "hidden": true,
+      "inherits": "base-tests",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "FORTE_BUILD_STATIC_LIBRARY": "ON",
+        "FORTE_BUILD_SHARED_LIBRARY": "ON",
+        "FORTE_C_INTERFACE": "ON",
+        "FORTE_TRACE_CTF": "ON"
+      }
+    },
+    {
+      "name": "systemtests",
+      "hidden": true,
+      "inherits": "base-tests",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "FORTE_MODULE_POWERLINK": "ON",
+        "FORTE_SYSTEM_TESTS": "ON"
+      }
+    },
+    {
       "name": "posix",
       "hidden": true,
       "inherits": "base",
@@ -48,6 +87,22 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
+    },
+    {
+      "name": "posix-tests",
+      "displayName": "Tests (Posix)",
+      "inherits": [
+        "tests",
+        "posix"
+      ]
+    },
+    {
+      "name": "posix-systemtests",
+      "displayName": "System Tests (Posix)",
+      "inherits": [
+        "systemtests",
+        "posix"
+      ]
     },
     {
       "name": "windows",
@@ -81,6 +136,22 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
+    },
+    {
+      "name": "windows-tests",
+      "displayName": "Tests (Windows)",
+      "inherits": [
+        "tests",
+        "windows"
+      ]
+    },
+    {
+      "name": "windows-systemtests",
+      "displayName": "System Tests (Windows)",
+      "inherits": [
+        "systemtests",
+        "windows"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add CMake presets for CI builds with tests and system tests. These presets allow to always use the same configuration as the CI builds.