### PR TITLE
Fixes static linking of utils and IEC61131-3

### DIFF
--- a/modules/utils/CMakeLists.txt
+++ b/modules/utils/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT FORTE_MODULE_UTILS)
 endif ()
 
 add_library(forte-utils)
-target_link_libraries(forte-utils PUBLIC forte-core forte-events forte-iec61131-3)
+target_link_libraries(forte-utils PUBLIC forte-core forte-events $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-iec61131-3,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-iec61131-3>>)
 target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-utils,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-utils>>)
 
 add_subdirectory(include)


### PR DESCRIPTION
Ensures correct linking of the utils and IEC61131-3 libraries when building statically.
This prevents linker errors when these libraries are used in other parts of the system.
Solves: https://github.com/eclipse-4diac/4diac-forte/issues/639

Solves #639
