### PR TITLE
Disable static_cast downcast clang-tidy warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,2 @@
-Checks: modernize-use-nullptr,modernize-use-bool-literals,modernize-redundant-void-arg,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-transparent-functors,modernize-use-override,-clang-diagnostic-*,-clang-analyzer-*
+Checks: modernize-use-nullptr,modernize-use-bool-literals,modernize-redundant-void-arg,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-transparent-functors,modernize-use-override,-clang-diagnostic-*,-clang-analyzer-*,-*-pro-type-static-cast-downcast
 HeaderFilterRegex: .*


### PR DESCRIPTION
Disable clang-tidy warning to use `dynamic_cast` instead of `static_cast`, which is not available since forte compiles without RTTI by default.