### PR TITLE
Add improved array bounds checks

### DIFF
--- a/core/include/forte/datatypes/forte_array.h
+++ b/core/include/forte/datatypes/forte_array.h
@@ -19,12 +19,13 @@
  *******************************************************************************/
 #pragma once
 
-#include <stddef.h>
-#include <inttypes.h>
+#include <cstddef>
+#include <cinttypes>
 
 #include "forte/datatypes/forte_any_derived.h"
 #include "forte/datatypes/forte_any_int.h"
 #include "forte/stringid.h"
+#include "forte/util/devlog.h"
 
 namespace forte {
   /** \brief A common supertype for all CIEC_ARRAY variants, providing the minimal interface an array must provide
@@ -146,6 +147,20 @@ namespace forte {
       }
 
       static const intmax_t cmCollapseMaxSize = 100;
+
+      constexpr static void
+      checkBounds(const intmax_t paIndex, const intmax_t paLowerBound, const intmax_t paUpperBound, bool paValid) {
+        if (paIndex < paLowerBound || paIndex > paUpperBound || !paValid) {
+#if __cpp_exceptions
+          throw std::out_of_range("Array access to index " + std::to_string(paIndex) + " is out of bounds from " +
+                                  std::to_string(paLowerBound) + " to " + std::to_string(paUpperBound));
+#else
+          DEVLOG_ERROR("Array access to index %" PRIdMAX " is out of bounds from %" PRIdMAX " to %" PRIdMAX "\n",
+                       paIndex, paLowerBound, paUpperBound);
+          std::abort();
+#endif
+        }
+      }
 
     private:
       void toCollapsedString(std::string &paTargetBuf) const;

--- a/core/include/forte/datatypes/forte_array_dynamic.h
+++ b/core/include/forte/datatypes/forte_array_dynamic.h
@@ -45,7 +45,7 @@ namespace forte {
 
   /*!\ingroup COREDTS CIEC_ARRAY_DYNAMIC represents the array data type according to IEC 61131.
    */
-  class CIEC_ARRAY_DYNAMIC : public CIEC_ARRAY {
+  class CIEC_ARRAY_DYNAMIC final : public CIEC_ARRAY {
       DECLARE_FIRMWARE_DATATYPE(ARRAY_DYNAMIC)
     public:
       using difference_type = std::ptrdiff_t;
@@ -514,37 +514,23 @@ namespace forte {
       }
 
       [[nodiscard]] reference at(intmax_t paIndex) override {
-        if (paIndex < mLowerBound || paIndex > mUpperBound || !mData) {
-#if __cpp_exceptions
-          throw std::out_of_range("array::at: Index: " + std::to_string(paIndex) +
-                                  " >=  size: " + std::to_string(size()));
-#else
-          std::abort();
-#endif
-        }
+        checkBounds(paIndex, mLowerBound, mUpperBound, mData);
+        return operator[](paIndex);
+      }
+
+      [[nodiscard]] const_reference at(intmax_t paIndex) const override {
+        checkBounds(paIndex, mLowerBound, mUpperBound, mData);
+        return operator[](paIndex);
+      }
+
+      [[nodiscard]] reference operator[](intmax_t paIndex) override {
         return *reinterpret_cast<pointer>(reinterpret_cast<TForteByte *>(mData) +
                                           getDataArrayIndex(paIndex) * mElementSize);
       }
 
-      [[nodiscard]] const_reference at(intmax_t paIndex) const override {
-        if (paIndex < mLowerBound || paIndex > mUpperBound || !mData) {
-#if __cpp_exceptions
-          throw std::out_of_range("array::at: Index: " + std::to_string(paIndex) +
-                                  " >=  size: " + std::to_string(size()));
-#else
-          std::abort();
-#endif
-        }
+      [[nodiscard]] const_reference operator[](intmax_t paIndex) const override {
         return *reinterpret_cast<const_pointer>(reinterpret_cast<const TForteByte *>(mData) +
                                                 getDataArrayIndex(paIndex) * mElementSize);
-      }
-
-      [[nodiscard]] reference operator[](intmax_t paIndex) override {
-        return at(paIndex);
-      }
-
-      [[nodiscard]] const_reference operator[](intmax_t paIndex) const override {
-        return at(paIndex);
       }
 
       [[nodiscard]] bool hasVariableBounds() const override {

--- a/core/include/forte/datatypes/forte_array_fixed.h
+++ b/core/include/forte/datatypes/forte_array_fixed.h
@@ -30,7 +30,7 @@ namespace forte {
   class CIEC_ARRAY_VARIABLE;
 
   template<typename T, intmax_t lowerBound, intmax_t upperBound>
-  class CIEC_ARRAY_FIXED : public CIEC_ARRAY_COMMON<T> {
+  class CIEC_ARRAY_FIXED final : public CIEC_ARRAY_COMMON<T> {
     public:
       constexpr static const size_t cmSize = upperBound - lowerBound + 1;
 
@@ -227,7 +227,8 @@ namespace forte {
       }
 
       [[nodiscard]] constexpr reference at(intmax_t index) override {
-        return data.at(getDataArrayIndex(index));
+        CIEC_ARRAY::checkBounds(index, lowerBound, upperBound, true);
+        return operator[](index);
       }
 
       // PLC-like systems always want range checks
@@ -236,7 +237,8 @@ namespace forte {
       }
 
       [[nodiscard]] constexpr const_reference at(intmax_t index) const override {
-        return data.at(getDataArrayIndex(index));
+        CIEC_ARRAY::checkBounds(index, lowerBound, upperBound, true);
+        return operator[](index);
       }
 
       // PLC-like systems always want range checks

--- a/core/include/forte/datatypes/forte_array_variable.h
+++ b/core/include/forte/datatypes/forte_array_variable.h
@@ -29,7 +29,7 @@
 
 namespace forte {
   template<typename T>
-  class CIEC_ARRAY_VARIABLE : public CIEC_ARRAY_COMMON<T> {
+  class CIEC_ARRAY_VARIABLE final : public CIEC_ARRAY_COMMON<T> {
     public:
       using difference_type = std::ptrdiff_t;
       using value_type = T;
@@ -212,7 +212,8 @@ namespace forte {
       }
 
       [[nodiscard]] reference at(intmax_t index) override {
-        return data.at(getDataArrayIndex(index));
+        CIEC_ARRAY::checkBounds(index, mLowerBound, mUpperBound, true);
+        return operator[](index);
       }
 
       // PLC-like systems always want range checks
@@ -221,7 +222,8 @@ namespace forte {
       }
 
       [[nodiscard]] const_reference at(intmax_t index) const override {
-        return data.at(getDataArrayIndex(index));
+        CIEC_ARRAY::checkBounds(index, mLowerBound, mUpperBound, true);
+        return operator[](index);
       }
 
       // PLC-like systems always want range checks


### PR DESCRIPTION
Add improved array bounds checks that properly report both the index and bounds. Also follow the convention of checking only in `at()` to speed up access from within forte core functions.