### PR TITLE
CI automatic format check

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,5 +1,11 @@
 src/core/trace/classic/generated/*
-src/core/trace/replay_debugging/*
-src/modules/*
+src/core/trace/replay_debugging/generated/*
 src/stdfblib/*
+src/stdfblib/*/*
 src/com/opc_ua/FBs/*
+src/com/opc_ua/FBs/*/*
+src/modules/*/*
+src/modules/*/*/*
+src/modules/*/*/*/*
+src/modules/*/*/*/*/*
+src/modules/*/*/*/*/*/*

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,4 @@
+rc/core/trace/classic/generated/*
+src/core/trace/replay_debugging/*
+src/modules/*
+src/stdfblib/*

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,4 +1,4 @@
-rc/core/trace/classic/generated/*
+src/core/trace/classic/generated/*
 src/core/trace/replay_debugging/*
 src/modules/*
 src/stdfblib/*

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -2,3 +2,4 @@ rc/core/trace/classic/generated/*
 src/core/trace/replay_debugging/*
 src/modules/*
 src/stdfblib/*
+src/com/opc_ua/FBs/*

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -22,7 +22,9 @@ jobs:
         id: find_sources
         run: |
           FILES=$(find src/ -type f \( -name "*.cpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" -o -name "*.hpp" \))
-
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Run clang-format check
         run: |
           echo "${{ steps.find_sources.outputs.files }}" | xargs clang-format --dry-run --Werror

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -17,15 +17,11 @@ jobs:
 
       - name: Install clang-format
         run: sudo apt-get install -y clang-format
-
-      - name: Find all source
-        id: find_sources
+      
+      - name: Run clang-format in dry mode
         run: |
-          FILES=$(find src/ -type f \( -name "*.cpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" -o -name "*.hpp" \))
-          echo "files<<EOF" >> $GITHUB_OUTPUT
-          echo "$FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-      - name: Run clang-format check
-        run: |
-          echo "${{ steps.find_sources.outputs.files }}" | xargs clang-format --dry-run --Werror
+          FILES=$(find src/ -type f -regex '.*\.\(c\|cpp\|cc\|h\|hpp\)$')
+          echo "Checking formatting on:"
+          echo "$FILES"
+          echo "$FILES" | xargs clang-format --dry-run --Werror
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,32 @@
+name: Clang Format Check
+
+on:
+  push:
+    branches: [ "release", "develop", "freeze", "feature/**" ]
+  pull_request:
+    branches: [ "release", "develop", "freeze", "feature/**" ]
+
+jobs:
+  clang-format:
+    name: Check Clang Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format
+
+      - name: Find all source
+        id: find_sources
+        run: |
+          FILES=$(find src/ -type f \( -name "*.cpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" -o -name "*.hpp" \))
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Run clang-format check
+        run: |
+          echo "${{ steps.find_sources.outputs.files }}" | xargs clang-format --dry-run --Werror
+

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -22,9 +22,6 @@ jobs:
         id: find_sources
         run: |
           FILES=$(find src/ -type f \( -name "*.cpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" -o -name "*.hpp" \))
-          echo "files<<EOF" >> $GITHUB_OUTPUT
-          echo "$FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Run clang-format check
         run: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,10 +18,6 @@ jobs:
       - name: Install clang-format
         run: sudo apt-get install -y clang-format
       
-      - name: Run clang-format in dry mode
-        run: |
-          FILES=$(find src/ -type f -regex '.*\.\(c\|cpp\|cc\|h\|hpp\)$')
-          echo "Checking formatting on:"
-          echo "$FILES"
-          echo "$FILES" | xargs clang-format --dry-run --Werror
+      - name: Run clang-format check script
+        run: ./checkstyle.sh
 

--- a/checkstyle.sh
+++ b/checkstyle.sh
@@ -1,43 +1,7 @@
 #!/bin/bash
-set -euo pipefail
+set -e
 
-cd "$(git rev-parse --show-toplevel)"
-
-IGNORE_FILE=".clang-format-ignore"
 SRC_DIR="src"
 
-ALL_FILES=$(find "$SRC_DIR" -type f -regex '.*\.\(c\|cpp\|cc\|h\|hpp\)$')
-
-if [[ -f "$IGNORE_FILE" ]]; then
-    mapfile -t IGNORE_PATTERNS < "$IGNORE_FILE"
-else
-    IGNORE_PATTERNS=()
-fi
-
-is_ignored() {
-    local file=$1
-    for pattern in "${IGNORE_PATTERNS[@]}"; do
-        if [[ "$file" == $pattern ]] || [[ "$file" == ./"$pattern" ]]; then
-            return 0
-        fi
-        if [[ "$file" == $pattern ]]; then
-            return 0
-        fi
-    done
-    return 1
-}
-
-CHECK_FILES=()
-for file in $ALL_FILES; do
-    if ! is_ignored "$file"; then
-        CHECK_FILES+=("$file")
-    fi
-done
-
-if [[ ${#CHECK_FILES[@]} -eq 0 ]]; then
-    echo "✅ No files to check"
-    exit 0
-fi
-
-echo "🔍 Checking formatting on ${#CHECK_FILES[@]} files..."
-clang-format --dry-run --Werror "${CHECK_FILES[@]}"
+cd "$(git rev-parse --show-toplevel)"
+find "$SRC_DIR" -type f -regex '.*\.\(c\|cpp\|cc\|h\|hpp\)' -exec clang-format --dry-run --Werror "{}" +

--- a/checkstyle.sh
+++ b/checkstyle.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+IGNORE_FILE=".clang-format-ignore"
+SRC_DIR="src"
+
+ALL_FILES=$(find "$SRC_DIR" -type f -regex '.*\.\(c\|cpp\|cc\|h\|hpp\)$')
+
+if [[ -f "$IGNORE_FILE" ]]; then
+    mapfile -t IGNORE_PATTERNS < "$IGNORE_FILE"
+else
+    IGNORE_PATTERNS=()
+fi
+
+is_ignored() {
+    local file=$1
+    for pattern in "${IGNORE_PATTERNS[@]}"; do
+        if [[ "$file" == $pattern ]] || [[ "$file" == ./"$pattern" ]]; then
+            return 0
+        fi
+        if [[ "$file" == $pattern ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+CHECK_FILES=()
+for file in $ALL_FILES; do
+    if ! is_ignored "$file"; then
+        CHECK_FILES+=("$file")
+    fi
+done
+
+if [[ ${#CHECK_FILES[@]} -eq 0 ]]; then
+    echo "✅ No files to check"
+    exit 0
+fi
+
+echo "🔍 Checking formatting on ${#CHECK_FILES[@]} files..."
+clang-format --dry-run --Werror "${CHECK_FILES[@]}"


### PR DESCRIPTION
This PR introduces a GitHub workflow which check if every file is well formatted according to our `.clang-format`, closes #379

Only one problem remains. As of now many files are not formatted correctly, so if this PR gets merged many errors will appear.
First, we need to introduce a formatted state of the source code.


Feedback welcome.


~To test it on your system, run the following script:~

```sh
#!/bin/bash
set -e

SRC_DIR="src"

cd "$(git rev-parse --show-toplevel)"
find "$SRC_DIR" -type f -regex '.*\.\(c\|cpp\|cc\|h\|hpp\)' -exec clang-format --dry-run --Werror "{}" +
```