### PR TITLE
Use Template Type

### DIFF
--- a/src/core/io/inputfb.h
+++ b/src/core/io/inputfb.h
@@ -90,8 +90,8 @@ namespace forte::core::io {
         return read();
       }
 
-      void evt_REQ(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, T &paIN) {
+      void
+      evt_REQ(const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, T &paIN) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         receiveInputEvent(scmEventREQID, nullptr);

--- a/src/core/io/inputfb.h
+++ b/src/core/io/inputfb.h
@@ -91,7 +91,7 @@ namespace forte::core::io {
       }
 
       void evt_REQ(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_BYTE &paIN) {
+          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, T &paIN) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         receiveInputEvent(scmEventREQID, nullptr);

--- a/src/core/io/outputfb.h
+++ b/src/core/io/outputfb.h
@@ -62,11 +62,8 @@ namespace forte::core::io {
         return IOMapper::Out;
       }
 
-      void evt_REQ(const CIEC_BOOL &paQI,
-                   const CIEC_STRING &paPARAMS,
-                   const T &paOUT,
-                   CIEC_BOOL &paQO,
-                   CIEC_STRING &paSTATUS) {
+      void evt_REQ(
+          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, const T &paOUT, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         var_OUT = paOUT;

--- a/src/core/io/outputfb.h
+++ b/src/core/io/outputfb.h
@@ -64,7 +64,7 @@ namespace forte::core::io {
 
       void evt_REQ(const CIEC_BOOL &paQI,
                    const CIEC_STRING &paPARAMS,
-                   const CIEC_BYTE &paOUT,
+                   const T &paOUT,
                    CIEC_BOOL &paQO,
                    CIEC_STRING &paSTATUS) {
         var_QI = paQI;


### PR DESCRIPTION
the 2 Assignments:
      paIN = var_IN;
        var_OUT = paOUT;

to me only make sense, if the other Type is also T
otherwise a no match for 'operator=' can happen.
