### PR TITLE
Replaces header guards with #pragma once

### DIFF
--- a/modules/IEC61131-3/include/forte/iec61131/arithmetic/GEN_ADD_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/arithmetic/GEN_ADD_fbt.h
@@ -18,8 +18,7 @@ class for better handling generic FBs
  *     - add generic readInputData and writeOutputData
  *******************************************************************************/
 
-#ifndef _GEN_ADD_H_
-#define _GEN_ADD_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_any_magnitude_variant.h"
@@ -67,4 +66,3 @@ namespace forte::iec61131::arithmetic {
   };
 } // namespace forte::iec61131::arithmetic
 
-#endif // _GEN_ADD_H_

--- a/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_AND_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_AND_fbt.h
@@ -17,8 +17,7 @@ class for better handling generic FBs
  *     - refactor for ANY variant
  *******************************************************************************/
 
-#ifndef _GEN_AND_H_
-#define _GEN_AND_H_
+#pragma once
 
 #include "genbitbase_fbt.h"
 
@@ -35,4 +34,3 @@ namespace forte::iec61131::bitwiseOperators {
   };
 } // namespace forte::iec61131::bitwiseOperators
 
-#endif //_GEN_AND_H_

--- a/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_OR_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_OR_fbt.h
@@ -17,8 +17,7 @@ class for better handling generic FBs
  *     - refactor for ANY variant
  *******************************************************************************/
 
-#ifndef _GEN_OR_H_
-#define _GEN_OR_H_
+#pragma once
 
 #include "genbitbase_fbt.h"
 
@@ -35,4 +34,3 @@ namespace forte::iec61131::bitwiseOperators {
   };
 } // namespace forte::iec61131::bitwiseOperators
 
-#endif //_GEN_OR_H_

--- a/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_XOR_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_XOR_fbt.h
@@ -17,8 +17,7 @@ class for better handling generic FBs
  *     - refactor for ANY variant
  *******************************************************************************/
 
-#ifndef _GEN_XOR_H_
-#define _GEN_XOR_H_
+#pragma once
 
 #include "genbitbase_fbt.h"
 
@@ -35,4 +34,3 @@ namespace forte::iec61131::bitwiseOperators {
   };
 } // namespace forte::iec61131::bitwiseOperators
 
-#endif //_GEN_XOR_H_

--- a/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/genbitbase_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/genbitbase_fbt.h
@@ -14,8 +14,7 @@
  *     - refactor for ANY variant
  *     - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GENBITBASE_H_
-#define _GENBITBASE_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_any_bit_variant.h"
@@ -68,4 +67,3 @@ namespace forte::iec61131::bitwiseOperators {
   };
 } // namespace forte::iec61131::bitwiseOperators
 
-#endif /* _GENBITBASE_H_ */

--- a/modules/convert/include/forte/eclipse4diac/convert/GEN_STRUCT_DEMUX_fbt.h
+++ b/modules/convert/include/forte/eclipse4diac/convert/GEN_STRUCT_DEMUX_fbt.h
@@ -13,8 +13,7 @@
  *   Martin Jobst - add generic readInputData and writeOutputData
  *   Markus Meingast - add support for configured struct demux instances
  *******************************************************************************/
-#ifndef _GEN_STRUCT_DEMUX_H_
-#define _GEN_STRUCT_DEMUX_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_struct.h"
@@ -73,4 +72,3 @@ namespace forte::eclipse4diac::convert {
   };
 } // namespace forte::eclipse4diac::convert
 
-#endif //_GEN_STRUCT_DEMUX_H_

--- a/modules/convert/include/forte/eclipse4diac/convert/GEN_STRUCT_MUX_fbt.h
+++ b/modules/convert/include/forte/eclipse4diac/convert/GEN_STRUCT_MUX_fbt.h
@@ -12,8 +12,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *   Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_STRUCT_MUX_H_
-#define _GEN_STRUCT_MUX_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_struct.h"
@@ -63,4 +62,3 @@ namespace forte::eclipse4diac::convert {
   };
 } // namespace forte::eclipse4diac::convert
 
-#endif //_GEN_STRUCT_MUX_H_

--- a/modules/utils/include/forte/eclipse4diac/utils/GEN_ARRAY2ARRAY_fbt.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/GEN_ARRAY2ARRAY_fbt.h
@@ -16,8 +16,7 @@
 class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_ARRAY2ARRAY_H_
-#define _GEN_ARRAY2ARRAY_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_array_dynamic.h"
@@ -70,4 +69,3 @@ namespace forte::eclipse4diac::utils {
   };
 } // namespace forte::eclipse4diac::utils
 
-#endif //_GEN_ARRAY2ARRAY_H_

--- a/modules/utils/include/forte/eclipse4diac/utils/GEN_ARRAY2VALUES_fbt.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/GEN_ARRAY2VALUES_fbt.h
@@ -16,8 +16,7 @@
 class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_ARRAY2VALUES_H_
-#define _GEN_ARRAY2VALUES_H_
+#pragma once
 
 #include "forte/genfb.h"
 
@@ -75,4 +74,3 @@ namespace forte::eclipse4diac::utils {
   };
 } // namespace forte::eclipse4diac::utils
 
-#endif //_GEN_ARRAY2VALUES_H_

--- a/modules/utils/include/forte/eclipse4diac/utils/GEN_CSV_WRITER_fbt.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/GEN_CSV_WRITER_fbt.h
@@ -16,8 +16,7 @@ class for better handling generic FBs
  *   Martin Jobst - add generic readInputData and writeOutputData
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
-#ifndef _GEN_CSV_WRITER_H_
-#define _GEN_CSV_WRITER_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include <stdio.h>
@@ -103,4 +102,3 @@ namespace forte::eclipse4diac::utils {
   };
 } // namespace forte::eclipse4diac::utils
 
-#endif //_GEN_CSV_WRITER_H_

--- a/modules/utils/include/forte/eclipse4diac/utils/GEN_VALUES2ARRAY_fbt.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/GEN_VALUES2ARRAY_fbt.h
@@ -14,8 +14,7 @@
 class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_VALUES2ARRAY_H_
-#define _GEN_VALUES2ARRAY_H_
+#pragma once
 
 #include "forte/genfb.h"
 
@@ -67,4 +66,3 @@ namespace forte::eclipse4diac::utils {
   };
 } // namespace forte::eclipse4diac::utils
 
-#endif //_GEN_VALUES2ARRAY_H_

--- a/stdfblib/events/include/forte/iec61499/events/E_CYCLE_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_CYCLE_fbt.h
@@ -12,8 +12,7 @@
  *     - initial API and implementation and/or initial documentation
  *   Alois Zoitl  - Reworked to new timer handler interface
  *******************************************************************************/
-#ifndef _E_CYCLE_H_
-#define _E_CYCLE_H_
+#pragma once
 
 #include "forte/iec61499/events/timedfb.h"
 
@@ -34,4 +33,3 @@ namespace forte::iec61499::events {
   };
 } // namespace forte::iec61499::events
 
-#endif /*E_CYCLE_H_*/

--- a/stdfblib/events/include/forte/iec61499/events/E_DELAY_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_DELAY_fbt.h
@@ -10,8 +10,7 @@
  *   Alois Zoitl, Gerhard Ebenhofer
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef _E_DELAY_H_
-#define _E_DELAY_H_
+#pragma once
 
 #include "forte/iec61499/events/timedfb.h"
 
@@ -34,4 +33,3 @@ namespace forte::iec61499::events {
   };
 } // namespace forte::iec61499::events
 
-#endif /*E_DELAY_H_*/

--- a/stdfblib/events/include/forte/iec61499/events/E_RDELAY_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_RDELAY_fbt.h
@@ -9,8 +9,7 @@
  * Contributors:
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef _E_RDELAY_H_
-#define _E_RDELAY_H_
+#pragma once
 
 #include "forte/iec61499/events/timedfb.h"
 
@@ -28,4 +27,3 @@ namespace forte::iec61499::events {
   };
 } // namespace forte::iec61499::events
 
-#endif /*E_RDELAY_H_*/

--- a/stdfblib/events/include/forte/iec61499/events/GEN_E_DEMUX_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/GEN_E_DEMUX_fbt.h
@@ -16,8 +16,7 @@
 class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_E_DEMUX_H_
-#define _GEN_E_DEMUX_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_uint.h"
@@ -56,4 +55,3 @@ namespace forte::iec61499::events {
       ~GEN_E_DEMUX() override = default;
   };
 } // namespace forte::iec61499::events
-#endif //_GEN_E_DEMUX_H_

--- a/stdfblib/net/include/forte/iec61499/net/GEN_CLIENT_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_CLIENT_fbt.h
@@ -14,8 +14,7 @@
  *   Martin Erich Jobst
  *    - add generic event accessors
  *******************************************************************************/
-#ifndef _GEN_CLIENT_H_
-#define _GEN_CLIENT_H_
+#pragma once
 
 #include "forte/cominfra/commfb.h"
 
@@ -53,4 +52,3 @@ namespace forte::iec61499::net {
   };
 } // namespace forte::iec61499::net
 
-#endif //_GEN_CLIENT_H_

--- a/stdfblib/net/include/forte/iec61499/net/GEN_PUBLISH_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_PUBLISH_fbt.h
@@ -14,8 +14,7 @@
  *   Martin Erich Jobst
  *    - add generic event accessors
  *******************************************************************************/
-#ifndef _GEN_PUBLISH_H_
-#define _GEN_PUBLISH_H_
+#pragma once
 
 #include "forte/cominfra/commfb.h"
 
@@ -52,4 +51,3 @@ namespace forte::iec61499::net {
   };
 } // namespace forte::iec61499::net
 
-#endif //_GEN_PUBLISH_H_

--- a/stdfblib/net/include/forte/iec61499/net/GEN_PUBL_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_PUBL_fbt.h
@@ -11,8 +11,7 @@
  *   Martin Melik Merkumians
  *    - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef GEN_PUBL_H_
-#define GEN_PUBL_H_
+#pragma once
 
 #include "forte/iec61499/net/GEN_PUBLISH_fbt.h"
 
@@ -37,4 +36,3 @@ namespace forte::iec61499::net {
   };
 } // namespace forte::iec61499::net
 
-#endif /*GEN_PUBL_H_*/

--- a/stdfblib/net/include/forte/iec61499/net/GEN_SERVER_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_SERVER_fbt.h
@@ -14,8 +14,7 @@
  *   Martin Erich Jobst
  *    - add generic event accessors
  *******************************************************************************/
-#ifndef _GEN_SERVER_H_
-#define _GEN_SERVER_H_
+#pragma once
 
 #include "forte/cominfra/commfb.h"
 
@@ -52,4 +51,3 @@ namespace forte::iec61499::net {
   };
 } // namespace forte::iec61499::net
 
-#endif //_GEN_SERVER_H_

--- a/stdfblib/net/include/forte/iec61499/net/GEN_SUBL_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_SUBL_fbt.h
@@ -11,8 +11,7 @@
  *   Martin Melik Merkumians
  *    - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef GEN_SUBL_H_
-#define GEN_SUBL_H_
+#pragma once
 
 #include "forte/iec61499/net/GEN_SUBSCRIBE_fbt.h"
 
@@ -37,4 +36,3 @@ namespace forte::iec61499::net {
   };
 } // namespace forte::iec61499::net
 
-#endif /*GEN_SUBL_H_*/

--- a/stdfblib/net/include/forte/iec61499/net/GEN_SUBSCRIBE_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_SUBSCRIBE_fbt.h
@@ -14,8 +14,7 @@
  *   Martin Erich Jobst
  *    - add generic event accessors
  *******************************************************************************/
-#ifndef _GEN_SUBSCRIBE_H_
-#define _GEN_SUBSCRIBE_H_
+#pragma once
 
 #include "forte/cominfra/commfb.h"
 
@@ -52,4 +51,3 @@ namespace forte::iec61499::net {
   };
 } // namespace forte::iec61499::net
 
-#endif //_GEN_SUBSCRIBE_H_


### PR DESCRIPTION
Replaces the traditional header guards with `#pragma once` in multiple header files.
This simplifies the code and avoids potential naming conflicts.
