### PR TITLE
Rework write value in resource

### DIFF
--- a/core/include/forte/basefb.h
+++ b/core/include/forte/basefb.h
@@ -26,7 +26,7 @@ namespace forte {
     public:
       ~CBaseFB() override = default;
 
-      CIEC_ANY *getVar(StringId *paNameList, unsigned int paNameListSize) override;
+      CIEC_ANY *getVar(std::span<const StringId> paNameList) override;
 
       void toString(std::string &paTargetBuf) const override;
 

--- a/core/include/forte/basicfb.h
+++ b/core/include/forte/basicfb.h
@@ -29,7 +29,7 @@ namespace forte {
     public:
       ~CBasicFB() override = default;
 
-      CIEC_ANY *getVar(StringId *paNameList, unsigned int paNameListSize) override;
+      CIEC_ANY *getVar(std::span<const StringId> paNameList) override;
 
     protected:
       CBasicFB(CFBContainer &paContainer,

--- a/core/include/forte/cfb.h
+++ b/core/include/forte/cfb.h
@@ -56,8 +56,6 @@ namespace forte {
       bool configureGenericDI(TPortId paDIPortId, const CIEC_ANY &paRefValue) override;
       bool configureGenericDIO(TPortId paDIOPortId, const CIEC_ANY &paRefValue) override;
       bool configureGenericDO(TPortId paDOPortId, const CIEC_ANY &paRefValue) override;
-      //! implement improved version of get Var for CFBs, allowing to read and write to internal elements
-      CIEC_ANY *getVar(StringId *paNameList, unsigned int paNameListSize) override;
 
       EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
 

--- a/core/include/forte/conn.h
+++ b/core/include/forte/conn.h
@@ -150,6 +150,10 @@ namespace forte {
         return false;
       }
 
+      virtual bool isInOut() const {
+        return false;
+      }
+
     protected:
       /*!\brief An identifier for the source of this connection
        *

--- a/core/include/forte/datatypes/forte_any.h
+++ b/core/include/forte/datatypes/forte_any.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <bit>
+#include <span>
 #include <limits>
 #include "forte/typelib.h"
 #include "forte/iec61131_cast_helper.h"
@@ -248,6 +249,13 @@ namespace forte {
       virtual size_t getIECMemorySize() const {
         const EDataTypeID typeId = getDataTypeID();
         return typeId > (sizeof(csmDataLengthLookup) / sizeof(size_t)) ? 0 : csmDataLengthLookup[typeId];
+      }
+
+      virtual CIEC_ANY *getVar(const std::span<const StringId> paNameList) {
+        if (paNameList.empty()) {
+          return this;
+        }
+        return nullptr;
       }
 
 #ifdef FORTE_SUPPORT_CUSTOM_SERIALIZABLE_DATATYPES

--- a/core/include/forte/datatypes/forte_struct.h
+++ b/core/include/forte/datatypes/forte_struct.h
@@ -137,10 +137,10 @@ namespace forte {
 
       /*! \brief Get the struct's member var with the given name id
        *
-       * \param paMemberNameId the string id of the member name
+       * \param paNameList the string id of the member name
        * \return on a valid member name id a pointer to the member var otherwise 0
        */
-      CIEC_ANY *getMemberNamed(std::span<const StringId> paMemberNameId);
+      CIEC_ANY *getVar(std::span<const StringId> paNameList) final;
 
       size_t getMemberIndex(StringId paMemberNameId);
 

--- a/core/include/forte/fbcontainer.h
+++ b/core/include/forte/fbcontainer.h
@@ -23,6 +23,7 @@
 #include <memory>
 
 namespace forte {
+  class CIEC_ANY;
 
   class CAdapter;
   class CAnyAdapterPin;
@@ -124,6 +125,20 @@ namespace forte {
       virtual bool isDynamicContainer() {
         return true;
       }
+
+      /*!\brief Get the pointer to a variable of the FB container.
+       *
+       * @param paNameList the name hierarchy the requested variable
+       * \return Pointer to the variable or 0.
+       */
+      virtual CIEC_ANY *getVar(std::span<const StringId> paNameList);
+
+      /*!\brief Set the force flag for a variable of the FB container.
+       *
+       * @param paNameList the name hierarchy the requested variable
+       * \return true on success, false otherwise.
+       */
+      virtual bool setForce(std::span<const StringId> paNameList, bool paForce);
 
       /*!\brief get the connection object for the given destination identifier
        *

--- a/core/include/forte/funcbloc.h
+++ b/core/include/forte/funcbloc.h
@@ -121,9 +121,31 @@ namespace forte {
       /*!\brief Get the pointer to a data input of the FB.
        *
        * \param paDINameId ID of the data input name.
-       * \return Pointer to the data input or 0. If 0 is returned DataInput is ANY
+       * \return Pointer to the data input or 0.
        */
       CIEC_ANY *getDataInput(StringId paDINameId);
+
+      /*!\brief Get the pointer to a data in-out of the FB.
+       *
+       * \param paDIONameId ID of the data in-out name.
+       * \return Pointer to the data input or 0.
+       */
+      CIEC_ANY *getDataInOut(StringId paDIONameId);
+
+      /*!\brief Get the pointer to a data output of the FB.
+       *
+       * \param paDONameId StringID of the data output name.
+       * \return Pointer to the data output or 0. If 0 is returned DataOutput is ANY
+       */
+      CIEC_ANY *getDataOutput(StringId paDONameId);
+
+      /*!\brief Get the pointer to a variable of the FB.
+       *
+       * @param paNameList the name hierarchy the requested variable
+       * \return Pointer to the variable or 0.
+       *  The variable may be an input, in-out, output or in the case of a BFB an internal var.
+       */
+      CIEC_ANY *getVar(std::span<const StringId> paNameList) override;
 
       /*!\brief get the pointer to a data input using the portId as identifier
        */
@@ -173,22 +195,6 @@ namespace forte {
        * the DO with the specific type coming from the other end of the connection
        */
       virtual bool configureGenericDO(TPortId paDOPortId, const CIEC_ANY &paRefValue);
-
-      /*!\brief Get the pointer to a data output of the FB.
-       *
-       * \param paDONameId StringID of the data output name.
-       * \return Pointer to the data output or 0. If 0 is returned DataOutput is ANY
-       */
-      CIEC_ANY *getDataOutput(StringId paDONameId);
-
-      /*!\brief Get the pointer to a variable of the FB.
-       *
-       * @param paNameList array of the name hierarchy the requested variable
-       * @param paNameListSize length of the array
-       * \return Pointer to the variable or 0.
-       *  The variable may be input, output or in the case of a BFB an internal var.
-       */
-      virtual CIEC_ANY *getVar(StringId *paNameList, unsigned int paNameListSize);
 
       /*!\brief Get the pointer to the plub pin of the FB.
        *
@@ -335,7 +341,7 @@ namespace forte {
 
       TAbsDataPortNum getAbsDataPortNum(StringId paPortNameId) const;
 
-      void setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue);
+      bool setForce(std::span<const StringId> paNameList, bool paForce) override;
 
       bool getForce(TAbsDataPortNum paAbsDataPortNum) const {
         return mForces[paAbsDataPortNum];
@@ -550,6 +556,8 @@ namespace forte {
        * \param paEIID Event output ID where event occurred.
        */
       virtual void writeOutputData(TEventID paEO) = 0;
+
+      void setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue);
 
     public:
       CFunctionBlock(const CFunctionBlock &) = delete;

--- a/core/include/forte/inoutdataconn.h
+++ b/core/include/forte/inoutdataconn.h
@@ -51,6 +51,10 @@ namespace forte {
         return *mValue;
       }
 
+      bool isInOut() const override {
+        return true;
+      }
+
     protected:
       EMGMResponse establishDataConnection(CFunctionBlock &paDstFB,
                                            const TPortId paDstPortId,

--- a/core/include/forte/resource.h
+++ b/core/include/forte/resource.h
@@ -197,13 +197,6 @@ namespace forte {
        */
       EMGMResponse readValue(TNameIdentifier &paNameList, std::string &paValue);
 
-      /*!\brief get the variable with the given name identifier
-       *
-       * @param paNameList the identifier name list of the variable to be retrieved
-       * @return the pointer to the variable or 0 if the variable with the given identifier name list does not exist
-       */
-      CIEC_ANY *getVariable(TNameIdentifier &paNameList);
-
       CConnection *getResIf2InConnection(StringId paResInput);
 
       virtual CConnection *getResIf2InConnectionUnchecked(TPortId) {

--- a/core/include/forte/resource.h
+++ b/core/include/forte/resource.h
@@ -21,6 +21,8 @@
 #include "forte/fbcontainer.h"
 #include "forte/funcbloc.h"
 
+#include <unordered_map>
+
 namespace forte {
   class ResourceInternal;
   struct SManagementCMD;
@@ -132,28 +134,7 @@ namespace forte {
         return nullptr;
       }
 
-      class CInitialValue {
-        private:
-          CIEC_ANY &mIECVariable;
-          const std::string mInitString;
-
-        public:
-          CInitialValue(CIEC_ANY &paVariable, std::string paInitString) :
-              mIECVariable(paVariable),
-              mInitString(std::move(paInitString)) {
-          }
-
-          [[nodiscard]]
-          const std::string &getInitString() const {
-            return mInitString;
-          }
-
-          CIEC_ANY &getIECVariable() {
-            return mIECVariable;
-          }
-      };
-
-      std::vector<CInitialValue> mInitialValues;
+      std::unordered_map<TNameIdentifier, std::string> mInitialValues;
 
       void setInitialValues() override;
 

--- a/core/include/forte/util/inplace_vector.h
+++ b/core/include/forte/util/inplace_vector.h
@@ -22,6 +22,7 @@
 #include <array>
 #include <cassert>
 #include <algorithm>
+#include <functional>
 
 namespace forte::util {
 
@@ -211,3 +212,14 @@ namespace forte::util {
     return !(paFirst == paSecond);
   }
 } // namespace forte::util
+
+template<typename T, std::size_t Capacity>
+struct std::hash<forte::util::inplace_vector<T, Capacity>> {
+    std::size_t operator()(const forte::util::inplace_vector<T, Capacity> &vec) const noexcept {
+      std::size_t seed = vec.size();
+      for (const auto &element : vec) {
+        seed ^= std::hash<T>{}(element) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+      }
+      return seed;
+    }
+};

--- a/core/src/basefb.cpp
+++ b/core/src/basefb.cpp
@@ -36,12 +36,15 @@ namespace forte {
     CFunctionBlock::setInitialValues();
   }
 
-  CIEC_ANY *CBaseFB::getVar(StringId *paNameList, unsigned int paNameListSize) {
-    CIEC_ANY *poRetVal = CFunctionBlock::getVar(paNameList, paNameListSize);
-    if ((nullptr == poRetVal) && (1 == paNameListSize)) {
-      poRetVal = getInternalVar(*paNameList);
+  CIEC_ANY *CBaseFB::getVar(const std::span<const StringId> paNameList) {
+    if (paNameList.empty()) {
+      return nullptr;
     }
-    return poRetVal;
+    const StringId name = paNameList.front();
+    if (const auto var = getInternalVar(name)) {
+      return var->getVar(paNameList.subspan(1));
+    }
+    return CFunctionBlock::getVar(paNameList);
   }
 
   CIEC_ANY *CBaseFB::getInternalVar(StringId paInternalName) {

--- a/core/src/basicfb.cpp
+++ b/core/src/basicfb.cpp
@@ -33,11 +33,13 @@ namespace forte {
     mECCState = CIEC_STATE(0);
   }
 
-  CIEC_ANY *CBasicFB::getVar(StringId *paNameList, unsigned int paNameListSize) {
-    CIEC_ANY *poRetVal = CBaseFB::getVar(paNameList, paNameListSize);
-    if ((nullptr == poRetVal) && (1 == paNameListSize) && *paNameList == "!ECC"_STRID) {
-      poRetVal = &mECCState;
+  CIEC_ANY *CBasicFB::getVar(const std::span<const StringId> paNameList) {
+    if (paNameList.empty()) {
+      return nullptr;
     }
-    return poRetVal;
+    if (paNameList.front() == "!ECC"_STRID) {
+      return mECCState.getVar(paNameList.subspan(1));
+    };
+    return CBaseFB::getVar(paNameList);
   }
 } // namespace forte

--- a/core/src/cfb.cpp
+++ b/core/src/cfb.cpp
@@ -139,23 +139,6 @@ namespace forte {
     // currently nothing to do
   }
 
-  CIEC_ANY *CCompositeFB::getVar(StringId *paNameList, unsigned int paNameListSize) {
-    CIEC_ANY *retVal = nullptr;
-
-    if (1 > paNameListSize) {
-      CFunctionBlock *child = getFB(*paNameList);
-      if (child != nullptr) {
-        paNameList++;
-        paNameListSize--;
-        retVal = child->getVar(paNameList, paNameListSize);
-      }
-    } else {
-      retVal = CFunctionBlock::getVar(paNameList, paNameListSize);
-    }
-
-    return retVal;
-  }
-
   void CCompositeFB::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
     if (cgInternal2InterfaceMarker & paEIID) {
       TEventID internalEvent = static_cast<TEventID>(paEIID & cgInternal2InterfaceRemovalMask);

--- a/core/src/dataconn.cpp
+++ b/core/src/dataconn.cpp
@@ -153,8 +153,7 @@ namespace forte {
       return EMGMResponse::NoSuchObject;
     }
 
-    auto &dstStruct = static_cast<CIEC_STRUCT &>(paDstDataPoint);
-    CIEC_ANY *dstMember = dstStruct.getMemberNamed(paDstPortNameId.subspan(1));
+    const CIEC_ANY *dstMember = paDstDataPoint.getVar(paDstPortNameId.subspan(1));
     if (!dstMember) {
       return EMGMResponse::NoSuchObject;
     }
@@ -167,7 +166,7 @@ namespace forte {
 
     CDataConnection *dstConnection = paDstFB.getDIConnection(paDstPortNameId.front());
     if (!dstConnection) {
-      dstConnection = new internal::CGatheringDataConnection(paDstFB, paDstPortId, dstStruct);
+      dstConnection = new internal::CGatheringDataConnection(paDstFB, paDstPortId, paDstDataPoint);
       if (!paDstFB.connectDI(paDstPortId, dstConnection)) {
         delete dstConnection;
         return EMGMResponse::InvalidState;
@@ -181,22 +180,19 @@ namespace forte {
   }
 
   CConnection::Wrapper CDataConnection::getDelegatingConnection(const std::span<const StringId> paSrcNameList) {
-    switch (getValue().getDataTypeID()) {
-      case CIEC_ANY::e_BOOL:
-        if (paSrcNameList.size() == 1 && paSrcNameList.front() == "NOT"_STRID) {
-          return make_delegating<internal::CNegatingDataConnection>(getSourceId().getFB(), getSourceId().getPortId(),
-                                                                    static_cast<CIEC_BOOL &>(getValue()));
-        }
-        break;
-      case CIEC_ANY::e_STRUCT:
-        if (CIEC_ANY *member = static_cast<CIEC_STRUCT &>(getValue()).getMemberNamed(paSrcNameList); member) {
-          return make_delegating<internal::CMemberDataConnection>(getSourceId().getFB(), getSourceId().getPortId(),
-                                                                  *member, paSrcNameList);
-        }
-        break;
-      default: break;
+    if (paSrcNameList.empty()) {
+      return Wrapper(this);
     }
-    return CConnection::getDelegatingConnection(paSrcNameList);
+    if (getValue().getDataTypeID() == CIEC_ANY::e_BOOL && paSrcNameList.size() == 1 &&
+        paSrcNameList.front() == "NOT"_STRID) {
+      return make_delegating<internal::CNegatingDataConnection>(getSourceId().getFB(), getSourceId().getPortId(),
+                                                                static_cast<CIEC_BOOL &>(getValue()));
+    }
+    if (CIEC_ANY *member = getValue().getVar(paSrcNameList)) {
+      return make_delegating<internal::CMemberDataConnection>(getSourceId().getFB(), getSourceId().getPortId(), *member,
+                                                              paSrcNameList);
+    }
+    return {};
   }
 
   void CDataConnection::getSourcePortName(TNameIdentifier &paResult) const {

--- a/core/src/datatypes/forte_struct.cpp
+++ b/core/src/datatypes/forte_struct.cpp
@@ -38,21 +38,15 @@ CIEC_ANY *CIEC_STRUCT::getMemberNamed(const char *paMemberName) {
   return nullptr;
 }
 
-CIEC_ANY *CIEC_STRUCT::getMemberNamed(const std::span<const StringId> paMemberName) {
-  if (paMemberName.empty()) {
-    return nullptr;
+CIEC_ANY *CIEC_STRUCT::getVar(const std::span<const StringId> paNameList) {
+  if (paNameList.empty()) {
+    return this;
   }
-  CIEC_ANY *member = getMemberNamed(paMemberName.front());
-  if (!member) {
-    return nullptr;
-  }
-  if (paMemberName.size() == 1) {
-    return member;
-  }
-  if (member->getDataTypeID() != e_STRUCT) {
-    return nullptr;
-  }
-  return static_cast<CIEC_STRUCT *>(member)->getMemberNamed(paMemberName.subspan(1));
+  const StringId name = paNameList.front();
+  if (const auto var = getMemberNamed(name)) {
+    return var->getVar(paNameList.subspan(1));
+  };
+  return nullptr;
 }
 
 size_t CIEC_STRUCT::getMemberIndex(StringId paMemberNameId) {

--- a/core/src/fbcontainer.cpp
+++ b/core/src/fbcontainer.cpp
@@ -228,6 +228,28 @@ namespace forte {
     return retVal;
   }
 
+  CIEC_ANY *CFBContainer::getVar(const std::span<const StringId> paNameList) {
+    if (paNameList.empty()) {
+      return nullptr;
+    }
+    const StringId name = paNameList.front();
+    if (const auto child = getChild(name)) {
+      return child->getVar(paNameList.subspan(1));
+    }
+    return nullptr;
+  }
+
+  bool CFBContainer::setForce(const std::span<const StringId> paNameList, const bool paForce) {
+    if (paNameList.empty()) {
+      return false;
+    }
+    const StringId name = paNameList.front();
+    if (const auto child = getChild(name)) {
+      return child->setForce(paNameList.subspan(1), paForce);
+    }
+    return false;
+  }
+
   CConnection *CFBContainer::getInputConnection(const std::span<const StringId> paDstNameList) {
     if (paDstNameList.empty()) {
       return nullptr;

--- a/core/src/funcbloc.cpp
+++ b/core/src/funcbloc.cpp
@@ -225,18 +225,23 @@ bool CFunctionBlock::configureGenericDO(TPortId paDOPortId, const CIEC_ANY &paRe
   return true;
 }
 
-CIEC_ANY *CFunctionBlock::getDataOutput(StringId paDONameId) {
-  TPortId unDID = getFBInterfaceSpec().getDOID(paDONameId);
-  if (unDID != cgInvalidPortId) {
-    return getDO(unDID);
+CIEC_ANY *CFunctionBlock::getDataInput(const StringId paDINameId) {
+  if (const TPortId portId = getFBInterfaceSpec().getDIID(paDINameId); portId != cgInvalidPortId) {
+    return getDI(portId);
   }
   return nullptr;
 }
 
-CIEC_ANY *CFunctionBlock::getDataInput(StringId paDINameId) {
-  TPortId unDID = getFBInterfaceSpec().getDIID(paDINameId);
-  if (unDID != cgInvalidPortId) {
-    return getDI(unDID);
+CIEC_ANY *CFunctionBlock::getDataOutput(const StringId paDONameId) {
+  if (const TPortId portId = getFBInterfaceSpec().getDOID(paDONameId); portId != cgInvalidPortId) {
+    return getDO(portId);
+  }
+  return nullptr;
+}
+
+CIEC_ANY *CFunctionBlock::getDataInOut(const StringId paDIONameId) {
+  if (const TPortId portId = getFBInterfaceSpec().getDIOID(paDIONameId); portId != cgInvalidPortId) {
+    return getDIO(portId);
   }
   return nullptr;
 }
@@ -262,22 +267,21 @@ CIEC_ANY *CFunctionBlock::getDIOFromPortId(TPortId paDIPortId) {
   return nullptr;
 }
 
-CIEC_ANY *CFunctionBlock::getVar(StringId *paNameList, unsigned int paNameListSize) {
-  if (1 == paNameListSize) {
-    TPortId portId = getFBInterfaceSpec().getDIID(*paNameList);
-    if (cgInvalidPortId != portId) {
-      return getDI(portId);
-    }
-    portId = getFBInterfaceSpec().getDOID(*paNameList);
-    if (cgInvalidPortId != portId) {
-      return getDO(portId);
-    }
-    portId = getFBInterfaceSpec().getDIOID(*paNameList);
-    if (cgInvalidPortId != portId) {
-      return getDIO(portId);
-    }
+CIEC_ANY *CFunctionBlock::getVar(const std::span<const StringId> paNameList) {
+  if (paNameList.empty()) {
+    return nullptr;
   }
-  return nullptr;
+  const StringId name = paNameList.front();
+  if (const auto var = getDataInput(name)) {
+    return var->getVar(paNameList.subspan(1));
+  };
+  if (const auto var = getDataOutput(name)) {
+    return var->getVar(paNameList.subspan(1));
+  };
+  if (const auto var = getDataInOut(name)) {
+    return var->getVar(paNameList.subspan(1));
+  };
+  return CFBContainer::getVar(paNameList);
 }
 
 IPlugPin *CFunctionBlock::getPlugPin(StringId paPlugNameId) {
@@ -427,6 +431,19 @@ TAbsDataPortNum CFunctionBlock::getAbsDataPortNum(StringId paPortNameId) const {
   }
 
   return INVALID_ABS_DATA_PORT_ID;
+}
+
+bool CFunctionBlock::setForce(const std::span<const StringId> paNameList, const bool paForce) {
+  if (paNameList.empty()) {
+    return false;
+  }
+  const StringId name = paNameList.front();
+  if (const auto absDataPortNum = getAbsDataPortNum(name);
+      absDataPortNum != INVALID_ABS_DATA_PORT_ID && paNameList.size() == 1) {
+    setForce(absDataPortNum, paForce);
+    return true;
+  }
+  return CFBContainer::setForce(paNameList, paForce);
 }
 
 void CFunctionBlock::setForce(TAbsDataPortNum paAbsDataPortNum, bool paForceValue) {

--- a/core/src/gatherdataconn.cpp
+++ b/core/src/gatherdataconn.cpp
@@ -60,21 +60,21 @@ namespace forte::internal {
 
   EMGMResponse CGatheringDataConnection::addMemberConnection(const std::span<const StringId> paMemberName,
                                                              CDataConnection &paConnection) {
-    if (CIEC_ANY *member = getValue().getMemberNamed(paMemberName)) {
+    if (CIEC_ANY *member = getValue().getVar(paMemberName)) {
       return addMemberConnection(member, &paConnection, paMemberName);
     }
     return EMGMResponse::NoSuchObject;
   }
 
   EMGMResponse CGatheringDataConnection::removeMemberConnection(const std::span<const StringId> paMemberName) {
-    if (const CIEC_ANY *member = getValue().getMemberNamed(paMemberName)) {
+    if (const CIEC_ANY *member = getValue().getVar(paMemberName)) {
       return removeMemberConnection(member);
     }
     return EMGMResponse::NoSuchObject;
   }
 
   CDataConnection *CGatheringDataConnection::getMemberConnection(const std::span<const StringId> paMemberName) {
-    if (const CIEC_ANY *member = getValue().getMemberNamed(paMemberName)) {
+    if (const CIEC_ANY *member = getValue().getVar(paMemberName)) {
       return getMemberConnection(member);
     }
     return CDataConnection::getMemberConnection(paMemberName);

--- a/core/src/gatherdataconn.h
+++ b/core/src/gatherdataconn.h
@@ -18,9 +18,9 @@
 
 namespace forte::internal {
 
-  class CGatheringDataConnection final : public CDelegatingDataConnection<CIEC_STRUCT> {
+  class CGatheringDataConnection final : public CDelegatingDataConnection<CIEC_ANY> {
     public:
-      CGatheringDataConnection(CFunctionBlock &paSrcFB, const TPortId paSrcPortId, CIEC_STRUCT &paValue) :
+      CGatheringDataConnection(CFunctionBlock &paSrcFB, const TPortId paSrcPortId, CIEC_ANY &paValue) :
           CDelegatingDataConnection(paSrcFB, paSrcPortId, paValue) {
       }
 

--- a/core/src/monitoring.cpp
+++ b/core/src/monitoring.cpp
@@ -178,7 +178,7 @@ namespace forte {
     if (nullptr != fB) {
       internal::SFBMonitoringEntry &fbMonitoringEntry(findOrCreateFBMonitoringEntry(fB, paNameList));
 
-      CIEC_ANY *dataVal = fB->getVar(&portName, 1);
+      CIEC_ANY *dataVal = fB->getVar(std::array{portName});
       if (nullptr != dataVal) {
         internal::addDataWatch(fbMonitoringEntry, portName, *dataVal);
         eRetVal = EMGMResponse::Ready;
@@ -241,20 +241,9 @@ namespace forte {
   }
 
   EMGMResponse CMonitoringHandler::clearForce(TNameIdentifier &paNameList) {
-    StringId portName = paNameList.back();
-    paNameList.pop_back();
-    CFunctionBlock *fB = getFB(paNameList);
-
-    if (fB == nullptr) {
+    if (!mResource.setForce(paNameList, false)) {
       return EMGMResponse::NoSuchObject;
     }
-
-    auto absDataPortId = fB->getAbsDataPortNum(portName);
-    if (absDataPortId == INVALID_ABS_DATA_PORT_ID) {
-      return EMGMResponse::NoSuchObject;
-    }
-
-    fB->setForce(absDataPortId, false);
     return EMGMResponse::Ready;
   }
 

--- a/core/src/resource.cpp
+++ b/core/src/resource.cpp
@@ -451,14 +451,16 @@ namespace forte {
       }
     }
     if (getState() == E_FBStates::Idle) {
-      mInitialValues.emplace_back(*var, paValue);
+      mInitialValues.emplace(paNameList, paValue);
     }
     return EMGMResponse::Ready;
   }
 
   void CResource::setInitialValues() {
-    for (auto it : mInitialValues) {
-      it.getIECVariable().fromString(it.getInitString().c_str());
+    for (const auto &[name, value] : mInitialValues) {
+      if (CIEC_ANY *var = getVar(name)) {
+        var->fromString(value.c_str());
+      }
     }
   }
 

--- a/core/src/resource.cpp
+++ b/core/src/resource.cpp
@@ -449,6 +449,9 @@ namespace forte {
       if (!setForce(paNameList, true)) {
         return EMGMResponse::NoSuchObject;
       }
+    } else if (const auto conn = getOutputConnection(paNameList);
+               conn && conn->isInOut() && !getInputConnection(paNameList)) {
+      static_cast<CInOutDataConnection *>(conn.get())->getValue().setValue(var->unwrap());
     }
     if (getState() == E_FBStates::Idle) {
       mInitialValues.emplace(paNameList, paValue);

--- a/core/src/resource.cpp
+++ b/core/src/resource.cpp
@@ -434,43 +434,26 @@ namespace forte {
   }
 
   EMGMResponse CResource::writeValue(TNameIdentifier &paNameList, const std::string &paValue, bool paForce) {
-    EMGMResponse retVal = EMGMResponse::NoSuchObject;
+    CIEC_ANY *const var = getVar(paNameList);
+    if (var == nullptr) {
+      return EMGMResponse::NoSuchObject;
+    }
 
-    StringId portName = paNameList.back();
-    paNameList.pop_back();
-    auto runner = paNameList.cbegin();
+    // 0 is not supported in the fromString method
+    if (paValue.empty() || var->fromString(paValue.c_str()) != static_cast<int>(paValue.length())) {
+      // if we cannot parse the full value the value is not valid
+      return EMGMResponse::BadParams;
+    }
 
-    CFunctionBlock *fb = this;
-    if (paNameList.size() >= 1) {
-      // this is not an identifier for the resource interface
-      fb = getFB(runner, paNameList.cend());
-      if (runner != paNameList.cend()) {
-        // currently we can not write values of FBs inside of FBs
+    if (paForce) {
+      if (!setForce(paNameList, true)) {
         return EMGMResponse::NoSuchObject;
       }
     }
-
-    if (fb != nullptr) {
-      CIEC_ANY *const var = fb->getVar(&portName, 1);
-      if (var != nullptr) {
-        // 0 is not supported in the fromString method
-        if ((paValue.length() > 0) && (static_cast<int>(paValue.length()) == var->fromString(paValue.c_str()))) {
-          // if we cannot parse the full value the value is not valid
-          if (paForce) {
-            auto absDataPortId = fb->getAbsDataPortNum(portName);
-            if (absDataPortId != INVALID_ABS_DATA_PORT_ID) {
-              fb->setForce(absDataPortId, true);
-            }
-          } else {
-            mInitialValues.emplace_back(*var, paValue);
-          }
-          retVal = EMGMResponse::Ready;
-        } else {
-          retVal = EMGMResponse::BadParams;
-        }
-      }
+    if (getState() == E_FBStates::Idle) {
+      mInitialValues.emplace_back(*var, paValue);
     }
-    return retVal;
+    return EMGMResponse::Ready;
   }
 
   void CResource::setInitialValues() {
@@ -480,7 +463,7 @@ namespace forte {
   }
 
   EMGMResponse CResource::readValue(TNameIdentifier &paNameList, std::string &paValue) {
-    CIEC_ANY *const var = getVariable(paNameList);
+    CIEC_ANY *const var = getVar(paNameList);
     if (var == nullptr) {
       return EMGMResponse::NoSuchObject;
     }
@@ -506,24 +489,6 @@ namespace forte {
       default: var->toString(paValue); break;
     }
     return EMGMResponse::Ready;
-  }
-
-  CIEC_ANY *CResource::getVariable(TNameIdentifier &paNameList) {
-    StringId portName = paNameList.back();
-    paNameList.pop_back();
-    auto runner = paNameList.cbegin();
-
-    CFunctionBlock *fb = this;
-    if (paNameList.size() >= 1) {
-      // this is not an identifier for the resource interface
-      fb = getFB(runner, paNameList.cend()); // the last entry is the input name therefore reduce list here by one
-    }
-
-    CIEC_ANY *var = nullptr;
-    if ((nullptr != fb) && (runner == paNameList.cend())) {
-      var = fb->getVar(&portName, 1);
-    }
-    return var;
   }
 
   CConnection::Wrapper CResource::getOutputConnection(const std::span<const StringId> paSrcNameList) {

--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -264,7 +264,7 @@ namespace forte::test {
 
       BOOST_CHECK_EQUAL(val, mFBUnderTest->getDIFromPortId(i));
       StringId stringIdBuf = interfaceSpec.mDINames[i];
-      BOOST_CHECK_EQUAL(val, mFBUnderTest->getVar(&stringIdBuf, 1));
+      BOOST_CHECK_EQUAL(val, mFBUnderTest->getVar(std::array{stringIdBuf}));
 
       BOOST_CHECK_EQUAL(i, interfaceSpec.getDIID(interfaceSpec.mDINames[i]));
 
@@ -290,7 +290,7 @@ namespace forte::test {
                     (CIEC_ANY::e_ANY == val->getDataTypeID()));
 
       StringId stringIdBuf = interfaceSpec.mDONames[i];
-      BOOST_CHECK_EQUAL(val, mFBUnderTest->getVar(&stringIdBuf, 1));
+      BOOST_CHECK_EQUAL(val, mFBUnderTest->getVar(std::array{stringIdBuf}));
 
       BOOST_CHECK_EQUAL(i, interfaceSpec.getDOID(interfaceSpec.mDONames[i]));
 

--- a/tests/core/internalvartests.cpp
+++ b/tests/core/internalvartests.cpp
@@ -95,10 +95,10 @@ namespace forte::test {
     StringId namelist[1] = {"DT"_STRID};
 
     CInternalVarTestFB testFB({});
-    BOOST_CHECK(nullptr == testFB.getVar(namelist, 1));
+    BOOST_CHECK(nullptr == testFB.getVar(namelist));
     // check that we should at least get the ECC variable
     namelist[0] = StringId::insert("!ECC");
-    BOOST_CHECK(nullptr != testFB.getVar(namelist, 1));
+    BOOST_CHECK(nullptr != testFB.getVar(namelist));
   }
 
   BOOST_AUTO_TEST_CASE(sampleInteralVarList) {
@@ -108,7 +108,7 @@ namespace forte::test {
     BOOST_REQUIRE(testFB.initialize());
 
     for (size_t i = 0; i < varInternalNames.size(); i++) {
-      CIEC_ANY *var = testFB.getVar(&(varInternalNames[i]), 1);
+      CIEC_ANY *var = testFB.getVar(std::array{varInternalNames[i]});
       BOOST_CHECK(nullptr != var);
       BOOST_CHECK_EQUAL(var, testFB.getVarInternal(static_cast<unsigned int>(i)));
     }


### PR DESCRIPTION
Rework write value in resource:
- rework variable access in FB and structured types to support individual member access,
- store symbolic references in resource initial values and also only when resource is Idle,
- write value of in-out connection if it is not connected on the left.