### PR TITLE
Fix out-of-bounds iteration in CFBContainer::getFB

### DIFF
--- a/src/core/fbcontainer.cpp
+++ b/src/core/fbcontainer.cpp
@@ -172,11 +172,13 @@ CFunctionBlock *CFBContainer::getFB(CStringDictionary::TStringId paFBName) {
 }
 
 CFunctionBlock *CFBContainer::getFB(NameIterator &paNameListIt, NameIterator paNameListEnd) {
-  CFBContainer *childCont = getChild(*paNameListIt);
-  if (childCont != nullptr) {
-    // remove the container from the name list
-    ++paNameListIt;
-    return childCont->getFB(paNameListIt, paNameListEnd);
+  if (paNameListIt != paNameListEnd) {
+    CFBContainer *childCont = getChild(*paNameListIt);
+    if (childCont != nullptr) {
+      // remove the container from the name list
+      ++paNameListIt;
+      return childCont->getFB(paNameListIt, paNameListEnd);
+    }
   }
   // we are the last FB in the name list
   return isFB() ? static_cast<CFunctionBlock *>(this) : nullptr;


### PR DESCRIPTION
The `CFBContainer::getFB` did not check the end iterator and instead assumed that there would always be another element if a child container was found. This adds the missing check for the end.