### PR TITLE
Fix tests in release mode

### DIFF
--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -153,7 +153,7 @@ void CFBTestFixtureBase::performFBDeleteTests() {
 }
 
 void CFBTestFixtureBase::setup() {
-  BOOST_ASSERT(initialize());
+  BOOST_REQUIRE(initialize());
 
   setupTestInterface();
   performDataInterfaceTests();
@@ -192,6 +192,9 @@ void CFBTestFixtureBase::triggerEvent(TPortId paEIId) {
 
 TEventID CFBTestFixtureBase::pullFirstChainEventID() {
   CCriticalRegion criticalRegion(mOutputEventLock);
+  if (mFBOutputEvents.empty()) {
+    return cgInvalidEventID;
+  }
   TEventID retVal = mFBOutputEvents.front();
   mFBOutputEvents.pop_front();
   return retVal;

--- a/tests/core/funcbloctests.cpp
+++ b/tests/core/funcbloctests.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(FB_TO_STRING_BUFFER_SIZE_TEST_WITH_INRENAL_VAR) {
 
   const auto cInternalsNames = std::array{STRID(QU), STRID(QD), STRID(CV)};
   CInternalVarTestFB testFb(cInternalsNames);
-  BOOST_ASSERT(testFb.initialize());
+  BOOST_REQUIRE(testFb.initialize());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/core/internalvartests.cpp
+++ b/tests/core/internalvartests.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(sampleInteralVarList) {
   auto varInternalNames = std::array{STRID(QU), STRID(QD), STRID(CV)};
 
   CInternalVarTestFB testFB(varInternalNames);
-  BOOST_ASSERT(testFB.initialize());
+  BOOST_REQUIRE(testFB.initialize());
 
   for (size_t i = 0; i < varInternalNames.size(); i++) {
     CIEC_ANY *var = testFB.getVar(&(varInternalNames[i]), 1);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(testToStringWithInternalVariables) {
   auto varInternalNames = std::array{STRID(QU), STRID(QD), STRID(CV)};
 
   CInternalVarTestFB testFB(varInternalNames);
-  BOOST_ASSERT(testFB.initialize());
+  BOOST_REQUIRE(testFB.initialize());
   constexpr char result[] = "(QU:=FALSE, QD:=FALSE, CV:=0)";
   std::string buffer;
   testFB.toString(buffer);

--- a/tests/core/mgmstatemachinetest.cpp
+++ b/tests/core/mgmstatemachinetest.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_SUITE(ManagedObjectStateMachine)
 
 BOOST_AUTO_TEST_CASE(idleTest) {
   CFunctionBlockMock testee;
-  BOOST_ASSERT(testee.initialize());
+  BOOST_REQUIRE(testee.initialize());
 
   BOOST_CHECK_EQUAL(CFunctionBlock::E_FBStates::Idle, testee.getState());
 
@@ -101,7 +101,7 @@ void putTesteeIntoRun(CFunctionBlock &paTestee) {
 
 BOOST_AUTO_TEST_CASE(runningTest) {
   CFunctionBlockMock testee;
-  BOOST_ASSERT(testee.initialize());
+  BOOST_REQUIRE(testee.initialize());
   putTesteeIntoRun(testee);
 
   BOOST_CHECK_EQUAL(false, testee.isCurrentlyDeleteable());
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(runningTest) {
 
   // we shold be able to kill it, use a new testee to have a clean running state
   CFunctionBlockMock killTestee;
-  BOOST_ASSERT(killTestee.initialize());
+  BOOST_REQUIRE(killTestee.initialize());
   putTesteeIntoRun(killTestee);
 
   BOOST_CHECK_EQUAL(EMGMResponse::Ready, killTestee.changeExecutionState(EMGMCommandType::Kill));
@@ -136,7 +136,7 @@ void putTesteeIntoStopped(CFunctionBlock &paTestee) {
 
 BOOST_AUTO_TEST_CASE(stoppedTest) {
   CFunctionBlockMock testee;
-  BOOST_ASSERT(testee.initialize());
+  BOOST_REQUIRE(testee.initialize());
   putTesteeIntoStopped(testee);
 
   BOOST_CHECK(testee.isCurrentlyDeleteable());
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(stoppedTest) {
 
   // we should be able to reset it, use new testeee for a clean stopped state
   CFunctionBlockMock resetTestee;
-  BOOST_ASSERT(resetTestee.initialize());
+  BOOST_REQUIRE(resetTestee.initialize());
   putTesteeIntoStopped(resetTestee);
 
   BOOST_CHECK_EQUAL(EMGMResponse::Ready, resetTestee.changeExecutionState(EMGMCommandType::Reset));
@@ -169,7 +169,7 @@ void putTesteeIntoKilled(CFunctionBlock &paTestee) {
 
 BOOST_AUTO_TEST_CASE(killedTest) {
   CFunctionBlockMock testee;
-  BOOST_ASSERT(testee.initialize());
+  BOOST_REQUIRE(testee.initialize());
   putTesteeIntoKilled(testee);
 
   BOOST_CHECK(testee.isCurrentlyDeleteable());
@@ -204,7 +204,7 @@ void testAllOtherCommands(CFunctionBlock &paTestee, CFunctionBlock::E_FBStates p
 
 BOOST_AUTO_TEST_CASE(testOtherCommands) {
   CFunctionBlockMock testee;
-  BOOST_ASSERT(testee.initialize());
+  BOOST_REQUIRE(testee.initialize());
 
   // test for idle
   testAllOtherCommands(testee, CFunctionBlock::E_FBStates::Idle);

--- a/tests/core/trace/replayAlgorithmTest.cpp
+++ b/tests/core/trace/replayAlgorithmTest.cpp
@@ -157,13 +157,13 @@ namespace {
       BOOST_TEST_INFO(CStringDictionary::get(paResourceName1));
 
       BOOST_TEST_INFO("Create FB Cycle");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(cycleName, STRID(E_CYCLE)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(cycleName, STRID(E_CYCLE)));
 
       BOOST_TEST_INFO("Create FB CTU");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(ctuName, STRID(E_CTU)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(ctuName, STRID(E_CTU)));
 
       BOOST_TEST_INFO("Create FB Publish");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(publishName, STRID(PUBLISH_1)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(publishName, STRID(PUBLISH_1)));
 
       forte::core::SManagementCMD command;
       command.mCMD = EMGMCommandType::CreateConnection;
@@ -175,7 +175,7 @@ namespace {
       command.mFirstParam.push_back(STRID(COLD));
       command.mSecondParam.push_back(publishName);
       command.mSecondParam.push_back(STRID(INIT));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: Publish.INITO -> Cycle.START");
       command.mFirstParam.clear();
@@ -184,7 +184,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(cycleName);
       command.mSecondParam.push_back(STRID(START));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: Cycle.EO -> CTU.CU");
       command.mFirstParam.clear();
@@ -193,7 +193,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(ctuName);
       command.mSecondParam.push_back(STRID(CU));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: CTU.CUO -> Publish.REQ");
       command.mFirstParam.clear();
@@ -202,7 +202,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(publishName);
       command.mSecondParam.push_back(STRID(REQ));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       // Data
       BOOST_TEST_INFO("Event connection: CTU.CV -> Publish.SD_1");
@@ -212,7 +212,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(publishName);
       command.mSecondParam.push_back(STRID(SD_1));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       // Literals
       command.mCMD = EMGMCommandType::Write;
@@ -222,28 +222,28 @@ namespace {
       command.mFirstParam.push_back(cycleName);
       command.mFirstParam.push_back(STRID(DT));
       command.mAdditionalParams = "T#200ms";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Literal: CTU.PV -> 0");
       command.mFirstParam.clear();
       command.mFirstParam.push_back(ctuName);
       command.mFirstParam.push_back(STRID(PV));
       command.mAdditionalParams = "0";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Literal: Pulbish.QI -> TRUE");
       command.mFirstParam.clear();
       command.mFirstParam.push_back(publishName);
       command.mFirstParam.push_back(STRID(QI));
       command.mAdditionalParams = "TRUE";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Literal: Pulbish.ID -> 239.0.0.1:61000");
       command.mFirstParam.clear();
       command.mFirstParam.push_back(publishName);
       command.mFirstParam.push_back(STRID(ID));
       command.mAdditionalParams = "239.0.0.1:61000";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
     }
 
     // resource 2
@@ -262,28 +262,28 @@ namespace {
       BOOST_TEST_INFO(CStringDictionary::get(paResourceName2));
 
       BOOST_TEST_INFO("Create FB Subscribe");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(subscribeName, STRID(SUBSCRIBE_1)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(subscribeName, STRID(SUBSCRIBE_1)));
 
       BOOST_TEST_INFO("Create FB Cycle");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(cycleName, STRID(E_CYCLE)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(cycleName, STRID(E_CYCLE)));
 
       BOOST_TEST_INFO("Create FB CTU");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(ctuName, STRID(E_CTU)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(ctuName, STRID(E_CTU)));
 
       BOOST_TEST_INFO("Create FB ADD");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(addName, STRID(F_ADD)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(addName, STRID(F_ADD)));
 
       BOOST_TEST_INFO("Create FB MUL");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(mulName, STRID(F_MUL)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(mulName, STRID(F_MUL)));
 
       BOOST_TEST_INFO("Create FB UINT2UINT 1");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(uint2uintFirst, STRID(UINT2UINT)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(uint2uintFirst, STRID(UINT2UINT)));
 
       BOOST_TEST_INFO("Create FB UINT2UINT 2");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(uint2uintSecond, STRID(UINT2UINT)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(uint2uintSecond, STRID(UINT2UINT)));
 
       BOOST_TEST_INFO("Create FB UINT2UINT 3");
-      BOOST_ASSERT(EMGMResponse::Ready == resource->createFB(uint2uintThird, STRID(UINT2UINT)));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->createFB(uint2uintThird, STRID(UINT2UINT)));
 
       forte::core::SManagementCMD command;
       command.mCMD = EMGMCommandType::CreateConnection;
@@ -295,7 +295,7 @@ namespace {
       command.mFirstParam.push_back(STRID(COLD));
       command.mSecondParam.push_back(subscribeName);
       command.mSecondParam.push_back(STRID(INIT));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: SUBSCRIBE.INIT -> Cycle.START");
       command.mFirstParam.clear();
@@ -304,7 +304,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(cycleName);
       command.mSecondParam.push_back(STRID(START));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: Cycle.EO -> CTU.CU");
       command.mFirstParam.clear();
@@ -313,7 +313,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(ctuName);
       command.mSecondParam.push_back(STRID(CU));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: CTU.CUO -> ADD.REQ");
       command.mFirstParam.clear();
@@ -322,7 +322,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(addName);
       command.mSecondParam.push_back(STRID(REQ));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: ADD.CNF -> UINT2UINT_3.REQ");
       command.mFirstParam.clear();
@@ -331,7 +331,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(uint2uintThird);
       command.mSecondParam.push_back(STRID(REQ));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: SUBSCRIBE.IND -> UINT2UINT_1.REQ");
       command.mFirstParam.clear();
@@ -340,7 +340,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(uint2uintFirst);
       command.mSecondParam.push_back(STRID(REQ));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: UINT2UINT_1.CNF -> MUL.REQ");
       command.mFirstParam.clear();
@@ -349,7 +349,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(mulName);
       command.mSecondParam.push_back(STRID(REQ));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: MUL.CNF -> UINT2UINT_2.REQ");
       command.mFirstParam.clear();
@@ -358,7 +358,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(uint2uintSecond);
       command.mSecondParam.push_back(STRID(REQ));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: UINT2UINT_2.CNF -> ADD.REQ");
       command.mFirstParam.clear();
@@ -367,7 +367,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(addName);
       command.mSecondParam.push_back(STRID(REQ));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       // Data
       BOOST_TEST_INFO("Event connection: CTU.CV -> ADD.IN1");
@@ -377,7 +377,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(addName);
       command.mSecondParam.push_back(STRID(IN1));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: ADD.OUT -> UINT2UINT_3.IN");
       command.mFirstParam.clear();
@@ -386,7 +386,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(uint2uintThird);
       command.mSecondParam.push_back(STRID(IN));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: SUBSCRIBE.RD_1 -> UINT2UINT_1.IN");
       command.mFirstParam.clear();
@@ -395,7 +395,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(uint2uintFirst);
       command.mSecondParam.push_back(STRID(IN));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: UINT2UINT_1.OUT -> MUL.IN2");
       command.mFirstParam.clear();
@@ -404,7 +404,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(mulName);
       command.mSecondParam.push_back(STRID(IN2));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: MUL.OUT -> UINT2UINT_2.IN");
       command.mFirstParam.clear();
@@ -413,7 +413,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(uint2uintSecond);
       command.mSecondParam.push_back(STRID(IN));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Event connection: UINT2UINT_2.OUT -> ADD.IN2");
       command.mFirstParam.clear();
@@ -422,7 +422,7 @@ namespace {
       command.mSecondParam.clear();
       command.mSecondParam.push_back(addName);
       command.mSecondParam.push_back(STRID(IN2));
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       // Literals
       command.mCMD = EMGMCommandType::Write;
@@ -432,35 +432,35 @@ namespace {
       command.mFirstParam.push_back(cycleName);
       command.mFirstParam.push_back(STRID(DT));
       command.mAdditionalParams = "T#200ms";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Literal: CTU.PV -> 0");
       command.mFirstParam.clear();
       command.mFirstParam.push_back(ctuName);
       command.mFirstParam.push_back(STRID(PV));
       command.mAdditionalParams = "0";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Literal: SUBSCRIBE.QI -> TRUE");
       command.mFirstParam.clear();
       command.mFirstParam.push_back(subscribeName);
       command.mFirstParam.push_back(STRID(QI));
       command.mAdditionalParams = "TRUE";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Literal: Pulbish.ID -> 239.0.0.1:61000");
       command.mFirstParam.clear();
       command.mFirstParam.push_back(subscribeName);
       command.mFirstParam.push_back(STRID(ID));
       command.mAdditionalParams = "239.0.0.1:61000";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
 
       BOOST_TEST_INFO("Literal: MUL.IN1 -> UINT#10");
       command.mFirstParam.clear();
       command.mFirstParam.push_back(mulName);
       command.mFirstParam.push_back(STRID(IN1));
       command.mAdditionalParams = "UINT#10";
-      BOOST_ASSERT(EMGMResponse::Ready == resource->executeMGMCommand(command));
+      BOOST_REQUIRE(EMGMResponse::Ready == resource->executeMGMCommand(command));
     }
 
     return device;
@@ -477,7 +477,7 @@ namespace {
           return EMGMResponse::Ready == commandParser.parseAndExecuteMGMCommand(paDest, paCommand);
         },
         paFilePath);
-    BOOST_ASSERT(LoadBootResult::LOAD_RESULT_OK == fileLoader.loadBootFile());
+    BOOST_REQUIRE(LoadBootResult::LOAD_RESULT_OK == fileLoader.loadBootFile());
     return device;
   }
 


### PR DESCRIPTION
The `BOOST_ASSERT` macro is disabled when building in *Release* mode, which causes tests that rely on side effects to fail. This replaces `BOOST_ASSERT` with `BOOST_REQUIRE` to ensure that tests also work when building in *Release* mode.