### PR TITLE
Treat empty destination string ids as device target

### DIFF
--- a/core/src/device.cpp
+++ b/core/src/device.cpp
@@ -19,7 +19,7 @@
 EMGMResponse CDevice::executeMGMCommand(forte::SManagementCMD &paCommand) {
   EMGMResponse retval = EMGMResponse::InvalidDst;
 
-  if (!paCommand.mDestination) {
+  if (paCommand.mDestination.empty()) {
     retval = CResource::executeMGMCommand(paCommand);
   } else {
     CResource *res = static_cast<CResource *>(getChild(paCommand.mDestination));


### PR DESCRIPTION
With the new string id infrastructure and that we have empty strings as string ids we need to check for invalid or empty string ids to know that a management command is targeting a device.