### PR TITLE
Add script to combine static forte libraries

### DIFF
--- a/buildsupport/combine-static-libs.sh
+++ b/buildsupport/combine-static-libs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#############################################################################
+# Copyright (c) 2025 Martin Erich Jobst
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#    Martin Erich Jobst
+#      - initial API and implementation and/or initial documentation
+#############################################################################
+
+for lib in libforte*.a; do
+  if [ ! -e "${lib}" ]; then
+    echo "No libforte*.a found in the current working directory"
+    exit 1
+  fi
+  break
+done
+
+ar -M - <<-EOF
+CREATE libforte-all.a
+$(for lib in libforte*.a; do
+  if [[ "${lib}" != "libforte-all.a" ]]; then
+    echo ADDLIB "${lib}"
+  fi
+done)
+SAVE
+END
+EOF


### PR DESCRIPTION
Add script to combine static forte libraries for easier consumption by non-CMake build systems. The script combines all `libforte*.a` files in the current working directory to a `libforte-all.a`, except any existing `libforte-all.a` itself. It is intended to be run inside the `lib` directory of the install prefix after installing forte and all external modules.