### PR TITLE
Remove "-forte_[PORT]" suffix from custom OPC UA server hostname

### DIFF
--- a/src/com/opc_ua/opcua_local_handler.cpp
+++ b/src/com/opc_ua/opcua_local_handler.cpp
@@ -161,8 +161,6 @@ void COPC_UA_Local_Handler::generateServerStrings(TForteUInt16 paUAServerPort, U
   paServerStrings.mHostname = std::string("opc.tcp://");
 #ifdef FORTE_COM_OPC_UA_CUSTOM_HOSTNAME
   paServerStrings.mHostname.append(FORTE_COM_OPC_UA_CUSTOM_HOSTNAME);
-  paServerStrings.mHostname.append("-"s);
-  paServerStrings.mHostname.append(helperBuffer);
   paServerStrings.mAppURI.append(paServerStrings.mHostname);
 #else
   paServerStrings.mAppURI.append(helperBuffer);


### PR DESCRIPTION
Discussed in #260

(https://github.com/eclipse-4diac/4diac-forte/pull/260#discussion_r1796460458)