### PR TITLE
Set _WIN32_WINNT version in compiler definitions for Win32

### DIFF
--- a/src/arch/win32/CMakeLists.txt
+++ b/src/arch/win32/CMakeLists.txt
@@ -19,7 +19,6 @@ target_include_directories(forte-global INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/)
 target_sources(forte PRIVATE ../main.cpp)
 
 option(FORTE_WINDOWS_XP_COMPAT "Use only APIs that still work on Windows XP" OFF)
-forte_generate_config_flag_include(FORTE_WINDOWS_XP_COMPAT)
 
 target_sources(forte-arch PRIVATE
     fortealloc.h
@@ -67,7 +66,12 @@ target_compile_definitions(forte-global INTERFACE _CRT_SECURE_NO_WARNINGS)
 target_compile_definitions(forte-global INTERFACE _NO_W32_PSEUDO_MODIFIERS)   #takes care of IN, OUT and OPTIONAL in mingw
 target_compile_definitions(forte-global INTERFACE FORTE_USE_DEFAULT_NEW_AND_DELETE)
 
-  
+if (FORTE_WINDOWS_XP_COMPAT)
+    target_compile_definitions(forte-global INTERFACE _WIN32_WINNT=0x0501) # Windows XP
+else ()
+    target_compile_definitions(forte-global INTERFACE _WIN32_WINNT=0x0600) # Windows Vista
+endif ()
+
 if (FORTE_TESTS AND FORTE_USE_TEST_CONFIG_IN_FORTE)
     target_compile_definitions(forte-global INTERFACE BOOST_TEST_NO_LIB)
 endif (FORTE_TESTS AND FORTE_USE_TEST_CONFIG_IN_FORTE)

--- a/src/arch/win32/forte_sync.cpp
+++ b/src/arch/win32/forte_sync.cpp
@@ -10,17 +10,6 @@
  *  Alois Zoitl, Gerhard Ebenhofer - initial API and implementation and/or initial documentation
  *******************************************************************************/
 
-#ifdef __GNUC__
-#ifdef __MINGW32__
-
-#ifdef _WIN32_WINNT
-#undef _WIN32_WINNT
-#endif
-#define _WIN32_WINNT 0x0600 // windows vista version, which included AcquireSRWLockExclusive and ReleaseSRWLockExclusive
-
-#endif //__MINGW32__
-#endif //__GNUC__
-
 #include "forte_sync.h"
 
 CPCSyncObject::CPCSyncObject() : mLock(SRWLOCK_INIT) {

--- a/src/arch/win32/forte_sync.h
+++ b/src/arch/win32/forte_sync.h
@@ -12,7 +12,6 @@
  *******************************************************************************/
 #pragma once
 
-#include "generated/config/FORTE_WINDOWS_XP_COMPAT.h"
 #include <windows.h>
 
 #define CSyncObject CPCSyncObject // allows that doxygen can generate better documenation
@@ -42,9 +41,9 @@ class CPCSyncObject {
     CPCSyncObject &operator=(const CPCSyncObject &) = delete;
 
   private:
-#ifdef FORTE_WINDOWS_XP_COMPAT
-    CRITICAL_SECTION mLock;
-#else
+#if _WIN32_WINNT >= 0x0600
     SRWLOCK mLock;
+#else
+    CRITICAL_SECTION mLock;
 #endif
 };


### PR DESCRIPTION
This ensures that we have a consistent `_WIN32_WINNT` version in forte.