### PR TITLE
Move TNameIdentifier to mgmcmd.h and update definition

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,14 +17,6 @@
 # ############################################################################
 add_subdirectory(generated)
 
-set(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY
-    "30"
-    CACHE STRING
-          "Max supported hierarchy that can be provided in a management commands"
-)
-mark_as_advanced(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY)
-forte_generate_config_value_include(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY)
-
 option(FORTE_USE_FAKE_ECET "Compile the fake ecet used for testing" FALSE)
 mark_as_advanced(FORTE_USE_FAKE_ECET)
 

--- a/src/core/conn.h
+++ b/src/core/conn.h
@@ -21,7 +21,6 @@
 
 #include "core/datatype.h"
 #include "core/mgmcmd.h"
-#include "core/mgmcmdstruct.h"
 #include "core/stringid.h"
 
 // forward declaration of a few classes to reduce include file dependencies

--- a/src/core/fbcontainer.h
+++ b/src/core/fbcontainer.h
@@ -19,7 +19,6 @@
 
 #include "core/conn.h"
 #include "core/stringid.h"
-#include "core/mgmcmdstruct.h"
 #include <vector>
 #include <memory>
 

--- a/src/core/funcbloc.h
+++ b/src/core/funcbloc.h
@@ -36,8 +36,6 @@ class CEventChainExecutionThread;
 class CTimerHandler;
 class CDevice;
 
-#include "core/mgmcmdstruct.h"
-
 namespace forte {
   class IPlugPin;
   class ISocketPin;

--- a/src/core/generated/config/CMakeLists.txt
+++ b/src/core/generated/config/CMakeLists.txt
@@ -40,6 +40,13 @@ option(FORTE_SUPPORT_CUSTOM_SERIALIZABLE_DATATYPES
 )
 mark_as_advanced(FORTE_SUPPORT_CUSTOM_SERIALIZABLE_DATATYPES)
 
+set(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY
+        "30"
+        CACHE STRING
+        "Max supported hierarchy that can be provided in a management commands"
+)
+mark_as_advanced(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY)
+
 configure_file(forte_config.h.in
                "${FORTE_GENERATED_FILES_DIR}/forte_config.h"
 )

--- a/src/core/generated/config/forte_config.h.in
+++ b/src/core/generated/config/forte_config.h.in
@@ -12,22 +12,27 @@
  *******************************************************************************/
 #pragma once
 
+#include <cstddef>
+
 #include "core/datatype.h"
 
 //! Define the number of times the CTimerHandler will be called per second.
-const TForteUInt32 cgForteTicksPerSecond = ${FORTE_TicksPerSecond};
+constexpr TForteUInt32 cgForteTicksPerSecond = ${FORTE_TicksPerSecond};
 
 //! Define the initial size of the event chain list used in the event chain execution thread.
-const unsigned int cgEventChainEventListSize = ${FORTE_EventChainEventListSize};
+constexpr std::size_t cgEventChainEventListSize = ${FORTE_EventChainEventListSize};
 
 //! Define the initial size of the event chain's external event list.
-const unsigned int cgEventChainExternalEventListSize = ${FORTE_EventChainExternalEventListSize};
+constexpr std::size_t cgEventChainExternalEventListSize = ${FORTE_EventChainExternalEventListSize};
 
 //! Defines the number of pending communication messages can be handled by a communication function block
-const unsigned int cgCommunicationInterruptQueueSize = ${FORTE_CommunicationInterruptQueueSize};
+constexpr std::size_t cgCommunicationInterruptQueueSize = ${FORTE_CommunicationInterruptQueueSize};
 
 //! Buffer size in bytes to be used by the ip layer as receive buffer.
-const unsigned int cgIPLayerRecvBufferSize = ${FORTE_IPLayerRecvBufferSize};
+constexpr std::size_t cgIPLayerRecvBufferSize = ${FORTE_IPLayerRecvBufferSize};
+
+//! Maximum supported depth of the name hierarchy.
+constexpr std::size_t cgMaxSupportedNameHierarchy = ${FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY};
 
 //! Support custom serializable data types
 #cmakedefine FORTE_SUPPORT_CUSTOM_SERIALIZABLE_DATATYPES

--- a/src/core/mgmcmd.h
+++ b/src/core/mgmcmd.h
@@ -17,10 +17,18 @@
 #include <cstdint>
 #include <string>
 
+#include "generated/forte_config.h"
+#include "util/inplace_vector.h"
+#include "core/stringid.h"
+
 /**  \ingroup CORE \defgroup MGMCommands Management Commands Internal Representation
  * \brief In this section the FORTE representation of the management commands is described.
  */
 /*@{*/
+
+namespace forte::core {
+  using TNameIdentifier = util::inplace_vector<forte::core::StringId, cgMaxSupportedNameHierarchy>;
+}
 
 /*!\brief Type for the management command (e.g. create, delete ...)
  *

--- a/src/core/mgmcmdstruct.h
+++ b/src/core/mgmcmdstruct.h
@@ -12,7 +12,6 @@
  *******************************************************************************/
 #pragma once
 
-#include "generated/config/FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY.h"
 #include "core/mgmcmd.h"
 #include "core/util/inplace_vector.h"
 #include "core/stringid.h"
@@ -25,8 +24,6 @@ namespace forte {
      * \brief In this section the FORTE-internal data-exchange-structure for management command passing is described.
      */
     /*@{*/
-
-    typedef util::inplace_vector<forte::core::StringId, FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY> TNameIdentifier;
 
     /*!\brief All the data necessary for processing a management command.
      *

--- a/src/modules/utils/STEST_END_fbt.h
+++ b/src/modules/utils/STEST_END_fbt.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "core/funcbloc.h"
-#include "core/mgmcmdstruct.h"
 
 class FORTE_STEST_END final : public CFunctionBlock {
     DECLARE_FIRMWARE_FB(FORTE_STEST_END)

--- a/tests/core/nameidentifiertest.cpp
+++ b/tests/core/nameidentifiertest.cpp
@@ -10,7 +10,7 @@
  *   Alois Zoitl  - initial API and implementation and/or initial documentation
  *******************************************************************************/
 #include <boost/test/unit_test.hpp>
-#include "core/mgmcmdstruct.h"
+#include "core/mgmcmd.h"
 
 using namespace forte::core::literals;
 
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(capacity) {
   // check that we have the capacity as configured in cmake
   forte::core::TNameIdentifier identifier;
 
-  for (size_t i = 0; i < FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY; i++) {
+  for (size_t i = 0; i < cgMaxSupportedNameHierarchy; i++) {
     BOOST_CHECK(identifier.push_back(forte::core::StringId::insert(std::to_string(i))));
     BOOST_CHECK_EQUAL(false, identifier.empty());
   }
@@ -101,15 +101,15 @@ BOOST_AUTO_TEST_CASE(push_back) {
 BOOST_AUTO_TEST_CASE(pop_back) {
   forte::core::TNameIdentifier identifier;
   // fill with testdata
-  for (size_t i = 0; i < FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY; i++) {
+  for (size_t i = 0; i < cgMaxSupportedNameHierarchy; i++) {
     identifier.push_back(forte::core::StringId::insert(std::to_string(i)));
   }
 
-  for (size_t i = 0; i < FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY; i++) {
-    BOOST_TEST(std::to_string(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY - 1 - i) == identifier.back().get());
-    BOOST_TEST(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY - i == identifier.size());
+  for (size_t i = 0; i < cgMaxSupportedNameHierarchy; i++) {
+    BOOST_TEST(std::to_string(cgMaxSupportedNameHierarchy - 1 - i) == identifier.back().get());
+    BOOST_TEST(cgMaxSupportedNameHierarchy - i == identifier.size());
     identifier.pop_back();
-    BOOST_TEST(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY - 1 - i == identifier.size());
+    BOOST_TEST(cgMaxSupportedNameHierarchy - 1 - i == identifier.size());
   }
   BOOST_CHECK(identifier.empty());
 }
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(pop_back) {
 BOOST_AUTO_TEST_CASE(iterator) {
   forte::core::TNameIdentifier identifier;
   // fill with testdata
-  for (size_t i = 0; i < FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY; i++) {
+  for (size_t i = 0; i < cgMaxSupportedNameHierarchy; i++) {
     identifier.push_back(forte::core::StringId::insert(std::to_string(i)));
   }
 
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(iterator) {
   for (const auto &it : identifier) {
     BOOST_CHECK_EQUAL(forte::core::StringId::insert(std::to_string(i++)), it);
   }
-  BOOST_CHECK_EQUAL(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY,
+  BOOST_CHECK_EQUAL(cgMaxSupportedNameHierarchy,
                     i); // we should have exactly visited each element once but started at zero
 }
 


### PR DESCRIPTION
Move TNameIdentifier from `mgmcmdstruct.h` to `mgmcmd.h` and make the max-supported name hierarchy a constexpr constant.