### PR TITLE
Removed CMake option FORTE_SUPPORT_MONITORING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,6 @@ mark_as_advanced(FORTE_RTTI_AND_EXCEPTIONS)
 add_library(forte-global INTERFACE)
 link_libraries(forte-global)
 
-# TODO: this might be removed in the near future
-target_compile_definitions(forte-global INTERFACE FORTE_SUPPORT_MONITORING)
-
 #######################################################################################
 # Determine log level
 #######################################################################################

--- a/src/core/funcbloc.cpp
+++ b/src/core/funcbloc.cpp
@@ -49,17 +49,13 @@ bool CFunctionBlock::initialize() {
   if (!CFBContainer::initialize()) {
     return false;
   }
-#ifdef FORTE_SUPPORT_MONITORING
   setupEventMonitoringData();
-#endif // FORTE_SUPPORT_MONITORING
   setupInputConnectionTrackingData();
   return true;
 }
 
 CFunctionBlock::~CFunctionBlock() {
-#ifdef FORTE_SUPPORT_MONITORING
   freeEventMonitoringData();
-#endif // FORTE_SUPPORT_MONITORING
 }
 
 void CFunctionBlock::deinitialize() {
@@ -388,7 +384,6 @@ CFunctionBlock::getOutputConnection(const std::span<const CStringDictionary::TSt
 
 //********************************** below here are monitoring specific functions
 //**********************************************************
-#ifdef FORTE_SUPPORT_MONITORING
 void CFunctionBlock::setupEventMonitoringData() {
   freeEventMonitoringData();
   mEventMonitorCount.resize(getFBInterfaceSpec().getNumEIs() + getFBInterfaceSpec().getNumEOs());
@@ -444,8 +439,6 @@ void CFunctionBlock::setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValu
     }
   }
 }
-
-#endif // FORTE_SUPPORT_MONITORING
 
 void CFunctionBlock::toString(std::string &paTargetBuf) const {
   paTargetBuf += '(';

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -38,8 +38,8 @@ class CEventChainExecutionThread;
 class CTimerHandler;
 class CDevice;
 
-#ifdef FORTE_SUPPORT_MONITORING
 #include "core/mgmcmdstruct.h"
+
 namespace forte {
   class IPlugPin;
   class ISocketPin;
@@ -48,7 +48,6 @@ namespace forte {
     class CMonitoringHandler;
   }
 } // namespace forte
-#endif // FORTE_SUPPORT_MONITORING
 
 //! Datatype for indicating an absolut port num
 using TAbsDataPortNum = size_t;
@@ -228,10 +227,8 @@ class CFunctionBlock : public forte::core::CFBContainer {
       if (E_FBStates::Running == getState()) {
         if (paEIID < getFBInterfaceSpec().getNumEIs()) {
           readInputData(paEIID);
-#ifdef FORTE_SUPPORT_MONITORING
           // Count Event for monitoring
           mEventMonitorCount[paEIID]++;
-#endif // FORTE_SUPPORT_MONITORING
         }
         executeEvent(paEIID, paExecEnv);
       }
@@ -336,7 +333,6 @@ class CFunctionBlock : public forte::core::CFBContainer {
      */
     CConnection::Wrapper getOutputConnection(std::span<const CStringDictionary::TStringId> paSrcNameList) override;
 
-#ifdef FORTE_SUPPORT_MONITORING
     TForteUInt32 &getEIMonitorData(TEventID paEIID);
 
     TForteUInt32 &getEOMonitorData(TEventID paEOID);
@@ -348,8 +344,6 @@ class CFunctionBlock : public forte::core::CFBContainer {
     bool getForce(TAbsDataPortNum paAbsDataPortNum) const {
       return mForces[paAbsDataPortNum];
     }
-
-#endif // FORTE_SUPPORT_MONITORING
 
     virtual void toString(std::string &paTargetBuf) const;
 
@@ -417,11 +411,9 @@ class CFunctionBlock : public forte::core::CFBContainer {
         writeOutputData(paEO);
         getEOConUnchecked(static_cast<TPortId>(paEO))->triggerEvent(paECET);
 
-#ifdef FORTE_SUPPORT_MONITORING
         // Count Event for monitoring, use size and number of EOs for performance reason so that only one value has to
         // be gathered from the interface spec
         mEventMonitorCount[mEventMonitorCount.size() - numEOs + paEO]++;
-#endif // FORTE_SUPPORT_MONITORING
       }
     }
 
@@ -435,13 +427,9 @@ class CFunctionBlock : public forte::core::CFBContainer {
       if (!paConn) {
         return;
       }
-#ifdef FORTE_SUPPORT_MONITORING
       if (!mForces[paAbsDataPortNum]) {
-#endif // FORTE_SUPPORT_MONITORING
         paConn->readData(paValue);
-#ifdef FORTE_SUPPORT_MONITORING
       }
-#endif // FORTE_SUPPORT_MONITORING
 #ifdef FORTE_TRACE_CTF
       traceReadData(paAbsDataPortNum, paValue);
 #endif // FORTE_TRACE_CTF
@@ -455,16 +443,12 @@ class CFunctionBlock : public forte::core::CFBContainer {
      */
     template<typename T, typename U>
     void writeData(TAbsDataPortNum paAbsDataPortNum, T &paValue, U &paConn) {
-#ifdef FORTE_SUPPORT_MONITORING
       if (!mForces[paAbsDataPortNum]) {
-#endif // FORTE_SUPPORT_MONITORING
         paConn.writeData(paValue);
-#ifdef FORTE_SUPPORT_MONITORING
       } else {
         // when forcing we write back the value from the connection to keep the forced value on the output
         paConn.readData(paValue);
       }
-#endif // FORTE_SUPPORT_MONITORING
 #ifdef FORTE_TRACE_CTF
       traceWriteData(paAbsDataPortNum - mInterfaceSpec.getNumDIs(), paValue);
 #endif // FORTE_TRACE_CTF
@@ -539,10 +523,9 @@ class CFunctionBlock : public forte::core::CFBContainer {
       }
     }
 
-#ifdef FORTE_SUPPORT_MONITORING
     void setupEventMonitoringData();
     void freeEventMonitoringData();
-#endif
+
   private:
     bool isFB() override {
       return true;
@@ -581,12 +564,10 @@ class CFunctionBlock : public forte::core::CFBContainer {
     constexpr static char csmToStringSeparator[] = ", ";
 
   private:
-#ifdef FORTE_SUPPORT_MONITORING
     //! vector for storing the event counts for input and output events together, first inputs then outputs
     std::vector<TForteUInt32> mEventMonitorCount;
     //! vector of bools for determining force state of data inputs, data outputs, and var in outs in that order
     std::vector<bool> mForces;
-#endif
 
 #ifdef FORTE_TRACE_CTF
     void traceInputEvent(TEventID paEIID);
@@ -615,9 +596,7 @@ class CFunctionBlock : public forte::core::CFBContainer {
      */
     bool mDeletable;
 
-#ifdef FORTE_SUPPORT_MONITORING
     friend class forte::core::CMonitoringHandler;
-#endif // FORTE_SUPPORT_MONITORING
 
 #ifdef FORTE_FMU
     friend class fmuInstance;

--- a/src/core/genfb.h
+++ b/src/core/genfb.h
@@ -353,15 +353,10 @@ void CGenFunctionBlock<T>::setupFBInterface() {
 
   T::setupInputConnectionTrackingData();
 
-#ifdef FORTE_SUPPORT_MONITORING
   T::setupEventMonitoringData();
-#endif
 }
 
 template<class T>
 void CGenFunctionBlock<T>::freeFBInterfaceData() {
-
-#ifdef FORTE_SUPPORT_MONITORING
   T::freeEventMonitoringData();
-#endif // FORTE_SUPPORT_MONITORING
 }

--- a/src/core/mgmcmd.h
+++ b/src/core/mgmcmd.h
@@ -244,7 +244,6 @@ enum class EMGMCommandType : uint8_t {
    */
   Reset = 0x08,
 
-#ifdef FORTE_SUPPORT_MONITORING
   MonitoringGroup = 0x0A,
   MonitoringAddWatch = 0x1A,
   MonitoringRemoveWatch = 0x2A,
@@ -253,7 +252,6 @@ enum class EMGMCommandType : uint8_t {
   MonitoringClearForce = 0x6A,
   MonitoringTriggerEvent = 0x7A,
   MonitoringResetEventCount = 0x8A,
-#endif // FORTE_SUPPORT_MONITORING
 
   /*! \brief invalid command: some of the data could not be parsed
    */

--- a/src/core/mgmcmdstruct.h
+++ b/src/core/mgmcmdstruct.h
@@ -75,10 +75,8 @@ namespace forte {
         /*\brief pointer to the ID to generate the correct response */
         char *mID;
 
-#ifdef FORTE_SUPPORT_MONITORING
         /*\brief pointer to the response to generate the correct response */
         std::string mMonitorResponse;
-#endif
     };
 
   } // namespace core

--- a/src/core/resource.cpp
+++ b/src/core/resource.cpp
@@ -259,11 +259,8 @@ CResource::CResource(forte::core::CFBContainer &paDevice,
                      const SFBInterfaceSpec &paInterfaceSpec,
                      const CStringDictionary::TStringId paInstanceNameId) :
     CFunctionBlock(paDevice, paInterfaceSpec, paInstanceNameId),
-    mResourceEventExecution(EcetFactory::createEcet())
-#ifdef FORTE_SUPPORT_MONITORING
-    ,
+    mResourceEventExecution(EcetFactory::createEcet()),
     mMonitoringHandler(*this)
-#endif
 #ifdef FORTE_TRACE_CTF
     ,
     mTracer(paInstanceNameId, FORTE_TRACE_CTF_BUFFER_SIZE)
@@ -273,11 +270,8 @@ CResource::CResource(forte::core::CFBContainer &paDevice,
 
 CResource::CResource(const SFBInterfaceSpec &paInterfaceSpec, const CStringDictionary::TStringId paInstanceNameId) :
     CFunctionBlock(*this, paInterfaceSpec, paInstanceNameId),
-    mResourceEventExecution(nullptr)
-#ifdef FORTE_SUPPORT_MONITORING
-    ,
+    mResourceEventExecution(nullptr),
     mMonitoringHandler(*this)
-#endif
 #ifdef FORTE_TRACE_CTF
     ,
     mTracer(paInstanceNameId, FORTE_TRACE_CTF_BUFFER_SIZE)
@@ -362,13 +356,7 @@ EMGMResponse CResource::executeMGMCommand(forte::core::SManagementCMD &paCommand
                                                       paCommand.mAdditionalParams);
         break;
       case EMGMCommandType::QueryConnection: retVal = queryConnections(paCommand.mAdditionalParams, *this); break;
-      default:
-#ifdef FORTE_SUPPORT_MONITORING
-        retVal = mMonitoringHandler.executeMonitoringCommand(paCommand);
-#else
-        retVal = EMGMResponse::UnsupportedCmd;
-#endif
-        break;
+      default: retVal = mMonitoringHandler.executeMonitoringCommand(paCommand); break;
     }
   }
   return retVal;

--- a/src/core/resource.h
+++ b/src/core/resource.h
@@ -21,9 +21,7 @@
 #include "core/fbcontainer.h"
 #include "core/funcbloc.h"
 
-#ifdef FORTE_SUPPORT_MONITORING
 #include "core/monitoring.h"
-#endif
 
 #ifdef FORTE_DYNAMIC_TYPE_LOAD
 class CLuaEngine;
@@ -108,11 +106,9 @@ class CResource : public CFunctionBlock {
     virtual EMGMResponse
     writeValue(forte::core::TNameIdentifier &paNameList, const std::string &paValue, bool paForce = false);
 
-#ifdef FORTE_SUPPORT_MONITORING
     forte::core::CMonitoringHandler &getMonitoringHandler() {
       return mMonitoringHandler;
     }
-#endif
 
 #ifdef FORTE_DYNAMIC_TYPE_LOAD
     CLuaEngine *getLuaEngine() {
@@ -247,9 +243,7 @@ class CResource : public CFunctionBlock {
      */
     CEventChainExecutionThread *mResourceEventExecution;
 
-#ifdef FORTE_SUPPORT_MONITORING
     forte::core::CMonitoringHandler mMonitoringHandler;
-#endif // #ifdef FORTE_SUPPORT_MONITORING
 
 #ifdef FORTE_TRACE_CTF
     CForteTracer mTracer;

--- a/src/stdfblib/ita/CommandParser.cpp
+++ b/src/stdfblib/ita/CommandParser.cpp
@@ -33,9 +33,7 @@ namespace forte::ita {
       mCommand.mAdditionalParams.clear();
       mCommand.mFirstParam.clear();
       mCommand.mSecondParam.clear();
-#ifdef FORTE_SUPPORT_MONITORING
       mCommand.mMonitorResponse.clear();
-#endif // FORTE_SUPPORT_MONITORING
 
       mCommand.mDestination =
           (strlen(paDest) != 0) ? CStringDictionary::insert(paDest) : CStringDictionary::scmInvalidStringId;
@@ -82,12 +80,10 @@ namespace forte::ita {
 
   void CommandParser::generateResponse(CIEC_STRING &paResponse) {
     paResponse.clear();
-#ifdef FORTE_SUPPORT_MONITORING
     if (!mCommand.mMonitorResponse.empty()) {
       generateMonitorResponse(paResponse);
       return;
     }
-#endif // FORTE_SUPPORT_MONITORING
 
     if (!mCommand.mAdditionalParams.empty()) {
       generateLongResponse(paResponse);
@@ -347,13 +343,11 @@ namespace forte::ita {
             mCommand.mCMD = EMGMCommandType::CreateConnection;
           }
           break;
-#ifdef FORTE_SUPPORT_MONITORING
         case 'W': // we have an Watch to Add
           if (parseMonitoringData(paRequestPartLeft)) {
             mCommand.mCMD = EMGMCommandType::MonitoringAddWatch;
           }
           break;
-#endif // FORTE_SUPPORT_MONITORING
         default: break;
       }
     }
@@ -373,13 +367,11 @@ namespace forte::ita {
             mCommand.mCMD = EMGMCommandType::DeleteConnection;
           }
           break;
-#ifdef FORTE_SUPPORT_MONITORING
         case 'W': // we have an Watch to remove
           if (parseMonitoringData(paRequestPartLeft)) {
             mCommand.mCMD = EMGMCommandType::MonitoringRemoveWatch;
           }
           break;
-#endif // FORTE_SUPPORT_MONITORING
         default: break;
       }
     }
@@ -396,14 +388,11 @@ namespace forte::ita {
   void CommandParser::parseReadData(char *paRequestPartLeft) {
     mCommand.mCMD = EMGMCommandType::INVALID;
     if (nullptr != paRequestPartLeft) {
-#ifdef FORTE_SUPPORT_MONITORING
       if ('W' == paRequestPartLeft[0]) {
         mCommand.mCMD = EMGMCommandType::MonitoringReadWatches;
-      } else
-#endif // FORTE_SUPPORT_MONITORING
-        if (parseConnectionData(paRequestPartLeft)) {
-          mCommand.mCMD = EMGMCommandType::Read;
-        }
+      } else if (parseConnectionData(paRequestPartLeft)) {
+        mCommand.mCMD = EMGMCommandType::Read;
+      }
     }
   }
 
@@ -411,7 +400,6 @@ namespace forte::ita {
     // We need an additional xml connection token parse if it is an connection definition
     mCommand.mCMD = EMGMCommandType::INVALID;
     if (nullptr != paRequestPartLeft && parseWriteConnectionData(paRequestPartLeft)) {
-#ifdef FORTE_SUPPORT_MONITORING
       char *pch = strstr(paRequestPartLeft, "force=\"");
       if (nullptr != pch) {
         if (!strncmp(&pch[7], "true", sizeof("true") - 1)) {
@@ -429,7 +417,6 @@ namespace forte::ita {
                   (('r' == mCommand.mAdditionalParams[2]) || ('R' == mCommand.mAdditionalParams[2])))) {
         mCommand.mCMD = EMGMCommandType::MonitoringResetEventCount;
       } else
-#endif // FORTE_SUPPORT_MONITORING
         mCommand.mCMD = EMGMCommandType::Write;
     }
   }
@@ -558,8 +545,6 @@ namespace forte::ita {
     }
   }
 
-#ifdef FORTE_SUPPORT_MONITORING
-
   bool CommandParser::parseMonitoringData(char *paRequestPartLeft) {
     bool bRetVal = false;
     if (!strncmp("Watch Source=\"", paRequestPartLeft, sizeof("Watch Source=\"") - 1)) {
@@ -592,7 +577,5 @@ namespace forte::ita {
       paResponse.append("\n</Response>");
     }
   }
-
-#endif // FORTE_SUPPORT_MONITORING
 
 } // namespace forte::ita

--- a/src/stdfblib/ita/CommandParser.h
+++ b/src/stdfblib/ita/CommandParser.h
@@ -123,10 +123,8 @@ namespace forte::ita {
                         forte::core::TNameIdentifier &paIdentifier,
                         std::string &paTypeHash);
 
-#ifdef FORTE_SUPPORT_MONITORING
       bool parseMonitoringData(char *paRequestPartLeft);
       void generateMonitorResponse(CIEC_STRING &paResponse);
-#endif // FORTE_SUPPORT_MONITORING
 
       /*! \brief Generate a short response string according to the previous executed command
        *

--- a/src/stdfblib/ita/OPCUA_MGR.cpp
+++ b/src/stdfblib/ita/OPCUA_MGR.cpp
@@ -203,8 +203,6 @@ char OPCUA_MGR::smQueryGlobalConstTypeOutArgDescription[] = "Query GlobalConstTy
 char OPCUA_MGR::smQueryGlobalConstTypeDisplayName[] = "Query GlobalConstType";
 char OPCUA_MGR::smQueryGlobalConstTypeDescription[] = "Query GlobalConstType";
 
-#ifdef FORTE_SUPPORT_MONITORING
-
 /* Add Watch */
 char OPCUA_MGR::smAddWatchMethodName[] = "addWatch";
 char OPCUA_MGR::smAddWatchArgName[] = "FB Port";
@@ -249,8 +247,6 @@ char OPCUA_MGR::smClearForceArgName[] = "FB Port";
 char OPCUA_MGR::smClearForceArgDescription[] = "Fully qualified name of FB Port";
 char OPCUA_MGR::smClearForceAttrDisplayName[] = "Clear Force";
 char OPCUA_MGR::smClearForceAttrDescription[] = "Clear Force";
-
-#endif // FORTE_SUPPORT_MONITORING
 
 /* Initialize UA Status Codes */
 const std::map<EMGMResponse, UA_StatusCode> OPCUA_MGR::scResponseMap = {
@@ -332,10 +328,8 @@ EMGMResponse OPCUA_MGR::createIEC61499MgmtObject(UA_Server *paServer) {
     return eRetVal;
   if (addQueryGlobalConstTypeMethod(paServer) != EMGMResponse::Ready)
     return eRetVal;
-#ifdef FORTE_SUPPORT_MONITORING
   if (addReadWatchesMethod(paServer) != EMGMResponse::Ready)
     return eRetVal;
-#endif // FORTE_SUPPORT_MONITORING
   if (addExtraMethods(paServer, mMgmtTypeId, mExtraMgmMethods) != EMGMResponse::Ready)
     return eRetVal;
   return addMgmtObjectInstance();
@@ -395,7 +389,6 @@ EMGMResponse OPCUA_MGR::createIEC61499ResourceObjectType(UA_Server *paServer) {
     return eRetVal;
   if (addDeleteConnectionMethod(paServer) != EMGMResponse::Ready)
     return eRetVal;
-#ifdef FORTE_SUPPORT_MONITORING
   if (addAddWatchMethod(paServer) != EMGMResponse::Ready)
     return eRetVal;
   if (addRemoveWatchMethod(paServer) != EMGMResponse::Ready)
@@ -406,7 +399,6 @@ EMGMResponse OPCUA_MGR::createIEC61499ResourceObjectType(UA_Server *paServer) {
     return eRetVal;
   if (addClearForceMethod(paServer) != EMGMResponse::Ready)
     return eRetVal;
-#endif // FORTE_SUPPORT_MONITORING
   if (addExtraMethods(paServer, mResourceTypeId, mExtraResourceMethods) != EMGMResponse::Ready)
     return eRetVal;
   return EMGMResponse::Ready;
@@ -1334,9 +1326,6 @@ UA_StatusCode OPCUA_MGR::onQueryGlobalConstType(UA_Server *,
   return status;
 }
 
-/* FORTE Monitoring */
-#ifdef FORTE_SUPPORT_MONITORING
-
 EMGMResponse OPCUA_MGR::addAddWatchMethod(UA_Server *paServer) {
   UA_Argument inputArgument;
   initArgument(inputArgument, UA_TYPES_STRING, smAddWatchArgName, smAddWatchArgDescription);
@@ -1556,8 +1545,6 @@ UA_StatusCode OPCUA_MGR::onClearForce(UA_Server *,
   return scResponseMap.find(eRetVal)->second;
 }
 
-#endif // FORTE_SUPPORT_MONITORING
-
 /* Helpers */
 
 EMGMResponse OPCUA_MGR::addMethodNode(UA_Server *paServer,
@@ -1614,9 +1601,7 @@ void OPCUA_MGR::clearMGMCommand() {
   mCommand.mFirstParam.clear();
   mCommand.mSecondParam.clear();
   mCommand.mAdditionalParams.clear();
-#ifdef FORTE_SUPPORT_MONITORING
   mCommand.mMonitorResponse.clear();
-#endif // FORTE_SUPPORT_MONITORING
 }
 
 void OPCUA_MGR::setMGMCommand(EMGMCommandType paCMD,

--- a/src/stdfblib/ita/OPCUA_MGR.h
+++ b/src/stdfblib/ita/OPCUA_MGR.h
@@ -237,9 +237,6 @@ class OPCUA_MGR {
     static char smQueryGlobalConstTypeDisplayName[];
     static char smQueryGlobalConstTypeDescription[];
 
-/* FORTE Monitoring */
-#ifdef FORTE_SUPPORT_MONITORING
-
     /* Add Watch */
     static char smAddWatchMethodName[];
     static char smAddWatchArgName[];
@@ -284,8 +281,6 @@ class OPCUA_MGR {
     static char smClearForceArgDescription[];
     static char smClearForceAttrDisplayName[];
     static char smClearForceAttrDescription[];
-
-#endif // FORTE_SUPPORT_MONITORING
 
     static const std::map<EMGMResponse, UA_StatusCode> scResponseMap;
 
@@ -652,8 +647,6 @@ class OPCUA_MGR {
 
     /* FORTE Monitoring */
 
-#ifdef FORTE_SUPPORT_MONITORING
-
     EMGMResponse addAddWatchMethod(UA_Server *paServer);
     static UA_StatusCode onAddWatch(UA_Server *server,
                                     const UA_NodeId *sessionId,
@@ -732,10 +725,7 @@ class OPCUA_MGR {
                                       size_t outputSize,
                                       UA_Variant *output);
 
-#endif // FORTE_SUPPORT_MONITORING
-
     /* Helpers */
-
     EMGMResponse addMethodNode(UA_Server *paServer,
                                char *paMethodName,
                                UA_NodeId paParentNodeId,


### PR DESCRIPTION
The monitoring infrastructure is now deeply integrated into 4diac IDE and 4diac FORTE. With the latest CMake changes it was not configurable anymore. With this commit the remaining ifdefs are removed.

See also: https://github.com/eclipse-4diac/4diac-forte/discussions/452