### PR TITLE
Add OPC UA property mapping to support IEC 61499 data in HMI tools

### DIFF
--- a/src/com/opc_ua/opcua_ac_layer.cpp
+++ b/src/com/opc_ua/opcua_ac_layer.cpp
@@ -32,6 +32,12 @@ char COPC_UA_AC_Layer::smTime[] = "Time";
 char COPC_UA_AC_Layer::smRetain[] = "Retain";
 char COPC_UA_AC_Layer::smSeverity[] = "Severity";
 
+const std::unordered_map<std::string, std::string> COPC_UA_AC_Layer::sm1499ToUAMap = {
+  {"Area", "ClientUserId"},
+  {"Origin", "ConditionName"},
+  {"Source", "SourceName"}
+};
+
 UA_UInt16 COPC_UA_AC_Layer::smSeverityValue = 500;
 
 COPC_UA_AC_Layer::COPC_UA_AC_Layer(CComLayer *paUpperLayer, CBaseCommFB *paComFB) :
@@ -162,7 +168,10 @@ EComResponse COPC_UA_AC_Layer::createOPCUAObject(UA_Server *paServer, const std:
   if(addOPCUACondition(paServer, objectBrowsePath, conditionBrowsePath) != UA_STATUSCODE_GOOD) {
     return e_InitTerminated;
   }
-  if(initializeMemberActions(conditionBrowsePath) != e_InitOk) {
+  if(initializeMapping() != UA_STATUSCODE_GOOD) {
+    return e_InitTerminated;
+  }
+  if (initializeMemberActions(conditionBrowsePath) != e_InitOk) {
     return e_InitTerminated;
   }
   return setConditionCallbacks(paServer);
@@ -246,6 +255,36 @@ UA_StatusCode COPC_UA_AC_Layer::addOPCUACondition(UA_Server *paServer, const std
   return status;
 }
 
+UA_StatusCode COPC_UA_AC_Layer::initializeMapping() {
+  COPC_UA_Local_Handler *localHandler = static_cast<COPC_UA_Local_Handler *>(mHandler);
+  UA_BrowseDescription nodesToBrowse;
+  nodesToBrowse.nodeId = mConditionInstanceId;
+  nodesToBrowse.browseDirection = UA_BROWSEDIRECTION_FORWARD;
+  nodesToBrowse.nodeClassMask = UA_NODECLASS_VARIABLE;
+  nodesToBrowse.resultMask = UA_BROWSERESULTMASK_BROWSENAME;
+  UA_BrowseResult result = localHandler->browseServer(nodesToBrowse);
+
+  size_t foundProperties = 0;  
+  for(size_t i = 0; i < result.referencesSize; i++) {
+    UA_ReferenceDescription *ref = &result.references[i];
+
+    // TODO: Find alternative to reinterpret_cast
+    std::string browseName(reinterpret_cast<const char*>(ref->browseName.name.data), ref->browseName.name.length);
+
+    if(mUAPropertyMap.find(browseName) != mUAPropertyMap.end()) {
+      mUAPropertyMap[browseName] = ref->nodeId.nodeId;
+      foundProperties++;
+    }
+  }
+  UA_BrowseResult_clear(&result);
+  if(foundProperties != mUAPropertyMap.size()) {
+    DEVLOG_ERROR("[OPC UA A&C LAYER]: Number of found properties does not match number of properties to be mapped. Expected: %d, Actual: %d",
+                mUAPropertyMap.size(), foundProperties);
+    return UA_STATUSCODE_BADNODEIDUNKNOWN;
+  }
+  return UA_STATUSCODE_GOOD;
+}
+
 EComResponse COPC_UA_AC_Layer::setConditionCallbacks(UA_Server *paServer) {
   EComResponse eRetVal = e_InitOk;
   UA_TwoStateVariableChangeCallback callback = enabledStateCallback;
@@ -272,11 +311,18 @@ EComResponse COPC_UA_AC_Layer::initializeMemberActions(const std::string &paPare
   size_t numPorts = getCommFB()->getNumSD();
   const SFBInterfaceSpec &interfaceSpec = getCommFB()->getFBInterfaceSpec();
   const CStringDictionary::TStringId *dataPortNameIds = interfaceSpec.mDINames;
-  for(size_t i = 0; i < numPorts; i++) {
-    std::string dataPortName = getPortNameFromConnection(dataPortNameIds[i+2], true);
-    std::string memberBrowsePath(COPC_UA_ObjectStruct_Helper::getMemberBrowsePath(paParentBrowsePath, dataPortName));
-    UA_NodeId *nodeId = COPC_UA_ObjectStruct_Helper::createStringNodeIdFromBrowsepath(memberBrowsePath);
-    mMemberActionInfo->getNodePairInfo().emplace_back(nodeId, memberBrowsePath);
+  for (size_t i = 0; i < numPorts; i++) {
+    std::string dataPortName = getPortNameFromConnection(dataPortNameIds[i + 2], true);
+    auto propertyKeyIt = sm1499ToUAMap.find(dataPortName);
+    if(propertyKeyIt != sm1499ToUAMap.end()) {
+      UA_NodeId *nodeId = UA_NodeId_new();
+      UA_NodeId_copy(&mUAPropertyMap[propertyKeyIt->second], nodeId);
+      mMemberActionInfo->getNodePairInfo().emplace_back(nodeId, std::string());
+    } else { 
+      std::string memberBrowsePath(COPC_UA_ObjectStruct_Helper::getMemberBrowsePath(paParentBrowsePath, dataPortName));
+      UA_NodeId *nodeId = COPC_UA_ObjectStruct_Helper::createStringNodeIdFromBrowsepath(memberBrowsePath);
+      mMemberActionInfo->getNodePairInfo().emplace_back(nodeId, memberBrowsePath);
+    }
   }
   if(mHandler->initializeAction(*mMemberActionInfo) != UA_STATUSCODE_GOOD) {
       DEVLOG_ERROR("[OPC UA A&C LAYER]: Error occured in FB %s while initializing members\n", getCommFB()->getInstanceName());
@@ -312,9 +358,9 @@ EComResponse COPC_UA_AC_Layer::addOPCUATypeProperties(UA_Server *paServer, const
   size_t numDataPorts = paIsPublisher ? getCommFB()->getNumSD() : getCommFB()->getNumRD();
   const SFBInterfaceSpec &interfaceSpec = getCommFB()->getFBInterfaceSpec();
   const CStringDictionary::TStringId *dataPortNameIds = paIsPublisher ? interfaceSpec.mDINames : interfaceSpec.mDONames;
-  for(size_t i = 0; i < numDataPorts; i++) {
-    std::string dataPortName = getPortNameFromConnection(dataPortNameIds[i+2], paIsPublisher);
-    char* propertyName = getNameFromString(dataPortName);
+  for (size_t i = 0; i < numDataPorts; i++) {
+    std::string dataPortName = getPortNameFromConnection(dataPortNameIds[i + 2], paIsPublisher);
+    char *propertyName = getNameFromString(dataPortName);
     UA_StatusCode status = addVariableNode(paServer, paTypeName, propertyName, apoDataPorts[i]->unwrap());
     if(status != UA_STATUSCODE_GOOD) {
       DEVLOG_ERROR("[OPC UA A&C LAYER]: Failed to add OPCUA AlarmType Property for FB %s, Port: %s, Status: %s\n", getCommFB()->getInstanceName(), dataPortName, UA_StatusCode_name(status));

--- a/src/com/opc_ua/opcua_ac_layer.cpp
+++ b/src/com/opc_ua/opcua_ac_layer.cpp
@@ -268,10 +268,7 @@ UA_StatusCode COPC_UA_AC_Layer::initializeMapping() {
   size_t foundProperties = 0;  
   for(size_t i = 0; i < result.referencesSize; i++) {
     UA_ReferenceDescription *ref = &result.references[i];
-
-    // TODO: Find alternative to reinterpret_cast
-    std::string browseName(reinterpret_cast<const char*>(ref->browseName.name.data), ref->browseName.name.length);
-
+    std::string browseName((const char*)ref->browseName.name.data, ref->browseName.name.length);
     if(mUAPropertyMap.find(browseName) != mUAPropertyMap.end()) {
       mUAPropertyMap[browseName] = ref->nodeId.nodeId;
       foundProperties++;

--- a/src/com/opc_ua/opcua_ac_layer.cpp
+++ b/src/com/opc_ua/opcua_ac_layer.cpp
@@ -21,25 +21,29 @@
 
 using namespace forte::com_infra;
 
-const std::string COPC_UA_AC_Layer::scmAlarmTypeBrowsePath = "/Types/0:EventTypes/0:BaseEventType/0:ConditionType/0:AcknowledgeableConditionType/0:AlarmConditionType/%d:";
-const std::string COPC_UA_AC_Layer::scmAlarmConditionName = "AlarmCondition";
+namespace {
+  const std::string scmAlarmTypeBrowsePath = "/Types/0:EventTypes/0:BaseEventType/0:ConditionType/0:AcknowledgeableConditionType/0:AlarmConditionType/%d:";
+  const std::string scmAlarmConditionName = "AlarmCondition";
 
-char COPC_UA_AC_Layer::smEmptyString[] = "";
-char COPC_UA_AC_Layer::smEnabledState[] = "EnabledState";
-char COPC_UA_AC_Layer::smEnableStateProperty[] = "EnableState"; // This is needed to avoid potential delete-subscription error with HMI tools
-char COPC_UA_AC_Layer::smActiveState[] = "ActiveState";
-char COPC_UA_AC_Layer::smId[] = "Id";
-char COPC_UA_AC_Layer::smTime[] = "Time";
-char COPC_UA_AC_Layer::smRetain[] = "Retain";
-char COPC_UA_AC_Layer::smSeverity[] = "Severity";
+  char smEmptyString[] = "";
+  char smEnabledState[] = "EnabledState";
+  char smEnableStateProperty[] = "EnableState"; // This is needed to avoid potential delete-subscription error with HMI tools
+  char smActiveState[] = "ActiveState";
+  char smId[] = "Id";
+  char smTime[] = "Time";
+  char smRetain[] = "Retain";
+  char smSeverity[] = "Severity";
 
-const std::unordered_map<std::string, std::string> COPC_UA_AC_Layer::sm1499ToUAMap = {
-  {"Area", "ClientUserId"},
-  {"Device", "ConditionName"},
-  {"Source", "SourceName"}
-};
+  UA_UInt16 smSeverityValue = 500;
 
-UA_UInt16 COPC_UA_AC_Layer::smSeverityValue = 500;
+  const size_t scmNumberOfAlarmParameters = 2;
+
+  const std::unordered_map<std::string, std::string> sm1499ToUAMap = {
+    {"Area", "ClientUserId"},
+    {"Device", "ConditionName"},
+    {"Source", "SourceName"}
+  };
+}
 
 COPC_UA_AC_Layer::COPC_UA_AC_Layer(CComLayer *paUpperLayer, CBaseCommFB *paComFB) :
   COPC_UA_Layer(paUpperLayer, paComFB), mHandler(nullptr), mMemberActionInfo(nullptr) {

--- a/src/com/opc_ua/opcua_ac_layer.cpp
+++ b/src/com/opc_ua/opcua_ac_layer.cpp
@@ -35,7 +35,7 @@ char COPC_UA_AC_Layer::smSeverity[] = "Severity";
 
 const std::unordered_map<std::string, std::string> COPC_UA_AC_Layer::sm1499ToUAMap = {
   {"Area", "ClientUserId"},
-  {"Origin", "ConditionName"},
+  {"Device", "ConditionName"},
   {"Source", "SourceName"}
 };
 
@@ -364,7 +364,7 @@ EComResponse COPC_UA_AC_Layer::addOPCUATypeProperties(UA_Server *paServer, const
     char *propertyName = getNameFromString(dataPortName);
     UA_StatusCode status = addVariableNode(paServer, paTypeName, propertyName, apoDataPorts[i]->unwrap());
     if(status != UA_STATUSCODE_GOOD) {
-      DEVLOG_ERROR("[OPC UA A&C LAYER]: Failed to add OPCUA AlarmType Property for FB %s, Port: %s, Status: %s\n", getCommFB()->getInstanceName(), dataPortName, UA_StatusCode_name(status));
+      DEVLOG_ERROR("[OPC UA A&C LAYER]: Failed to add OPCUA AlarmType Property for FB %s, Port: %s, Status: %s\n", getCommFB()->getInstanceName(), dataPortName.c_str(), UA_StatusCode_name(status));
       return e_InitTerminated;
     }
   }

--- a/src/com/opc_ua/opcua_ac_layer.cpp
+++ b/src/com/opc_ua/opcua_ac_layer.cpp
@@ -26,6 +26,7 @@ const std::string COPC_UA_AC_Layer::scmAlarmConditionName = "AlarmCondition";
 
 char COPC_UA_AC_Layer::smEmptyString[] = "";
 char COPC_UA_AC_Layer::smEnabledState[] = "EnabledState";
+char COPC_UA_AC_Layer::smEnableStateProperty[] = "EnableState"; // This is needed to avoid potential delete-subscription error with HMI tools
 char COPC_UA_AC_Layer::smActiveState[] = "ActiveState";
 char COPC_UA_AC_Layer::smId[] = "Id";
 char COPC_UA_AC_Layer::smTime[] = "Time";
@@ -366,6 +367,26 @@ EComResponse COPC_UA_AC_Layer::addOPCUATypeProperties(UA_Server *paServer, const
       DEVLOG_ERROR("[OPC UA A&C LAYER]: Failed to add OPCUA AlarmType Property for FB %s, Port: %s, Status: %s\n", getCommFB()->getInstanceName(), dataPortName, UA_StatusCode_name(status));
       return e_InitTerminated;
     }
+  }
+  return addOPCUATypeEnableStateProperty(paServer);
+}
+
+forte::com_infra::EComResponse COPC_UA_AC_Layer::addOPCUATypeEnableStateProperty(UA_Server *paServer) {
+  UA_VariableAttributes vAttr = UA_VariableAttributes_default;
+    vAttr.displayName = UA_LOCALIZEDTEXT(smEmptyString, smEnableStateProperty);
+    vAttr.valueRank = UA_VALUERANK_ANY;
+    vAttr.accessLevel = UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE;
+    vAttr.dataType = UA_TYPES[UA_TYPES_LOCALIZEDTEXT].typeId;
+
+  UA_NodeId memberNodeId;
+  UA_StatusCode status = UA_Server_addVariableNode(paServer, UA_NODEID_NULL, mTypeNodeId,
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_HASCOMPONENT),
+                          UA_QUALIFIEDNAME(0, smEnableStateProperty),    // TODO Change 1 to namespaceIndex
+                          UA_NODEID_NUMERIC(0, UA_NS0ID_TWOSTATEVARIABLETYPE), vAttr, nullptr, &memberNodeId);
+  mTypePropertyNodes.emplace_back(memberNodeId);
+  if(status != UA_STATUSCODE_GOOD) {
+    DEVLOG_ERROR("[OPC UA A&C LAYER]: Failed to add OPCUA EnableState Property for FB %s, Status: %s\n", getCommFB()->getInstanceName(), UA_StatusCode_name(status));
+    return e_InitTerminated;
   }
   return e_InitOk;
 }

--- a/src/com/opc_ua/opcua_ac_layer.h
+++ b/src/com/opc_ua/opcua_ac_layer.h
@@ -55,22 +55,6 @@ class COPC_UA_AC_Layer : public COPC_UA_Layer {
       PathToInstance
     };
 
-    static const std::string scmAlarmTypeBrowsePath;
-    static const std::string scmAlarmConditionName;
-
-    static char smEmptyString[];
-    static char smEnabledState[];
-    static char smEnableStateProperty[]; // This is needed to avoid potential delete-subscription error with HMI tools
-    static char smActiveState[];
-    static char smId[];
-    static char smTime[];
-    static char smRetain[];
-    static char smSeverity[];
-
-    static UA_UInt16 smSeverityValue;
-
-    static const size_t scmNumberOfAlarmParameters = 2;
-
     COPC_UA_HandlerAbstract *mHandler;
 
     UA_NodeId mTypeNodeId;
@@ -80,8 +64,6 @@ class COPC_UA_AC_Layer : public COPC_UA_Layer {
     std::vector<char*> mNames;
     std::vector<UA_NodeId> mTypePropertyNodes;
     std::unique_ptr<CActionInfo> mMemberActionInfo;
-
-    static const std::unordered_map<std::string, std::string> sm1499ToUAMap;
 
     std::unordered_map<std::string, UA_NodeId> mUAPropertyMap = 
     {

--- a/src/com/opc_ua/opcua_ac_layer.h
+++ b/src/com/opc_ua/opcua_ac_layer.h
@@ -60,6 +60,7 @@ class COPC_UA_AC_Layer : public COPC_UA_Layer {
 
     static char smEmptyString[];
     static char smEnabledState[];
+    static char smEnableStateProperty[]; // This is needed to avoid potential delete-subscription error with HMI tools
     static char smActiveState[];
     static char smId[];
     static char smTime[];
@@ -118,6 +119,8 @@ class COPC_UA_AC_Layer : public COPC_UA_Layer {
     forte::com_infra::EComResponse createAlarmType(UA_Server *paServer, const std::string &paTypeName);
     
     forte::com_infra::EComResponse addOPCUATypeProperties(UA_Server *paServer, const std::string &paTypeName, bool paIsPublisher);
+
+    forte::com_infra::EComResponse addOPCUATypeEnableStateProperty(UA_Server *paServer);
 
     UA_StatusCode addVariableNode(UA_Server *paServer, const std::string &paParentTypeName, char *paVariableName, CIEC_ANY &paVariableType);
 

--- a/src/com/opc_ua/opcua_ac_layer.h
+++ b/src/com/opc_ua/opcua_ac_layer.h
@@ -80,6 +80,15 @@ class COPC_UA_AC_Layer : public COPC_UA_Layer {
     std::vector<UA_NodeId> mTypePropertyNodes;
     std::unique_ptr<CActionInfo> mMemberActionInfo;
 
+    static const std::unordered_map<std::string, std::string> sm1499ToUAMap;
+
+    std::unordered_map<std::string, UA_NodeId> mUAPropertyMap = 
+    {
+      {"ClientUserId", UA_NODEID_NULL},
+      {"ConditionName", UA_NODEID_NULL},
+      {"SourceName", UA_NODEID_NULL}
+    };
+
     /**
      * Called when INIT is triggered in the FB and QI is set to true
      * @param paLayerParameter String conatained between the square brackets in the ID data input (opc_ua[...])
@@ -101,6 +110,8 @@ class COPC_UA_AC_Layer : public COPC_UA_Layer {
     UA_StatusCode createOPCUAObjectNode(UA_Server *paServer, const std::string &paPathToInstance, std::string &paBrowsePath, bool paIsPublisher);
 
     UA_StatusCode addOPCUACondition(UA_Server *paServer, const std::string &paPathToInstance, std::string &paBrowsePath);
+
+    UA_StatusCode initializeMapping();
 
     forte::com_infra::EComResponse setConditionCallbacks(UA_Server *paServer);
 

--- a/src/com/opc_ua/opcua_local_handler.cpp
+++ b/src/com/opc_ua/opcua_local_handler.cpp
@@ -1168,6 +1168,10 @@ void COPC_UA_Local_Handler::initializeCreateInfo(std::string &paNodeName, const 
   paResult.mParentNodeId = paParentNodeId;
 }
 
+UA_BrowseResult COPC_UA_Local_Handler::browseServer(UA_BrowseDescription &paBrowseDescription) {
+  return UA_Server_browse(mUaServer, 500, &paBrowseDescription);
+}
+
 UA_StatusCode COPC_UA_Local_Handler::getNode(CActionInfo::CNodePairInfo &paNodePairInfo, CSinglyLinkedList<UA_NodeId*> &paFoundNodeIds, bool *paIsPresent) {
   UA_StatusCode retVal = UA_STATUSCODE_GOOD;
   *paIsPresent = false;

--- a/src/com/opc_ua/opcua_local_handler.h
+++ b/src/com/opc_ua/opcua_local_handler.h
@@ -104,6 +104,8 @@ class COPC_UA_Local_Handler : public COPC_UA_HandlerAbstract, public CThread {
      */
     UA_StatusCode splitAndCreateFolders(const std::string &paBrowsePath, std::string &paNodeName, CSinglyLinkedList<UA_NodeId*> &paRreferencedNodes) const;
 
+    UA_BrowseResult browseServer(UA_BrowseDescription &paBrowseDescription);
+
     /**
      * Default value for the namespace of the browsename for all created nodes
      */


### PR DESCRIPTION
This PR is on top of freeze, because the Message CFB is currently not exportable on develop. This can be changed to develop, if necessary.