### PR TITLE
Add CAN com

### DIFF
--- a/src/com/can/CANHandler.cpp
+++ b/src/com/can/CANHandler.cpp
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Alexander Trojnin github.com/trojninalex
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Alexander Trojnin - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include <sockhand.h>
+
+#include "fdselecthand.h"
+#include "devlog.h"
+#include "devexec.h"
+#include "commfb.h"
+#include "comCallback.h"
+#include "criticalregion.h"
+
+#include "CANHandler.h"
+
+DEFINE_HANDLER(CCANHandler);
+
+CCANHandler::CCANHandler(CDeviceExecution &paDeviceExecution) : CExternalEventHandler(paDeviceExecution)
+{
+    mConnectionListChanged = false;
+}
+
+CCANHandler::~CCANHandler()
+{
+    mConnectionsList.clear();
+
+    this->end();
+}
+
+void CCANHandler::addComCallback(CFDSelectHandler::TFileDescriptor paFD, forte::com_infra::CComCallback *paCanLayer)
+{
+    DEVLOG_DEBUG("[CAN Handler] add callback");
+
+    CCriticalRegion criticalRegion(mSync);
+    TConnContType stNewNode(paFD, paCanLayer);
+
+    mConnectionsList.push_back(stNewNode);
+    mConnectionListChanged = true;
+    
+    if (!isAlive())
+    {
+        this->start();
+    }
+}
+
+void CCANHandler::removeComCallback(CFDSelectHandler::TFileDescriptor paFD)
+{
+    CCriticalRegion criticalRegion(mSync);
+
+    auto itRunner(mConnectionsList.begin());
+    auto itRefNode(mConnectionsList.end());
+    auto itEnd(mConnectionsList.end());
+
+    while (itRunner != itEnd)
+    {
+        if (itRunner->mSockDes == paFD)
+        {
+            if (itRefNode != itEnd)
+            {
+                mConnectionsList.erase(itRefNode);
+            }
+            break;
+        }
+
+        itRefNode = itRunner;
+        ++itRunner;
+    }
+
+    mConnectionListChanged = true;
+}
+
+CFDSelectHandler::TFileDescriptor CCANHandler::createFDSet(fd_set *m_panFDSet)
+{
+    CFDSelectHandler::TFileDescriptor nRetVal = scmInvalidFileDescriptor;
+    FD_ZERO(m_panFDSet);
+
+    auto itEnd(mConnectionsList.end());
+    for (auto itRunner = mConnectionsList.begin(); itRunner != itEnd; ++itRunner)
+    {
+        FD_SET(itRunner->mSockDes, m_panFDSet);
+        if (itRunner->mSockDes > nRetVal || scmInvalidFileDescriptor == nRetVal)
+        {
+            nRetVal = itRunner->mSockDes;
+        }
+    }
+    mConnectionListChanged = false;
+    return nRetVal;
+}
+
+void CCANHandler::run()
+{
+    while (isAlive())
+    {
+        DEVLOG_DEBUG("[CAN Handler] method run\n");
+        auto itEnd(mConnectionsList.end());
+        for (auto itRunner = mConnectionsList.begin(); itRunner != itEnd; ++itRunner)
+        {
+            memset(&frame, 0, sizeof(can_frame));
+
+            if (read(itRunner->mSockDes, &frame, sizeof(struct can_frame)) > 0)
+            {
+                DEVLOG_DEBUG("[CAN Handler] readd data\n");
+                forte::com_infra::CComCallback *called = itRunner->mCalled;
+                
+                if (forte::com_infra::e_Nothing != called->recvData(&frame, frame.can_dlc))
+                {
+                    startNewEventChain(called->getCommFB());
+                }
+            }
+        }
+
+        CThread::sleepThread(1);
+    }
+}

--- a/src/com/can/CANHandler.h
+++ b/src/com/can/CANHandler.h
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Alexander Trojnin github.com/trojninalex
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Alexander Trojnin - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#ifndef CANHANDLER_H_
+#define CANHANDLER_H_
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+#include <sockhand.h>
+#include <forte_config.h>
+#include <extevhan.h>
+#include <comlayer.h>
+
+#include "CANLayer.h"
+
+class CCANHandler : public CExternalEventHandler, private CThread
+{
+    DECLARE_HANDLER(CCANHandler)
+public:
+    void addComCallback(CFDSelectHandler::TFileDescriptor paFD, forte::com_infra::CComCallback *paCanLayer);
+    void removeComCallback(CFDSelectHandler::TFileDescriptor paFD);
+
+    void enableHandler(void)
+    {
+        start();
+    }
+
+    void disableHandler(void)
+    {
+        end();
+    }
+
+    void setPriority(int)
+    {
+    }
+
+    int getPriority(void) const
+    {
+        return 0;
+    }
+
+protected:
+    virtual void run(void);
+
+private:
+    struct TConnContType
+    {
+        CFDSelectHandler::TFileDescriptor mSockDes;
+        forte::com_infra::CComCallback *mCalled;
+    };
+
+    struct can_frame frame;
+
+    const CFDSelectHandler::TFileDescriptor scmInvalidFileDescriptor = FORTE_INVALID_SOCKET;
+
+    typedef std::vector <TConnContType> TConnectionContainer;
+
+    CFDSelectHandler::TFileDescriptor createFDSet(fd_set *m_panFDSet);
+
+    TConnectionContainer mConnectionsList;
+    CSyncObject mSync;
+    bool mConnectionListChanged;
+};
+
+#endif

--- a/src/com/can/CANLayer.cpp
+++ b/src/com/can/CANLayer.cpp
@@ -1,0 +1,252 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Malte Grave, LIT CPS Johannes Kepler Universität,
+ *                                 github.com/gravemalte
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Malte Grave, Alexander Trojnin - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <linux/can.h>
+#include <string>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <vector>
+
+#include "basecommfb.h"
+#include "comtypes.h"
+#include "datatype.h"
+#include "devlog.h"
+#include "forte_any.h"
+#include "forte_array.h"
+#include "string_utils.h"
+
+#include "CANLayer.h"
+#include "CANHandler.h"
+
+using namespace forte::com_infra;
+
+CCANComLayer::CCANComLayer(CComLayer *paUpperLayer, CBaseCommFB *paComFB)
+    : CComLayer(paUpperLayer, paComFB) {}
+
+EComResponse CCANComLayer::openConnection(char *paLayerParameter)
+{
+  EComResponse eRetVal = e_InitInvalidId;
+  CParameterParser parser(paLayerParameter, ';', eCANComParamterAmount);
+  if (eCANComParamterAmount != parser.parseParameters())
+  {
+    DEVLOG_ERROR("[CAN Layer] Parsing of the parameters failed.\n");
+    return eRetVal;
+  }
+
+  SCANParameters can_params = setupCANInternals(parser);
+
+  DEVLOG_DEBUG("[CAN Layer] Opening connection\n");
+
+  CFDSelectHandler::TFileDescriptor fd = socket(PF_CAN, SOCK_RAW | SOCK_NONBLOCK, CAN_RAW);
+
+  switch (mFb->getComServiceType())
+  {
+  case e_Server:
+    DEVLOG_ERROR("[CAN Layer] the layer only supports the PUB/SUB "
+                  "pattern. Please use a Publisher block to send data.");
+    eRetVal = e_InitTerminated;
+    break;
+  case e_Client:
+    DEVLOG_ERROR("[CAN Layer] the layer only supports the PUB/SUB "
+                 "pattern. Please use a Subscribe block to receive data.");
+    eRetVal = e_InitTerminated;
+    break;
+  case e_Publisher:
+    // is only sendData
+    mFrame.can_id = can_params.CANId;
+    break;
+  case e_Subscriber:
+    // is only recvData
+    rfilter.can_id = can_params.CANId;
+    rfilter.can_mask = CAN_SFF_MASK;
+    setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, &rfilter, sizeof(rfilter));
+    break;
+
+  default:
+    DEVLOG_ERROR("[CAN Layer] Invalid COM service type.\n");
+    eRetVal = e_InitTerminated;
+    break;
+  }
+
+  if (eRetVal != e_InitInvalidId)
+  {
+    return eRetVal;
+  }
+
+  if (CFDSelectHandler::scmInvalidFileDescriptor == fd)
+  {
+    DEVLOG_ERROR("[CAN Layer] Socket can't be created: %s\n", strerror(errno));
+    return e_InitInvalidId;
+  }
+
+  std::strncpy(mIfr.ifr_name, can_params.interfaceName.c_str(), IFNAMSIZ - 1);
+  mIfr.ifr_name[IFNAMSIZ - 1] = '\0'; // Ensure that null termination is added if input is too long.
+  
+  if (-1 == ioctl(fd, SIOCGIFINDEX, &mIfr))
+  {
+    DEVLOG_ERROR("[CAN Layer] Socket cannot be controlled. %s\n",
+                 strerror(errno));
+    close(fd);
+    return eRetVal;
+  }
+
+  mCANSocket = fd;
+  mAddr.can_family = AF_CAN;
+  mAddr.can_ifindex = mIfr.ifr_ifindex;
+
+  if (-1 == bind(mCANSocket, (struct sockaddr *)&mAddr, sizeof(mAddr)))
+  {
+    DEVLOG_ERROR("[CAN Layer] Binding of the socket unsuccessful: %s\n",
+                 strerror(errno));
+    close(mCANSocket);
+    return eRetVal;
+  }
+
+  this->getExtEvHandler<CCANHandler>().addComCallback(mCANSocket, this);
+  DEVLOG_DEBUG("[CAN Layer] Callback handler added.\n");
+
+  eRetVal = e_InitOk;
+  return eRetVal;
+}
+
+CCANComLayer::~CCANComLayer() {}
+
+void CCANComLayer::closeConnection()
+{
+  if (mCANSocket != CFDSelectHandler::scmInvalidFileDescriptor)
+  {
+    DEVLOG_DEBUG("[CAN Layer] Closing socket\n");
+    close(mCANSocket);
+    DEVLOG_DEBUG("[CAN Layer] Unregister layer\n");
+    this->getExtEvHandler<CCANHandler>().removeComCallback(mCANSocket);
+  }
+}
+
+EComResponse CCANComLayer::sendData(void *paData, unsigned int)
+{
+  EComResponse eRetVal = e_InitOk;
+
+  CIEC_ANY **apoSDs = mFb->getSDs();
+  size_t size = mFb->getNumSD(); 
+
+  uint8_t *data = new uint8_t[size];
+
+  for (size_t i = 0; i < size; i++)
+  {
+    CIEC_ANY &sd(apoSDs[i]->unwrap());
+    data[i] = *sd.getConstDataPtr();
+    DEVLOG_DEBUG("[CAN Layer] send data[%d] = %d\n", i, data[i]);
+  }
+
+  eRetVal = e_ProcessDataOk;
+
+  size_t offset = 0;
+  while (offset < size && eRetVal == e_ProcessDataOk)
+  {
+
+    mFrame.can_dlc = static_cast<uint8_t>(
+        (size - offset > CAN_MAX_DLEN) ? CAN_MAX_DLEN : (size - offset));
+
+    // Clear old data and copy new chunk
+    std::memset(mFrame.data, 0, CAN_MAX_DLEN);
+    std::memcpy(mFrame.data, data + offset, mFrame.can_dlc);
+
+    offset += mFrame.can_dlc;
+
+    DEVLOG_DEBUG("[CAN Layer] Sending data ...\n");
+
+    if (write(mCANSocket, &mFrame, sizeof(struct can_frame)) < 0)
+    {
+      DEVLOG_ERROR("CAN send failed: %s\n", strerror(errno));
+      eRetVal = e_ProcessDataSendFailed;
+      break;
+    }
+  }
+
+  delete[] data;
+
+  return e_ProcessDataOk;
+}
+
+EComResponse CCANComLayer::recvData(const void *paData, unsigned int paSize)
+{
+  DEVLOG_DEBUG("[CAN Layer] Receive data.\n");
+
+  m_eInterruptResp = e_Nothing;
+
+  if (mFb->getComServiceType() == e_Subscriber)
+  {
+    const can_frame *frame = (can_frame*)(paData);
+    memcpy(&mFrame, frame, sizeof(struct can_frame));
+
+    mFb->interruptCommFB(this);
+    m_eInterruptResp = e_ProcessDataOk;
+  }
+
+  return m_eInterruptResp;
+}
+
+EComResponse CCANComLayer::processInterrupt()
+{
+  DEVLOG_DEBUG("[CAN Layer] Interupt process.\n");
+
+  if (m_eInterruptResp == e_ProcessDataOk)
+  {
+    CIEC_ANY **apoRDs = mFb->getRDs();
+    size_t size_rd = mFb->getNumRD();
+
+     DEVLOG_DEBUG("[CAN Layer] Size rd: %d,\tpaSize: %d\n", size_rd, mFrame.can_dlc);
+
+    for (size_t i = 0; i < size_rd; i++)
+    {
+      CIEC_ANY &rd(apoRDs[i]->unwrap());
+      
+      if (i >= mFrame.can_dlc)
+      {
+         DEVLOG_DEBUG("[CAN Layer] Data[%d] = %d\n", i, 0);
+        rd.setValue(CIEC_BYTE(0));
+      }
+      else
+      {
+        DEVLOG_DEBUG("[CAN Layer] Data[%d] = %d\n", i, mFrame.data[i]);
+        rd.setValue(CIEC_BYTE(mFrame.data[i]));
+      }
+    }
+  }
+
+  return m_eInterruptResp;
+}
+
+CCANComLayer::SCANParameters
+CCANComLayer::setupCANInternals(CParameterParser &parser)
+{
+  SCANParameters can_params;
+
+  can_params.interfaceName =
+      std::string(parser[eInterface], strlen(parser[eInterface]));
+
+  can_params.CANId = static_cast<TForteUInt32>( \
+      forte::core::util::strtoul(parser[eCANId], nullptr, 10));
+
+  DEVLOG_DEBUG(
+      "[CAN Layer] Using interface: %s and CAN-ID: %u\n",
+      can_params.interfaceName.c_str(), can_params.CANId);
+
+  return can_params;
+}

--- a/src/com/can/CANLayer.h
+++ b/src/com/can/CANLayer.h
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Malte Grave, LIT CPS Johannes Kepler Universität,
+ *                                 github.com/gravemalte
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Malte Grave, Alexander Trojnin - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#pragma once
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <net/if.h>
+
+#include <sockhand.h>
+
+#include "comlayer.h"
+#include "datatype.h"
+#include "gensockhand.h"
+#include "parameterParser.h"
+#include "string"
+
+#include "CANHandler.h"
+
+namespace forte
+{
+  namespace com_infra
+  {
+
+    class CCANComLayer : public CComLayer
+    {
+    public:
+      typedef FORTE_SOCKET_TYPE TCANSocketHandle;
+
+      CCANComLayer(CComLayer *paUpperLayer, CBaseCommFB *paComFB);
+      ~CCANComLayer() override;
+
+      EComResponse sendData(void *paData, unsigned int paSize) override;
+      EComResponse recvData(const void *paData, unsigned int paSize) override;
+
+      EComResponse processInterrupt() override;
+
+    private:
+      struct SCANParameters
+      {
+        std::string interfaceName;
+        TForteUInt32 CANId;
+      };
+
+      enum ECANCommunicationParameter
+      {
+        eInterface = 0,
+        eCANId = 1,
+        eCANComParamterAmount = 2
+      };
+
+      CFDSelectHandler::TFileDescriptor mCANSocket =
+          CFDSelectHandler::scmInvalidFileDescriptor;
+
+      EComResponse m_eInterruptResp;
+
+      struct sockaddr_can mAddr;
+      struct ifreq mIfr;
+      struct can_frame mFrame;
+      struct can_filter rfilter;
+
+      EComResponse openConnection(char *paLayerParameter) override;
+      void closeConnection() override;
+
+      SCANParameters setupCANInternals(CParameterParser &parser);
+    };
+  }
+} // namespace forte::com_infra

--- a/src/com/can/CMakeLists.txt
+++ b/src/com/can/CMakeLists.txt
@@ -1,0 +1,59 @@
+# *******************************************************************************
+# *******************************************************************************
+# Copyright (c) 2025 Malte Grave, LIT CPS Johannes Kepler Universität,
+#                                 github.com/gravemalte
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     Malte Grave, Alexander Trojnin - initial API and implementation and/or initial documentation
+# *******************************************************************************/
+# *******************************************************************************/
+#############################################################################
+# CAN Com Layer (currently only usable on Linux)
+#############################################################################
+
+forte_add_network_layer(CAN OFF "can" CCANComLayer CANLayer "Enable the CAN Commuication Layer")
+set(FORTE_COM_CAN_MODULE_CHECK OFF CACHE BOOL "Build Tests")
+
+if(FORTE_COM_CAN)
+  if(FORTE_COM_CAN_MODULE_CHECK)
+    execute_process(
+      COMMAND lsmod
+      COMMAND grep -wE "^(can|can_raw|vcan|can_dev)"
+      COMMAND awk "{print $1}"
+      COMMAND tr "\n" " "
+      OUTPUT_VARIABLE CAN_MODULES_FOUND
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    
+    message(STATUS "Found CAN modules: ${CAN_MODULES_FOUND}")
+    if(NOT "${CAN_MODULES_FOUND}" MATCHES "can")
+        message(FATAL_ERROR "can module is missing!")
+    endif(NOT "${CAN_MODULES_FOUND}" MATCHES "can")
+    
+    if(NOT "${CAN_MODULES_FOUND}" MATCHES "vcan")
+        message(FATAL_ERROR "vcan module is missing!")
+    endif(NOT "${CAN_MODULES_FOUND}" MATCHES "vcan")
+
+    if(NOT "${CAN_MODULES_FOUND}" MATCHES "can_raw")
+        message(FATAL_ERROR "can_raw module is missing!")
+    endif(NOT "${CAN_MODULES_FOUND}" MATCHES "can_raw")
+
+    if(NOT "${CAN_MODULES_FOUND}" MATCHES "can_dev")
+        message(FATAL_ERROR "can_dev module is missing!")
+    endif(NOT "${CAN_MODULES_FOUND}" MATCHES "can_dev")
+
+  endif(FORTE_COM_CAN_MODULE_CHECK)
+
+  forte_add_include_directories(${CMAKE_CURRENT_SOURCE_DIR})  
+  forte_add_sourcefile_hcpp(
+    CANHandler
+  )
+
+  forte_add_handler(CCANHandler CANHandler)
+
+endif(FORTE_COM_CAN)


### PR DESCRIPTION
That CAN communication layer for Linux develop on the basic pull-request 
for @gravemalte https://github.com/eclipse-4diac/4diac-forte/pull/367.

The current version realize classical CAN frame structure (aka CAN2.0B). Added class CANHandler for processing receive in thread and make data handling. 

FB support: Subscribe (receive) и Publish (transmit).

Publish:
In method sendData maked changes, writed to can-frame of value port SD, i.e. can-frame.data[0] = SD[0], can-frame.data[1] = SD[1], ..., can-frame.data[7] = SD[7]. If SD.count < 8, then to compensate write zero for lost bytes. ID block set in next format: can[<can_interface>;<id_message>], example can[can0;10].

Subscribe:
Logic write from can-frame.data to RD ports equal logic of FB Subscribe. In this block filter message on theirs ID message. It ID have next format:
can[<can_interface>;<id_filter_message>], example can[can1;5].

Example work:

![Screenshot from 2025-06-22 10-03-52](https://github.com/user-attachments/assets/4c6dc31f-bffb-4f04-a0e0-db827847b7b8)

