### PR TITLE
Fix mingw build

### DIFF
--- a/src/core/devexec.h
+++ b/src/core/devexec.h
@@ -21,6 +21,7 @@ class CDevice;
 
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 /**\ingroup CORE
  Handles all the IEC 61499 execution requests and aspects within one device


### PR DESCRIPTION
Include `<cstdint>` explicitly to fix build error using mingw.