### PR TITLE
Use fixed bitset to store force flags and reset all forced outputs after event execution

### DIFF
--- a/core/include/forte/config/CMakeLists.txt
+++ b/core/include/forte/config/CMakeLists.txt
@@ -13,38 +13,38 @@
 #############################################################################
 
 set(FORTE_TicksPerSecond
-    "1000"
-    CACHE STRING "FORTE ticks per second"
+        "1000"
+        CACHE STRING "FORTE ticks per second"
 )
 mark_as_advanced(FORTE_TicksPerSecond)
 
 set(FORTE_EventChainEventListSize
-    "256"
-    CACHE STRING "FORTE eventchain event list size"
+        "256"
+        CACHE STRING "FORTE eventchain event list size"
 )
 mark_as_advanced(FORTE_EventChainEventListSize)
 
 set(FORTE_EventChainExternalEventListSize
-    "16"
-    CACHE STRING "FORTE eventchain external event list size"
+        "16"
+        CACHE STRING "FORTE eventchain external event list size"
 )
 mark_as_advanced(FORTE_EventChainExternalEventListSize)
 
 set(FORTE_CommunicationInterruptQueueSize
-    "10"
-    CACHE STRING "FORTE Communication interrupt queue size"
+        "10"
+        CACHE STRING "FORTE Communication interrupt queue size"
 )
 mark_as_advanced(FORTE_CommunicationInterruptQueueSize)
 
 if (FORTE_DYNAMIC_TYPE_LOAD)
     set(FORTE_IPLayerRecvBufferSize
-        "20000"
-        CACHE STRING "FORTE IP layer recv buffer size"
+            "20000"
+            CACHE STRING "FORTE IP layer recv buffer size"
     )
 else ()
     set(FORTE_IPLayerRecvBufferSize
-        "1500"
-        CACHE STRING "FORTE IP layer recv buffer size"
+            "1500"
+            CACHE STRING "FORTE IP layer recv buffer size"
     )
 endif ()
 mark_as_advanced(FORTE_IPLayerRecvBufferSize)
@@ -60,6 +60,13 @@ set(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY
         "Max supported hierarchy that can be provided in a management commands"
 )
 mark_as_advanced(FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY)
+
+set(FORTE_MGM_MAX_SUPPORTED_FORCE_INDEX
+        "64"
+        CACHE STRING
+        "Max supported absolute port index for forcing data pins (multiples of 64 recommended)"
+)
+mark_as_advanced(FORTE_MGM_MAX_SUPPORTED_FORCE_INDEX)
 
 configure_file(forte_config.h.in
         "${CMAKE_CURRENT_BINARY_DIR}/forte_config.h"

--- a/core/include/forte/config/forte_config.h.in
+++ b/core/include/forte/config/forte_config.h.in
@@ -34,6 +34,9 @@ namespace forte {
 
   //! Maximum supported depth of the name hierarchy.
   constexpr std::size_t cgMaxSupportedNameHierarchy = ${FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY};
+
+  //! Maximum supported absolute port index for forcing data pins.
+  constexpr std::size_t cgMaxSupportedForceIndex = ${FORTE_MGM_MAX_SUPPORTED_FORCE_INDEX};
 }
 
 //! Support custom serializable data types

--- a/core/include/forte/fbcontainer.h
+++ b/core/include/forte/fbcontainer.h
@@ -138,7 +138,7 @@ namespace forte {
        * @param paNameList the name hierarchy the requested variable
        * \return true on success, false otherwise.
        */
-      virtual bool setForce(std::span<const StringId> paNameList, bool paForce);
+      virtual bool setForced(std::span<const StringId> paNameList, bool paForce);
 
       /*!\brief get the connection object for the given destination identifier
        *

--- a/core/include/forte/funcbloc.h
+++ b/core/include/forte/funcbloc.h
@@ -235,6 +235,9 @@ namespace forte {
             mEventMonitorCount[paEIID]++;
           }
           executeEvent(paEIID, paExecEnv);
+          if (mForces.any()) [[unlikely]] {
+            resetForcedOutputs();
+          }
         }
       }
 
@@ -447,9 +450,6 @@ namespace forte {
       void writeData(const TAbsDataPortNum paAbsDataPortNum, T &paValue, U &paConn) {
         if (!getForce(paAbsDataPortNum)) [[likely]] {
           paConn.writeData(paValue);
-        } else {
-          // when forcing we write back the value from the connection to keep the forced value on the output
-          paConn.readData(paValue);
         }
 #ifdef FORTE_TRACE_CTF
         traceWriteData(paAbsDataPortNum - mInterfaceSpec.getNumDIs(), paValue);
@@ -541,7 +541,8 @@ namespace forte {
        *
        * \param paECET the event chain execution thread this FB was invoked from
        * \param paEIID Event input ID where event occurred.
-       * \param paExecEnv Event chain execution environment the FB will be executed in (used for adding output events).
+       * \param paExecEnv Event chain execution environment the FB will be executed in (used for adding output
+       * events).
        *
        *
        */
@@ -560,6 +561,10 @@ namespace forte {
       virtual void writeOutputData(TEventID paEO) = 0;
 
       bool setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue);
+
+      /*!\brief Function resetting the values of forced outputs to the value from the output connection.
+       */
+      void resetForcedOutputs();
 
     public:
       CFunctionBlock(const CFunctionBlock &) = delete;

--- a/core/include/forte/funcbloc.h
+++ b/core/include/forte/funcbloc.h
@@ -346,9 +346,9 @@ namespace forte {
 
       TAbsDataPortNum getAbsDataPortNum(StringId paPortNameId) const;
 
-      bool setForce(std::span<const StringId> paNameList, bool paForce) override;
+      bool setForced(std::span<const StringId> paNameList, bool paForce) override;
 
-      [[nodiscard]] constexpr bool getForce(const TAbsDataPortNum paAbsDataPortNum) const {
+      [[nodiscard]] constexpr bool isForced(const TAbsDataPortNum paAbsDataPortNum) const {
         return paAbsDataPortNum < mForces.size() && mForces[paAbsDataPortNum];
       }
 
@@ -432,7 +432,7 @@ namespace forte {
         if (!paConn) {
           return;
         }
-        if (!getForce(paAbsDataPortNum)) [[likely]] {
+        if (!isForced(paAbsDataPortNum)) [[likely]] {
           paConn->readData(paValue);
         }
 #ifdef FORTE_TRACE_CTF
@@ -448,7 +448,7 @@ namespace forte {
        */
       template<typename T, typename U>
       void writeData(const TAbsDataPortNum paAbsDataPortNum, T &paValue, U &paConn) {
-        if (!getForce(paAbsDataPortNum)) [[likely]] {
+        if (!isForced(paAbsDataPortNum)) [[likely]] {
           paConn.writeData(paValue);
         }
 #ifdef FORTE_TRACE_CTF
@@ -560,7 +560,7 @@ namespace forte {
        */
       virtual void writeOutputData(TEventID paEO) = 0;
 
-      bool setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue);
+      bool setForced(TAbsDataPortNum paAbsDataPortNum, bool paForceValue);
 
       /*!\brief Function resetting the values of forced outputs to the value from the output connection.
        */

--- a/core/include/forte/funcbloc.h
+++ b/core/include/forte/funcbloc.h
@@ -31,6 +31,8 @@
 #include "forte/util/devlog.h"
 #include "forte/stringid.h"
 
+#include <bitset>
+
 namespace forte {
   class CEventChainExecutionThread;
   class CTimerHandler;
@@ -343,8 +345,8 @@ namespace forte {
 
       bool setForce(std::span<const StringId> paNameList, bool paForce) override;
 
-      bool getForce(TAbsDataPortNum paAbsDataPortNum) const {
-        return mForces[paAbsDataPortNum];
+      [[nodiscard]] constexpr bool getForce(const TAbsDataPortNum paAbsDataPortNum) const {
+        return paAbsDataPortNum < mForces.size() && mForces[paAbsDataPortNum];
       }
 
       virtual void toString(std::string &paTargetBuf) const;
@@ -423,11 +425,11 @@ namespace forte {
        * \param paValue Variable to read into.
        * \param paConn Connection to read from.
        */
-      void readData(TPortId paAbsDataPortNum, CIEC_ANY &paValue, const CDataConnection *const paConn) {
+      void readData(const TPortId paAbsDataPortNum, CIEC_ANY &paValue, const CDataConnection *const paConn) {
         if (!paConn) {
           return;
         }
-        if (!mForces[paAbsDataPortNum]) {
+        if (!getForce(paAbsDataPortNum)) [[likely]] {
           paConn->readData(paValue);
         }
 #ifdef FORTE_TRACE_CTF
@@ -442,8 +444,8 @@ namespace forte {
        * \param paConn Connection to write into.
        */
       template<typename T, typename U>
-      void writeData(TAbsDataPortNum paAbsDataPortNum, T &paValue, U &paConn) {
-        if (!mForces[paAbsDataPortNum]) {
+      void writeData(const TAbsDataPortNum paAbsDataPortNum, T &paValue, U &paConn) {
+        if (!getForce(paAbsDataPortNum)) [[likely]] {
           paConn.writeData(paValue);
         } else {
           // when forcing we write back the value from the connection to keep the forced value on the output
@@ -557,7 +559,7 @@ namespace forte {
        */
       virtual void writeOutputData(TEventID paEO) = 0;
 
-      void setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue);
+      bool setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue);
 
     public:
       CFunctionBlock(const CFunctionBlock &) = delete;
@@ -569,7 +571,7 @@ namespace forte {
       //! vector for storing the event counts for input and output events together, first inputs then outputs
       std::vector<TForteUInt32> mEventMonitorCount;
       //! vector of bools for determining force state of data inputs, data outputs, and var in outs in that order
-      std::vector<bool> mForces;
+      std::bitset<cgMaxSupportedForceIndex> mForces;
 
 #ifdef FORTE_TRACE_CTF
       void traceInputEvent(TEventID paEIID);

--- a/core/src/fbcontainer.cpp
+++ b/core/src/fbcontainer.cpp
@@ -239,13 +239,13 @@ namespace forte {
     return nullptr;
   }
 
-  bool CFBContainer::setForce(const std::span<const StringId> paNameList, const bool paForce) {
+  bool CFBContainer::setForced(const std::span<const StringId> paNameList, const bool paForce) {
     if (paNameList.empty()) {
       return false;
     }
     const StringId name = paNameList.front();
     if (const auto child = getChild(name)) {
-      return child->setForce(paNameList.subspan(1), paForce);
+      return child->setForced(paNameList.subspan(1), paForce);
     }
     return false;
   }

--- a/core/src/funcbloc.cpp
+++ b/core/src/funcbloc.cpp
@@ -430,20 +430,20 @@ TAbsDataPortNum CFunctionBlock::getAbsDataPortNum(StringId paPortNameId) const {
   return INVALID_ABS_DATA_PORT_ID;
 }
 
-bool CFunctionBlock::setForce(const std::span<const StringId> paNameList, const bool paForce) {
+bool CFunctionBlock::setForced(const std::span<const StringId> paNameList, const bool paForce) {
   if (paNameList.empty()) {
     return false;
   }
   const StringId name = paNameList.front();
   if (const auto absDataPortNum = getAbsDataPortNum(name);
       absDataPortNum != INVALID_ABS_DATA_PORT_ID && paNameList.size() == 1) {
-    setForce(absDataPortNum, paForce);
+    setForced(absDataPortNum, paForce);
     return true;
   }
-  return CFBContainer::setForce(paNameList, paForce);
+  return CFBContainer::setForced(paNameList, paForce);
 }
 
-bool CFunctionBlock::setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue) {
+bool CFunctionBlock::setForced(TAbsDataPortNum paAbsDataPortNum, bool paForceValue) {
   if (paAbsDataPortNum >= mForces.size()) {
     return false;
   }
@@ -468,7 +468,7 @@ void CFunctionBlock::resetForcedOutputs() {
   const std::size_t numDIs = getFBInterfaceSpec().getNumDIs();
   const std::size_t numDOs = getFBInterfaceSpec().getNumDOs();
   for (TPortId index = 0; index < numDOs; ++index) {
-    if (getForce(numDIs + index)) {
+    if (isForced(numDIs + index)) {
       // when forcing we write back the value from the connection to keep the forced value on the output
       getDOConUnchecked(index)->readData(*getDO(index));
     }

--- a/core/src/funcbloc.cpp
+++ b/core/src/funcbloc.cpp
@@ -464,6 +464,17 @@ bool CFunctionBlock::setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValu
   return true;
 }
 
+void CFunctionBlock::resetForcedOutputs() {
+  const std::size_t numDIs = getFBInterfaceSpec().getNumDIs();
+  const std::size_t numDOs = getFBInterfaceSpec().getNumDOs();
+  for (TPortId index = 0; index < numDOs; ++index) {
+    if (getForce(numDIs + index)) {
+      // when forcing we write back the value from the connection to keep the forced value on the output
+      getDOConUnchecked(index)->readData(*getDO(index));
+    }
+  }
+}
+
 void CFunctionBlock::toString(std::string &paTargetBuf) const {
   paTargetBuf += '(';
 

--- a/core/src/funcbloc.cpp
+++ b/core/src/funcbloc.cpp
@@ -396,13 +396,10 @@ CConnection::Wrapper CFunctionBlock::getOutputConnection(const std::span<const S
 void CFunctionBlock::setupEventMonitoringData() {
   freeEventMonitoringData();
   mEventMonitorCount.resize(getFBInterfaceSpec().getNumEIs() + getFBInterfaceSpec().getNumEOs());
-  mForces.resize(getFBInterfaceSpec().getNumDIs() + getFBInterfaceSpec().getNumDOs() +
-                 getFBInterfaceSpec().getNumDIOs());
 }
 
 void CFunctionBlock::freeEventMonitoringData() {
   mEventMonitorCount.clear();
-  mForces.clear();
 }
 
 TForteUInt32 &CFunctionBlock::getEIMonitorData(TEventID paEIID) {
@@ -446,7 +443,11 @@ bool CFunctionBlock::setForce(const std::span<const StringId> paNameList, const 
   return CFBContainer::setForce(paNameList, paForce);
 }
 
-void CFunctionBlock::setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue) {
+bool CFunctionBlock::setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue) {
+  if (paAbsDataPortNum >= mForces.size()) {
+    return false;
+  }
+
   mForces[paAbsDataPortNum] = paForceValue;
 
   if (paForceValue) {
@@ -460,6 +461,7 @@ void CFunctionBlock::setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValu
       con->writeData(*getDO(doPortId));
     }
   }
+  return true;
 }
 
 void CFunctionBlock::toString(std::string &paTargetBuf) const {

--- a/core/src/monitoring.cpp
+++ b/core/src/monitoring.cpp
@@ -134,7 +134,7 @@ namespace forte {
 
     void CDataWatchEntry::update(const CFunctionBlock &paFB) {
       mDataBuffer->setValue(mDataValueRef);
-      mForced = paFB.getForce(mForceIndex);
+      mForced = paFB.isForced(mForceIndex);
     }
 
     void CEventWatchEntry::update() {
@@ -241,7 +241,7 @@ namespace forte {
   }
 
   EMGMResponse CMonitoringHandler::clearForce(TNameIdentifier &paNameList) {
-    if (!mResource.setForce(paNameList, false)) {
+    if (!mResource.setForced(paNameList, false)) {
       return EMGMResponse::NoSuchObject;
     }
     return EMGMResponse::Ready;

--- a/core/src/resource.cpp
+++ b/core/src/resource.cpp
@@ -446,7 +446,7 @@ namespace forte {
     }
 
     if (paForce) {
-      if (!setForce(paNameList, true)) {
+      if (!setForced(paNameList, true)) {
         return EMGMResponse::NoSuchObject;
       }
     } else if (const auto conn = getOutputConnection(paNameList);


### PR DESCRIPTION
Use fixed bitset to store force flags with a configurable maximum supported absolute port index for forcing data pins. Reset all forced outputs after event execution.