### PR TITLE
Rework FORTE_LOGLEVEL and FORTE_STACKTRACE options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,6 @@ mark_as_advanced(FORTE_BUILD_EXECUTABLE)
 #option(FORTE_C_INTERFACE "Build C interface to 4diac FORTE" OFF)
 #mark_as_advanced(FORTE_C_INTERFACE)
 
-add_library(forte-global INTERFACE)
-link_libraries(forte-global)
-
 #############################################################################
 # Whole archive
 #############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,30 +47,6 @@ add_library(forte-global INTERFACE)
 link_libraries(forte-global)
 
 #############################################################################
-# Configure stacktrace
-#############################################################################
-# if (FORTE_STACKTRACE)
-#     if (FORTE_STACKTRACE_IMPL MATCHES "boost")
-#         find_package(Boost REQUIRED)
-#         forte_add_link_library(backtrace)
-#         forte_add_custom_configuration("#define BOOST_STACKTRACE_USE_BACKTRACE")
-
-#         if (WIN32 OR MINGW)
-#             forte_add_link_flags(-no-pie)
-#         elseif (UNIX)
-#             forte_add_link_flags(-rdynamic)
-#             forte_add_link_library(dl)
-#         endif ()
-#     endif ()
-
-#     if (FORTE_STACKTRACE_IMPL MATCHES "cxx23")
-#         if (CMAKE_COMPILER_IS_GNUCXX)
-#             forte_add_link_library(-lstdc++_libbacktrace)
-#         endif ()
-#     endif ()
-# endif ()
-
-#############################################################################
 # Whole archive
 #############################################################################
 if (NOT CMAKE_LINK_LIBRARY_USING_WHOLE_ARCHIVE_SUPPORTED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,28 +46,6 @@ mark_as_advanced(FORTE_BUILD_EXECUTABLE)
 add_library(forte-global INTERFACE)
 link_libraries(forte-global)
 
-#######################################################################################
-# Determine log level
-#######################################################################################
-string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWERCASE)
-if (BUILD_TYPE_LOWERCASE STREQUAL "debug")
-    if (FORTE_LOGLEVEL MATCHES "NOLOG")
-        message(WARNING "Log Level is set to NOLOG and CMAKE_BUILD_TYPE is set to Debug. Are sure you don't want to log anything?")
-    endif()
-    if (NOT DEFINED FORTE_LOGLEVEL)
-    	message(STATUS "No Log Level was specified. Setting Log Level to Debug default LOGINFO.")
-        set(FORTE_LOGLEVEL "LOGINFO" CACHE STRING "Loglevel to use" FORCE)
-    endif()
-else()
-    if (NOT DEFINED FORTE_LOGLEVEL)
-        message(STATUS "No Log Level was specified. Setting Log Level to Release default LOGERROR.")
-        set(FORTE_LOGLEVEL "LOGERROR" CACHE STRING "Loglevel to use" FORCE)
-    endif()
-endif()
-set_property(CACHE FORTE_LOGLEVEL PROPERTY STRINGS LOGDEBUG LOGERROR LOGWARNING LOGINFO NOLOG)
-
-target_compile_definitions(forte-global INTERFACE ${FORTE_LOGLEVEL})
-
 #############################################################################
 # Configure stacktrace
 #############################################################################

--- a/arch/common/src/bsdsocketinterf.cpp
+++ b/arch/common/src/bsdsocketinterf.cpp
@@ -29,7 +29,7 @@ CBSDSocketInterface::TSocketDescriptor CBSDSocketInterface::openTCPServerConnect
                                                                                     unsigned short paPort) {
   TSocketDescriptor nRetVal = -1;
 
-#ifndef LOGINFO
+#ifndef FORTE_LOGINFO
   (void) paIPAddr;
 #else
   DEVLOG_INFO("CBSDSocketInterface: Opening TCP-Server connection at: %s:%d\n", paIPAddr, paPort);

--- a/core/include/forte/util/devlog.h
+++ b/core/include/forte/util/devlog.h
@@ -10,8 +10,8 @@
  *   Rene Smodic, Thomas Strasser, Alois Zoitl, Ingo Hegny, Monika Wenger
  *    - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef _DEVLOG_H_
-#define _DEVLOG_H_
+
+#pragma once
 
 /*!\ingroup FORTE_HAL
  * \brief CDeviceLog is the entity that logs messages created by the FORTE Runtime system.
@@ -29,11 +29,12 @@ enum class E_MsgLevel { Info, Warning, Error, Debug, Trace };
  * NOLOG: log no messages
  */
 
-#if !(defined(NOLOG) || defined(LOGERROR) || defined(LOGWARNING) || defined(LOGINFO) || defined(LOGDEBUG))
-#define LOGDEBUG /* Set default loglevel */
+#if !(defined(FORTE_NOLOG) || defined(FORTE_LOGERROR) || defined(FORTE_LOGWARNING) || defined(FORTE_LOGINFO) ||        \
+      defined(FORTE_LOGDEBUG))
+#define FORTE_LOGDEBUG /* Set default loglevel */
 #endif
 
-#ifdef LOGDEBUG
+#ifdef FORTE_LOGDEBUG
 #define DEVLOG_ERROR(...) logMessage(E_MsgLevel::Error, __VA_ARGS__)
 #define DEVLOG_WARNING(...) logMessage(E_MsgLevel::Warning, __VA_ARGS__)
 #define DEVLOG_INFO(...) logMessage(E_MsgLevel::Info, __VA_ARGS__)
@@ -44,7 +45,7 @@ enum class E_MsgLevel { Info, Warning, Error, Debug, Trace };
 #define DEVLOG_DEBUG_VAR(X) X
 #endif
 
-#ifdef LOGERROR
+#ifdef FORTE_LOGERROR
 #define DEVLOG_ERROR(...) logMessage(E_MsgLevel::Error, __VA_ARGS__)
 #define DEVLOG_WARNING(...)
 #define DEVLOG_INFO(...)
@@ -55,7 +56,7 @@ enum class E_MsgLevel { Info, Warning, Error, Debug, Trace };
 #define DEVLOG_DEBUG_VAR(X)
 #endif
 
-#ifdef LOGWARNING
+#ifdef FORTE_LOGWARNING
 #define DEVLOG_ERROR(...) logMessage(E_MsgLevel::Error, __VA_ARGS__)
 #define DEVLOG_WARNING(...) logMessage(E_MsgLevel::Warning, __VA_ARGS__)
 #define DEVLOG_INFO(...)
@@ -66,7 +67,7 @@ enum class E_MsgLevel { Info, Warning, Error, Debug, Trace };
 #define DEVLOG_DEBUG_VAR(X)
 #endif
 
-#ifdef LOGINFO
+#ifdef FORTE_LOGINFO
 #define DEVLOG_ERROR(...) logMessage(E_MsgLevel::Error, __VA_ARGS__)
 #define DEVLOG_WARNING(...) logMessage(E_MsgLevel::Warning, __VA_ARGS__)
 #define DEVLOG_INFO(...) logMessage(E_MsgLevel::Info, __VA_ARGS__)
@@ -77,7 +78,7 @@ enum class E_MsgLevel { Info, Warning, Error, Debug, Trace };
 #define DEVLOG_DEBUG_VAR(X)
 #endif
 
-#ifdef NOLOG
+#ifdef FORTE_NOLOG
 #define DEVLOG_INFO(...)
 #define DEVLOG_WARNING(...)
 #define DEVLOG_ERROR(...)
@@ -88,19 +89,17 @@ enum class E_MsgLevel { Info, Warning, Error, Debug, Trace };
 #define DEVLOG_DEBUG_VAR(X)
 #endif
 
-#if (defined(FORTE_TRACE_EVENTS) && !defined(NOLOG))
+#if (defined(FORTE_TRACE_EVENTS) && !defined(FORTE_NOLOG))
 #define FORTE_TRACE(...) logMessage(E_MsgLevel::Trace, __VA_ARGS__)
 #else
 #define FORTE_TRACE(...)
 #endif
 
-#ifndef NOLOG
+#ifndef FORTE_NOLOG
 
 /*! \brief Adds an Entry to the LogBook
  *
  */
 void logMessage(E_MsgLevel paLevel, const char *pacMessage, ...);
 
-#endif // #ifndef NOLOG
-
-#endif //_DEVLOG_H_
+#endif // #ifndef FORTE_NOLOG

--- a/core/src/fmi/CMakeLists.txt
+++ b/core/src/fmi/CMakeLists.txt
@@ -19,7 +19,7 @@ option(FORTE_ENABLE_FMU
 if (NOT FORTE_ENABLE_FMU)
     return()
 endif ()
-target_compile_definitions(forte-global INTERFACE FORTE_FMU)
+target_compile_definitions(forte-core PUBLIC FORTE_FMU)
 
 set(FORTE_FMU_INCLUDE
     ""

--- a/core/src/fmi/fmuConfig.h
+++ b/core/src/fmi/fmuConfig.h
@@ -171,7 +171,7 @@ const unsigned int allowedStatesInFunction[] = {
 
 #define NOT_USED(var) (void) var;
 
-#ifdef LOGDEBUG
+#ifdef FORTE_LOGDEBUG
 #include "forte/arch/forte_sync.h"
 #include <sstream>
 #include "core/fmi/fmuInstance.h"

--- a/core/src/fmi/fmuInstance.cpp
+++ b/core/src/fmi/fmuInstance.cpp
@@ -26,7 +26,7 @@ fmuInstance *fmuInstance::sFmuInstance = 0;
 
 CSyncObject fmuInstance::sFmuInstanceMutex;
 
-#ifdef LOGDEBUG
+#ifdef FORTE_LOGDEBUG
 #include "forte/util/criticalregion.h"
 #include <ctime>
 #include <sstream>
@@ -64,7 +64,7 @@ fmuInstance::fmuInstance(fmi2String instanceName,
   this->mCallbackFunctions = callbackFunctions;
   this->mState = STATE_ERROR;
 
-#ifdef LOGDEBUG
+#ifdef FORTE_LOGDEBUG
   std::stringstream fileName;
   fileName << "fmu4diacDebug1" << ((long) time(0)) << GUID << "_" << this << ".txt";
   fmuInstance::debugFile.open(fileName.str().c_str(), std::fstream::out);

--- a/core/src/fmi/fmuInstance.h
+++ b/core/src/fmi/fmuInstance.h
@@ -31,7 +31,7 @@ class fmuInstance : public CDevice {
                 const fmi2CallbackFunctions *callbackFunctions);
     ~fmuInstance() override;
 
-#ifdef LOGDEBUG
+#ifdef FORTE_LOGDEBUG
     std::fstream debugFile;
     void printToFile(const char *message);
 #endif

--- a/core/src/util/CMakeLists.txt
+++ b/core/src/util/CMakeLists.txt
@@ -13,8 +13,15 @@
 # core/util
 # ############################################################################
 
+include(CMakeDependentOption)
+
 set(FORTE_LOGLEVEL "$<IF:$<CONFIG:Debug>,LOGINFO,LOGERROR>" CACHE STRING "Loglevel to use")
 set_property(CACHE FORTE_LOGLEVEL PROPERTY STRINGS LOGDEBUG LOGERROR LOGWARNING LOGINFO NOLOG)
+
+cmake_dependent_option(FORTE_STACKTRACE "Include stacktrace when logging errors" OFF "NOT FORTE_LOGLEVEL STREQUAL NOLOG" OFF)
+if (FORTE_STACKTRACE)
+    set(FORTE_STACKTRACE_IMPL "boost" CACHE STRING "Stacktrace implementation to use")
+endif ()
 
 option(FORTE_LOGGER_READABLE_TIME "Logger time in IEC 61131-3 date time literal" OFF)
 
@@ -28,3 +35,27 @@ target_sources(forte-core PRIVATE
         $<IF:$<BOOL:${FORTE_LOGGER_READABLE_TIME}>,${CMAKE_CURRENT_SOURCE_DIR}/readableTimeString.cpp,${CMAKE_CURRENT_SOURCE_DIR}/plainTimeString.cpp>
 )
 target_compile_definitions(forte-core PUBLIC "FORTE_${FORTE_LOGLEVEL}")
+
+if (FORTE_STACKTRACE)
+    target_compile_definitions(forte-core PRIVATE "FORTE_STACKTRACE")
+    if (FORTE_STACKTRACE_IMPL MATCHES "boost")
+        find_package(Boost REQUIRED)
+        target_link_libraries(forte-core PRIVATE backtrace)
+        target_compile_definitions(forte-core PRIVATE "FORTE_STACKTRACE_BOOST" "BOOST_STACKTRACE_USE_BACKTRACE")
+
+        if (WIN32 OR MINGW)
+            target_link_options(forte-core PUBLIC -no-pie)
+        elseif (UNIX)
+            target_link_options(forte-core PUBLIC -rdynamic)
+            target_link_libraries(forte-core PRIVATE dl)
+        endif ()
+    endif ()
+
+    if (FORTE_STACKTRACE_IMPL MATCHES "cxx23")
+        target_compile_features(forte-core PRIVATE cxx_std_23)
+        target_compile_definitions(forte-core PRIVATE "FORTE_STACKTRACE_CXX23")
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            target_link_libraries(forte-core PRIVATE stdc++exp)
+        endif ()
+    endif ()
+endif ()

--- a/core/src/util/CMakeLists.txt
+++ b/core/src/util/CMakeLists.txt
@@ -13,14 +13,18 @@
 # core/util
 # ############################################################################
 
+set(FORTE_LOGLEVEL "$<IF:$<CONFIG:Debug>,LOGINFO,LOGERROR>" CACHE STRING "Loglevel to use")
+set_property(CACHE FORTE_LOGLEVEL PROPERTY STRINGS LOGDEBUG LOGERROR LOGWARNING LOGINFO NOLOG)
+
 option(FORTE_LOGGER_READABLE_TIME "Logger time in IEC 61131-3 date time literal" OFF)
 
 target_sources(forte-core PRIVATE
         configFileParser.cpp
         configFileParser.h
-        devlog.cpp
         mainparam_utils.cpp
         parameterParser.cpp
         string_utils.cpp
+        $<$<NOT:$<OR:$<STREQUAL:${FORTE_LOGLEVEL},NOLOG>,$<BOOL:${FORTE_EXTERNAL_LOG_HANDLER}>>>:${CMAKE_CURRENT_SOURCE_DIR}/devlog.cpp>
         $<IF:$<BOOL:${FORTE_LOGGER_READABLE_TIME}>,${CMAKE_CURRENT_SOURCE_DIR}/readableTimeString.cpp,${CMAKE_CURRENT_SOURCE_DIR}/plainTimeString.cpp>
 )
+target_compile_definitions(forte-core PUBLIC "FORTE_${FORTE_LOGLEVEL}")

--- a/core/src/util/devlog.cpp
+++ b/core/src/util/devlog.cpp
@@ -12,8 +12,6 @@
  *******************************************************************************/
 #include "forte/util/devlog.h"
 
-#ifndef NOLOG
-
 #include "forte/config/devlog_config.h"
 #include "forte/timerha.h"
 #include "forte/arch/forte_printer.h"
@@ -48,9 +46,6 @@
 std::string getRealtimeString();
 
 static const char *scLogLevel[] = {"INFO", "WARNING", "ERROR", "DEBUG", "TRACE"};
-
-// this define allows to provide an own log handler (see LMS for an example of this)
-#ifndef FORTE_EXTERNAL_LOG_HANDLER
 
 /*! \brief print the given log message with the error level and a time stamp
  *
@@ -99,7 +94,3 @@ void printLogMessage(E_MsgLevel paLevel, const char *paMessage) {
   (paLevel == E_MsgLevel::Error ? std::cerr : std::cout) << std::flush;
 #endif
 }
-
-#endif /* FORTE_EXTERNAL_LOG_HANDLER */
-
-#endif /* NOLOG */

--- a/modules/powerlink/CMakeLists.txt
+++ b/modules/powerlink/CMakeLists.txt
@@ -38,7 +38,7 @@ set(FORTE_MODULE_POWERLINK_TINYXML_DIR
 )
 
 if (FORTE_ARCHITECTURE STREQUAL "Win32")
-    target_compile_definitions(forte-global INTERFACE WPCAP)
+    target_compile_definitions(forte-powerlink PRIVATE WPCAP)
     target_link_libraries(forte PUBLIC openPOWERLINK wpcap iphlpapi)
 elseif (FORTE_ARCHITECTURE STREQUAL "Posix")
     target_link_libraries(forte PUBLIC powerlink pcap rt)

--- a/modules/ros/CMakeLists.txt
+++ b/modules/ros/CMakeLists.txt
@@ -23,8 +23,6 @@ if (NOT FORTE_MODULE_ROS)
     return()
 endif ()
 
-target_compile_definitions(forte-global INTERFACE FORTE_ROS)
-
 # ############################################################################
 # Communication Layer for ROS (publish, subscribe)
 # ############################################################################


### PR DESCRIPTION
Rework `FORTE_LOGLEVEL` and `FORTE_STACKTRACE` options. Also remove the `forte-global` target.