### PR TITLE
Adds pin validation to I/O handles

### DIFF
--- a/src/core/io/mapper/io_handle.cpp
+++ b/src/core/io/mapper/io_handle.cpp
@@ -9,7 +9,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
- *   Franz Höpfinger - adding "pin Valid" 
+ *   Franz Höpfinger - adding "pin Valid"
  *******************************************************************************/
 
 #include "core/io/mapper/io_handle.h"
@@ -19,7 +19,10 @@
 
 using namespace forte::core::io;
 
-IOHandle::IOHandle(IODeviceController *paController, IOMapper::Direction paDirection, CIEC_ANY::EDataTypeID paType, bool paPinValid) :
+IOHandle::IOHandle(IODeviceController *paController,
+                   IOMapper::Direction paDirection,
+                   CIEC_ANY::EDataTypeID paType,
+                   bool paPinValid) :
     mController(paController),
     mType(paType),
     mDirection(paDirection),

--- a/src/core/io/mapper/io_handle.cpp
+++ b/src/core/io/mapper/io_handle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 - 2018 Johannes Messmer (admin@jomess.com), fortiss GmbH
+ * Copyright (c) 2016, 2025 Johannes Messmer (admin@jomess.com), fortiss GmbH, HR Agrartechnik GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +9,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
+ *   Franz Höpfinger - adding "pin Valid" 
  *******************************************************************************/
 
 #include "core/io/mapper/io_handle.h"
@@ -18,11 +19,12 @@
 
 using namespace forte::core::io;
 
-IOHandle::IOHandle(IODeviceController *paController, IOMapper::Direction paDirection, CIEC_ANY::EDataTypeID paType) :
+IOHandle::IOHandle(IODeviceController *paController, IOMapper::Direction paDirection, CIEC_ANY::EDataTypeID paType, bool paPinValid) :
     mController(paController),
     mType(paType),
     mDirection(paDirection),
-    mObserver(nullptr) {
+    mObserver(nullptr),
+    mPinValid(paPinValid) {
 }
 
 IOHandle::~IOHandle() {

--- a/src/core/io/mapper/io_handle.h
+++ b/src/core/io/mapper/io_handle.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 - 2018 Johannes Messmer (admin@jomess.com), fortiss GmbH
+ * Copyright (c) 2016, 2025 Johannes Messmer (admin@jomess.com), fortiss GmbH, HR Agrartechnik GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +9,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
+ *   Franz Höpfinger - adding "pin Valid" 
  *******************************************************************************/
 
 #ifndef SRC_CORE_IO_MAPPER_HANDLE_H_
@@ -29,7 +30,7 @@ namespace forte {
           friend class IOMapper;
 
         public:
-          IOHandle(IODeviceController *paController, IOMapper::Direction paDirection, CIEC_ANY::EDataTypeID paType);
+          IOHandle(IODeviceController *paController, IOMapper::Direction paDirection, CIEC_ANY::EDataTypeID paType, bool paPinValid = true);
           virtual ~IOHandle();
 
           bool hasObserver() const {
@@ -56,6 +57,10 @@ namespace forte {
             return mDirection == IOMapper::Out;
           }
 
+          bool isPinValid() const {
+            return mPinValid;
+          }
+
           virtual void set(const CIEC_ANY &) = 0;
           virtual void get(CIEC_ANY &) = 0;
 
@@ -66,6 +71,8 @@ namespace forte {
           CIEC_ANY::EDataTypeID mType;
 
           IOMapper::Direction mDirection;
+
+          bool mPinValid;
 
           virtual void onObserver(IOObserver *paObserver);
           virtual void dropObserver();

--- a/src/core/io/mapper/io_handle.h
+++ b/src/core/io/mapper/io_handle.h
@@ -9,7 +9,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
- *   Franz Höpfinger - adding "pin Valid" 
+ *   Franz Höpfinger - adding "pin Valid"
  *******************************************************************************/
 
 #ifndef SRC_CORE_IO_MAPPER_HANDLE_H_
@@ -30,7 +30,10 @@ namespace forte {
           friend class IOMapper;
 
         public:
-          IOHandle(IODeviceController *paController, IOMapper::Direction paDirection, CIEC_ANY::EDataTypeID paType, bool paPinValid = true);
+          IOHandle(IODeviceController *paController,
+                   IOMapper::Direction paDirection,
+                   CIEC_ANY::EDataTypeID paType,
+                   bool paPinValid = true);
           virtual ~IOHandle();
 
           bool hasObserver() const {

--- a/src/core/io/processinterfacefb.cpp
+++ b/src/core/io/processinterfacefb.cpp
@@ -16,7 +16,7 @@
  *   Thomas Öllinger  - use PARAMS to reference to I/O configuration
  *   Alois ZOitl      - removed old process interface structure, added common
  *                      interface elements
- *   Franz Höpfinger - adding "pin Valid" 
+ *   Franz Höpfinger - adding "pin Valid"
  *******************************************************************************/
 
 #include "core/io/processinterfacefb.h"

--- a/src/core/io/processinterfacefb.cpp
+++ b/src/core/io/processinterfacefb.cpp
@@ -16,6 +16,7 @@
  *   Thomas Öllinger  - use PARAMS to reference to I/O configuration
  *   Alois ZOitl      - removed old process interface structure, added common
  *                      interface elements
+ *   Franz Höpfinger - adding "pin Valid" 
  *******************************************************************************/
 
 #include "core/io/processinterfacefb.h"
@@ -31,6 +32,7 @@ const CIEC_STRING CProcessInterfaceFB::scmMappedWrongDirectionOutput(
 const CIEC_STRING CProcessInterfaceFB::scmMappedWrongDirectionInput(
     "Mapped invalid direction. An I block requires an input handle."_STRING);
 const CIEC_STRING CProcessInterfaceFB::scmMappedWrongDataType("Mapped invalid data type."_STRING);
+const CIEC_STRING CProcessInterfaceFB::scmPinNotValid("Pin not Valid"_STRING);
 
 CProcessInterfaceFB::CProcessInterfaceFB(forte::core::CFBContainer &paContainer,
                                          const SFBInterfaceSpec &paInterfaceSpec,
@@ -155,6 +157,11 @@ void CProcessInterfaceFB::onHandle(IOHandle *const paHandle) {
 
   if (paHandle->getIOHandleDataType() != getIOObserverDataType()) {
     var_STATUS = scmMappedWrongDataType;
+    return;
+  }
+
+  if (!paHandle->isPinValid()) {
+    var_STATUS = scmPinNotValid;
     return;
   }
 

--- a/src/core/io/processinterfacefb.h
+++ b/src/core/io/processinterfacefb.h
@@ -16,7 +16,7 @@
  *                      configuration
  *   Alois ZOitl      - removed old process interface structure, added common
  *                      interface elements
- *   Franz Höpfinger - adding "pin Valid" 
+ *   Franz Höpfinger - adding "pin Valid"
  *******************************************************************************/
 
 #pragma once

--- a/src/core/io/processinterfacefb.h
+++ b/src/core/io/processinterfacefb.h
@@ -16,6 +16,7 @@
  *                      configuration
  *   Alois ZOitl      - removed old process interface structure, added common
  *                      interface elements
+ *   Franz Höpfinger - adding "pin Valid" 
  *******************************************************************************/
 
 #pragma once
@@ -101,6 +102,7 @@ namespace forte::core::io {
       static const CIEC_STRING scmMappedWrongDirectionOutput;
       static const CIEC_STRING scmMappedWrongDirectionInput;
       static const CIEC_STRING scmMappedWrongDataType;
+      static const CIEC_STRING scmPinNotValid;
   };
 
 } // namespace forte::core::io


### PR DESCRIPTION
Adds a mechanism to validate I/O pins, ensuring that only valid pins are used in process interface function blocks.

This prevents errors caused by using invalid pins and provides a way to indicate a pin is not usable.
