### PR TITLE
Set mimumum CMake version to 3.30

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 #      - complete rewrite
 # *******************************************************************************/
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.30)
 project(FORTE
         DESCRIPTION "4diac FORTE is a small portable implementation of an IEC 61499 runtime environment targeting small embedded control devices, implemented in C++."
         HOMEPAGE_URL "https://eclipse.dev/4diac/"


### PR DESCRIPTION
Set mimumum CMake version to 3.30 to avoid problems with WHOLE_ARCHIVE link option, see https://gitlab.kitware.com/cmake/cmake/-/issues/24504 and https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9510.