### PR TITLE
Updates class description for QD function blocks

### DIFF
--- a/src/core/io/QD_fbt.h
+++ b/src/core/io/QD_fbt.h
@@ -19,7 +19,7 @@
 #include "core/io/outputfb.h"
 #include "core/datatypes/forte_dword.h"
 
-/*! /brief generic class for QW function blocks providing access to one word physical output
+/*! /brief generic class for QD function blocks providing access to one double word physical output
  */
 class FORTE_QD final : public forte::core::io::COutputFB<CIEC_DWORD> {
     DECLARE_FIRMWARE_FB(FORTE_QD)


### PR DESCRIPTION
Corrects the description of the FORTE_QD class to accurately reflect that it provides access to a double word (QD) physical output, rather than a single word (QW).
