### PR TITLE
Rework FORTE_RTTI_AND_EXCEPTIONS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,15 +33,15 @@ project(FORTE
 #######################################################################################
 # Global configuration
 #######################################################################################
+option(FORTE_TESTS "Build Tests" OFF)
+option(FORTE_SYSTEM_TESTS "FORTE System Tests" OFF)
+
 option(FORTE_BUILD_EXECUTABLE "Build 4diac FORTE as an executable, otherwise build a library" ON)
 mark_as_advanced(FORTE_BUILD_EXECUTABLE)
 
 # TODO
 #option(FORTE_C_INTERFACE "Build C interface to 4diac FORTE" OFF)
 #mark_as_advanced(FORTE_C_INTERFACE)
-
-option(FORTE_RTTI_AND_EXCEPTIONS "Enable RTTI and Exceptions" OFF)
-mark_as_advanced(FORTE_RTTI_AND_EXCEPTIONS)
 
 add_library(forte-global INTERFACE)
 link_libraries(forte-global)
@@ -125,14 +125,8 @@ add_subdirectory(stdfblib)
 add_subdirectory(com)
 add_subdirectory(modules)
 
-enable_testing()
+if (FORTE_TESTS OR FORTE_SYSTEM_TESTS)
+    enable_testing()
+endif ()
 add_subdirectory(systemtests)
 add_subdirectory(tests)
-
-# set this late as it may be overridden by tests
-if (NOT MSVC)
-    target_compile_options(forte-global INTERFACE
-        $<IF:$<BOOL:${FORTE_RTTI_AND_EXCEPTIONS}>,-frtti,-fno-rtti>
-        $<IF:$<BOOL:${FORTE_RTTI_AND_EXCEPTIONS}>,-fexceptions,-fno-exceptions>
-    )
-endif()

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -12,9 +12,23 @@
 # *    - added utils directory
 # *******************************************************************************/
 
+include(CMakeDependentOption)
+include(CheckCXXCompilerFlag)
+
+check_cxx_compiler_flag(-frtti HAVE_RTTI_FLAG)
+check_cxx_compiler_flag(-fexceptions HAVE_EXCEPTIONS_FLAG)
+
+cmake_dependent_option(FORTE_RTTI_AND_EXCEPTIONS "Enable RTTI and Exceptions" OFF "HAVE_RTTI_FLAG AND HAVE_EXCEPTIONS_FLAG AND NOT FORTE_TESTS" ON)
+mark_as_advanced(FORTE_RTTI_AND_EXCEPTIONS)
+
 add_library(forte-arch)
 target_link_libraries(forte-arch PUBLIC forte-core)
 target_link_libraries(forte PUBLIC $<LINK_LIBRARY:WHOLE_ARCHIVE,forte-arch>)
+
+target_compile_options(forte-arch PUBLIC
+        $<$<BOOL:${HAVE_RTTI_FLAG}>:$<IF:$<BOOL:${FORTE_RTTI_AND_EXCEPTIONS}>,-frtti,-fno-rtti>>
+        $<$<BOOL:${HAVE_EXCEPTIONS_FLAG}>:$<IF:$<BOOL:${FORTE_RTTI_AND_EXCEPTIONS}>,-fexceptions,-fno-exceptions>>
+)
 
 ###############################################################################
 # Architectures
@@ -23,7 +37,7 @@ macro(forte_register_architecture arch)
     set_property(TARGET forte-arch APPEND PROPERTY forte_architectures ${arch})
     if (NOT FORTE_ARCHITECTURE STREQUAL "${arch}")
         return()
-    endif()
+    endif ()
 endmacro()
 
 add_subdirectory(common)
@@ -52,4 +66,4 @@ set_property(CACHE FORTE_ARCHITECTURE PROPERTY STRINGS None ${architectures})
 
 if (FORTE_ARCHITECTURE STREQUAL "None")
     message(FATAL_ERROR "No FORTE_ARCHITECTURE selected. Use one of ${architectures}")
-endif()
+endif ()

--- a/core/include/forte/datatypes/forte_array_dynamic.h
+++ b/core/include/forte/datatypes/forte_array_dynamic.h
@@ -514,12 +514,12 @@ class CIEC_ARRAY_DYNAMIC : public CIEC_ARRAY {
 
     [[nodiscard]] reference at(intmax_t paIndex) override {
       if (paIndex < mLowerBound || paIndex > mUpperBound || !mData) {
-#ifdef FORTE_RTTI_AND_EXCEPTIONS
+#if __cpp_exceptions
         throw std::out_of_range("array::at: Index: " + std::to_string(paIndex) +
                                 " >=  size: " + std::to_string(size()));
-#else // FORTE_RTTI_AND_EXCEPTIONS
+#else
         std::abort();
-#endif // FORTE_RTTI_AND_EXCEPTIONS
+#endif
       }
       return *reinterpret_cast<pointer>(reinterpret_cast<TForteByte *>(mData) +
                                         getDataArrayIndex(paIndex) * mElementSize);
@@ -527,12 +527,12 @@ class CIEC_ARRAY_DYNAMIC : public CIEC_ARRAY {
 
     [[nodiscard]] const_reference at(intmax_t paIndex) const override {
       if (paIndex < mLowerBound || paIndex > mUpperBound || !mData) {
-#ifdef FORTE_RTTI_AND_EXCEPTIONS
+#if __cpp_exceptions
         throw std::out_of_range("array::at: Index: " + std::to_string(paIndex) +
                                 " >=  size: " + std::to_string(size()));
-#else // FORTE_RTTI_AND_EXCEPTIONS
+#else
         std::abort();
-#endif // FORTE_RTTI_AND_EXCEPTIONS
+#endif
       }
       return *reinterpret_cast<const_pointer>(reinterpret_cast<const TForteByte *>(mData) +
                                               getDataArrayIndex(paIndex) * mElementSize);

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -1,4 +1,3 @@
-option(FORTE_SYSTEM_TESTS "FORTE System Tests" OFF)
 if (NOT FORTE_SYSTEM_TESTS)
   return()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,12 +12,9 @@
 # *   Martin Melik-Merkumians  - adds subdirectory for arch tests
 # *******************************************************************************/
 
-option(FORTE_TESTS "Build Tests" OFF)
 if (NOT FORTE_TESTS)
   return()
 endif()
-
-set(FORTE_RTTI_AND_EXCEPTIONS ON CACHE BOOL "This value is forced ON because of FORTE_TESTS enabled" FORCE)
 
 if (FORTE_ARCHITECTURE STREQUAL "Posix")
   option(FORTE_TEST_CODE_COVERAGE_ANALYSIS "Perform code coverage analyis with GCOV and presentation with LCOV" OFF)


### PR DESCRIPTION
Move FORTE_RTTI_AND_EXCEPTIONS to arch, test for compiler flag, and add dependency on test enablement.