### PR TITLE
Fix compile error in the IEC61131-3 package using the debug log level

### DIFF
--- a/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
@@ -83,7 +83,7 @@ bool GEN_ADD::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &
   pcPos++;
   // we have an underscore and it is the first underscore after AND
   unsigned int numDIs = static_cast<unsigned int>(forte::core::util::strtoul(pcPos, nullptr, 10));
-  DEVLOG_DEBUG("DIs: %d;\n", paInterfaceSpec.getNumDIs());
+  DEVLOG_DEBUG("DIs: %d;\n", numDIs);
 
   if (numDIs < 2) {
     return false;

--- a/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
+++ b/src/modules/IEC61131-3/Arithmetic/GEN_ADD_fbt.cpp
@@ -83,7 +83,7 @@ bool GEN_ADD::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &
   pcPos++;
   // we have an underscore and it is the first underscore after AND
   unsigned int numDIs = static_cast<unsigned int>(forte::core::util::strtoul(pcPos, nullptr, 10));
-  DEVLOG_DEBUG("DIs: %d;\n", mDInputs);
+  DEVLOG_DEBUG("DIs: %d;\n", paInterfaceSpec.getNumDIs());
 
   if (numDIs < 2) {
     return false;

--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -52,7 +52,7 @@ bool CGenBitBase::createInterfaceSpec(const char *paConfigString, SFBInterfaceSp
     pcPos++;
     // we have an underscore and it is the first underscore after AND
     numDIs = static_cast<TPortId>(forte::core::util::strtoul(pcPos, nullptr, 10));
-    DEVLOG_DEBUG("DIs: %d;\n", paInterfaceSpec.mNumDIs);
+    DEVLOG_DEBUG("DIs: %d;\n", paInterfaceSpec.getNumDIs());
   } else {
     return false;
   }

--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -52,7 +52,7 @@ bool CGenBitBase::createInterfaceSpec(const char *paConfigString, SFBInterfaceSp
     pcPos++;
     // we have an underscore and it is the first underscore after AND
     numDIs = static_cast<TPortId>(forte::core::util::strtoul(pcPos, nullptr, 10));
-    DEVLOG_DEBUG("DIs: %d;\n", paInterfaceSpec.getNumDIs());
+    DEVLOG_DEBUG("DIs: %d;\n", numDIs);
   } else {
     return false;
   }


### PR DESCRIPTION
This little PR fixes the compile issue in the IEC61131-3 package, in which the old interface API was used in two `DEVLOG_DEBUG(...)` statements.

The CI didn't catch the error because the binaries are not build using the debug level.