### PR TITLE
Renames data input prefix for consistency

### DIFF
--- a/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
+++ b/src/modules/IEC61131-3/BitwiseOperators/genbitbase_fbt.cpp
@@ -66,7 +66,7 @@ bool CGenBitBase::createInterfaceSpec(const char *paConfigString, SFBInterfaceSp
   if (numDIs < CFunctionBlock::scmMaxInterfaceEvents) {
 
     // create the data inputs
-    generateGenericInterfacePointNameArray("IN_", mDataInputNames, numDIs);
+    generateGenericInterfacePointNameArray("IN", mDataInputNames, numDIs);
 
     // setup the interface Specification
     paInterfaceSpec.mEINames = cEventInputNames;


### PR DESCRIPTION
Updates the prefix used for generating data input names from "IN_" to "IN"
to maintain consistency with other naming conventions.

this is because AND has Inputs IN1 and IN2 and so on.
