### PR TITLE
Add extern template declarations for factories and registries

### DIFF
--- a/com/opc_ua/include/forte/com/opc_ua/opcua_nodesets.h
+++ b/com/opc_ua/include/forte/com/opc_ua/opcua_nodesets.h
@@ -17,6 +17,12 @@
 
 #include <open62541.h>
 
-namespace forte::com_infra::opc_ua {
-  using OPC_UA_Nodesets = util::hook::Registry<UA_StatusCode, UA_Server *>;
-}
+namespace forte {
+  namespace util::hook {
+    extern template class Registry<UA_StatusCode, UA_Server *>;
+  }
+
+  namespace com_infra::opc_ua {
+    using OPC_UA_Nodesets = util::hook::Registry<UA_StatusCode, UA_Server *>;
+  }
+} // namespace forte

--- a/com/opc_ua/include/forte/com/opc_ua/opcua_types.h
+++ b/com/opc_ua/include/forte/com/opc_ua/opcua_types.h
@@ -17,6 +17,12 @@
 
 #include <open62541.h>
 
-namespace forte::com_infra::opc_ua {
-  using OPC_UA_External_Types = util::Registry<"", const UA_DataType *>;
-}
+namespace forte {
+  namespace util {
+    extern template class Registry<"", const UA_DataType *>;
+  }
+
+  namespace com_infra::opc_ua {
+    using OPC_UA_External_Types = util::Registry<"", const UA_DataType *>;
+  }
+} // namespace forte

--- a/com/opc_ua/src/CMakeLists.txt
+++ b/com/opc_ua/src/CMakeLists.txt
@@ -26,10 +26,12 @@ configure_file(opcua_defaults.h.in
 target_sources(forte-com-opc_ua PRIVATE
         opcua_local_handler.h
         opcua_local_handler.cpp
+        opcua_nodesets.cpp
         opcua_helper.h
         opcua_helper.cpp
         opcua_remote_handler.h
         opcua_remote_handler.cpp
+        opcua_types.cpp
         opcua_handler_abstract.h
         opcua_handler_abstract.cpp
         opcua_client_information.h

--- a/com/opc_ua/src/opcua_nodesets.cpp
+++ b/com/opc_ua/src/opcua_nodesets.cpp
@@ -11,14 +11,8 @@
  *    Martin Erich Jobst - initial implementation
  *******************************************************************************/
 
-#pragma once
+#include "forte/com/opc_ua/opcua_nodesets.h"
 
-#include "forte/util/hook.h"
-
-namespace forte {
-  namespace util::hook {
-    extern template class Registry<void, int, char **>;
-  }
-
-  using StartupHookRegistry = util::hook::Registry<void, int, char **>;
-} // namespace forte
+namespace forte::util::hook {
+  template class Registry<UA_StatusCode, UA_Server *>;
+}

--- a/com/opc_ua/src/opcua_types.cpp
+++ b/com/opc_ua/src/opcua_types.cpp
@@ -11,14 +11,8 @@
  *    Martin Erich Jobst - initial implementation
  *******************************************************************************/
 
-#pragma once
+#include "forte/com/opc_ua/opcua_types.h"
 
-#include "forte/util/hook.h"
-
-namespace forte {
-  namespace util::hook {
-    extern template class Registry<void, int, char **>;
-  }
-
-  using StartupHookRegistry = util::hook::Registry<void, int, char **>;
-} // namespace forte
+namespace forte::util {
+  template class Registry<"", const UA_DataType *>;
+}

--- a/core/include/forte/com/factory.h
+++ b/core/include/forte/com/factory.h
@@ -13,12 +13,20 @@
 
 #pragma once
 
+#include "forte/com/buffer.h"
 #include "forte/com/channel.h"
 
 #include "forte/util/factory.h"
 
-namespace forte::com {
+namespace forte {
+  class CIEC_ANY_VARIANT;
 
-  template<typename T>
-  using ComChannelFactory = util::factory::Factory<util::factory::DynamicImpl, "", ComChannel<T>, ComObserver<T> &>;
-} // namespace forte::com
+  namespace com {
+    template<typename T>
+    class ComChannelFactory
+        : public util::factory::Factory<util::factory::DynamicImpl, "", ComChannel<T>, ComObserver<T> &> {};
+
+    extern template class ComChannelFactory<ComBuffer>;
+    extern template class ComChannelFactory<std::span<CIEC_ANY_VARIANT>>;
+  } // namespace com
+} // namespace forte

--- a/core/include/forte/cominfra/comlayersmanager.h
+++ b/core/include/forte/cominfra/comlayersmanager.h
@@ -16,28 +16,40 @@
 
 #include "forte/util/factory.h"
 
-namespace forte::com_infra {
+namespace forte {
+  namespace com_infra {
+    class CBaseCommFB;
+    class CComLayer;
+  } // namespace com_infra
 
-  class CBaseCommFB;
-  class CComLayer;
+  namespace util::factory {
+    extern template class Factory<DynamicImpl,
+                                  "",
+                                  com_infra::CComLayer,
+                                  com_infra::CComLayer *,
+                                  com_infra::CBaseCommFB *>;
+  }
 
-  /*!\brief Communication Layers Manager for communication with Server/Client and Publish/Subscriber
-   *
-   * The communication interface is separated into two part, the handler and the protocol
-   * The Hander is the interface for all function blocks which wants to communicate over
-   * a network. Every function block which wants to communicate has to be registered at the
-   * handler. A registration does not open any connection. Therefore the registration can be
-   * handled in the function block creation. The connection with a network is established with
-   * a INIT+ event.
-   * The protocol is a layered protocol-stack which has two interfaces. One for the communication
-   * with the upper layer and one with the underneath layer. The top layer is the network handler
-   * and the bottom layer is either the operating system or a protocol layer which is able to communicate
-   * directly with the network.
-   * The memory-allocation is always done by the underneath layer. Thus the upper layer can simple send
-   * data to a underlying layer. The underneath layer can notify the upper layer by calling the
-   * newDataAvailable-function. Then the upper layer has to get the data by calling the getDataPackage-
-   * function. The returned pointer has to be deleted by the upper layer. A smart-pointer like design
-   * is desirable.
-   */
-  using ComLayerManager = util::factory::Factory<util::factory::DynamicImpl, "", CComLayer, CComLayer *, CBaseCommFB *>;
-} // namespace forte::com_infra
+  namespace com_infra {
+    /*!\brief Communication Layers Manager for communication with Server/Client and Publish/Subscriber
+     *
+     * The communication interface is separated into two part, the handler and the protocol
+     * The Hander is the interface for all function blocks which wants to communicate over
+     * a network. Every function block which wants to communicate has to be registered at the
+     * handler. A registration does not open any connection. Therefore the registration can be
+     * handled in the function block creation. The connection with a network is established with
+     * a INIT+ event.
+     * The protocol is a layered protocol-stack which has two interfaces. One for the communication
+     * with the upper layer and one with the underneath layer. The top layer is the network handler
+     * and the bottom layer is either the operating system or a protocol layer which is able to communicate
+     * directly with the network.
+     * The memory-allocation is always done by the underneath layer. Thus the upper layer can simple send
+     * data to a underlying layer. The underneath layer can notify the upper layer by calling the
+     * newDataAvailable-function. Then the upper layer has to get the data by calling the getDataPackage-
+     * function. The returned pointer has to be deleted by the upper layer. A smart-pointer like design
+     * is desirable.
+     */
+    using ComLayerManager =
+        util::factory::Factory<util::factory::DynamicImpl, "", CComLayer, CComLayer *, CBaseCommFB *>;
+  } // namespace com_infra
+} // namespace forte

--- a/core/include/forte/devicefactory.h
+++ b/core/include/forte/devicefactory.h
@@ -20,5 +20,9 @@
 #include <string_view>
 
 namespace forte {
+  namespace util::factory {
+    extern template class Factory<FixedDeviceImpl, DefaultDeviceImpl, CDevice, std::string_view>;
+  }
+
   using DeviceFactory = util::factory::Factory<FixedDeviceImpl, DefaultDeviceImpl, CDevice, std::string_view>;
 } // namespace forte

--- a/core/include/forte/ecetfactory.h
+++ b/core/include/forte/ecetfactory.h
@@ -20,5 +20,9 @@
 #include <string_view>
 
 namespace forte {
+  namespace util::factory {
+    extern template class Factory<FixedEcetImpl, DefaultEcetImpl, CEventChainExecutionThread>;
+  }
+
   using EcetFactory = util::factory::Factory<FixedEcetImpl, DefaultEcetImpl, CEventChainExecutionThread>;
 } // namespace forte

--- a/core/include/forte/timerhandlerfactory.h
+++ b/core/include/forte/timerhandlerfactory.h
@@ -20,6 +20,10 @@
 #include <string_view>
 
 namespace forte {
+  namespace util::factory {
+    extern template class Factory<FixedTimerHandlerImpl, DefaultTimerHandlerImpl, CTimerHandler, CDeviceExecution &>;
+  }
+
   using TimerHandlerFactory =
       util::factory::Factory<FixedTimerHandlerImpl, DefaultTimerHandlerImpl, CTimerHandler, CDeviceExecution &>;
 } // namespace forte

--- a/core/include/forte/util/factory.h
+++ b/core/include/forte/util/factory.h
@@ -34,7 +34,7 @@ namespace forte::util::factory {
 
   template<typename FixedImpl, fixed_string, typename T, typename... Args>
     requires Constructible<FixedImpl, T, Args...> || std::same_as<FixedImpl, DynamicImpl>
-  class Factory final {
+  class Factory {
     public:
       class Entry {
         public:
@@ -83,7 +83,7 @@ namespace forte::util::factory {
   };
 
   template<fixed_string DefaultImpl, typename T, typename... Args>
-  class Factory<DynamicImpl, DefaultImpl, T, Args...> final {
+  class Factory<DynamicImpl, DefaultImpl, T, Args...> {
     public:
       class Entry {
         public:

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(forte-core PRIVATE
         device.cpp
         devicefactory.cpp
         ecet.cpp
+        ecetfactory.cpp
         eventconn.cpp
         extevhan.cpp
         fbcontainer.cpp
@@ -61,6 +62,7 @@ target_sources(forte-core PRIVATE
         resource.cpp
         resource_internal.h
         simplefb.cpp
+        startuphook.cpp
         stringid.cpp
         timerha.cpp
         timerhandlerfactory.cpp

--- a/core/src/com/CMakeLists.txt
+++ b/core/src/com/CMakeLists.txt
@@ -15,6 +15,7 @@
 target_sources(forte-core PRIVATE
         basefb.cpp
         common.cpp
+        factory.cpp
         fb.cpp
 )
 

--- a/core/src/com/factory.cpp
+++ b/core/src/com/factory.cpp
@@ -11,14 +11,9 @@
  *    Martin Erich Jobst - initial implementation
  *******************************************************************************/
 
-#pragma once
+#include <forte/com/factory.h>
 
-#include "forte/util/hook.h"
-
-namespace forte {
-  namespace util::hook {
-    extern template class Registry<void, int, char **>;
-  }
-
-  using StartupHookRegistry = util::hook::Registry<void, int, char **>;
-} // namespace forte
+namespace forte::com {
+  template class ComChannelFactory<ComBuffer>;
+  template class ComChannelFactory<std::span<CIEC_ANY_VARIANT>>;
+} // namespace forte::com

--- a/core/src/cominfra/CMakeLists.txt
+++ b/core/src/cominfra/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(forte-core PRIVATE
         basecommfb.cpp
         commfb.cpp
         comlayer.cpp
+        comlayersmanager.cpp
         $<$<BOOL:${FORTE_COM_ETH}>:${CMAKE_CURRENT_SOURCE_DIR}/ipcomlayer.cpp>
         $<$<BOOL:${FORTE_COM_ETH}>:${CMAKE_CURRENT_SOURCE_DIR}/ipcomlayer.h>
         $<$<BOOL:${FORTE_COM_FBDK}>:${CMAKE_CURRENT_SOURCE_DIR}/fbdkasn1layer.cpp>

--- a/core/src/cominfra/comlayersmanager.cpp
+++ b/core/src/cominfra/comlayersmanager.cpp
@@ -11,14 +11,10 @@
  *    Martin Erich Jobst - initial implementation
  *******************************************************************************/
 
-#pragma once
+#include "forte/cominfra/comlayersmanager.h"
 
-#include "forte/util/hook.h"
+#include "forte/cominfra/comlayer.h"
 
-namespace forte {
-  namespace util::hook {
-    extern template class Registry<void, int, char **>;
-  }
-
-  using StartupHookRegistry = util::hook::Registry<void, int, char **>;
-} // namespace forte
+namespace forte::util::factory {
+  template class Factory<DynamicImpl, "", com_infra::CComLayer, com_infra::CComLayer *, com_infra::CBaseCommFB *>;
+}

--- a/core/src/devicefactory.cpp
+++ b/core/src/devicefactory.cpp
@@ -15,21 +15,27 @@
 
 #include "forte/util/mainparam_utils.h"
 
-namespace {
-  class DeviceOption final
-      : public forte::util::CommandLineParser::OptionImpl<"d", "device", "<device>", "Set the device to be used"> {
-    public:
-      bool parseOption(const std::string_view paArgument) override {
-        if (forte::DeviceFactory::setDefaultImpl(forte::StringId::lookup(paArgument))) {
-          return true;
-        }
-        printf("The selected device '%s' is not valid. Select one of the following:\n", paArgument.data());
-        for (const auto name : forte::DeviceFactory::getNames()) {
-          printf("  %s\n", name.data());
-        }
-        return false;
-      }
-  };
+namespace forte {
+  namespace util::factory {
+    template class Factory<FixedDeviceImpl, DefaultDeviceImpl, CDevice, std::string_view>;
+  }
 
-  [[maybe_unused]] DeviceOption gDeviceOption;
-} // namespace
+  namespace {
+    class DeviceOption final
+        : public util::CommandLineParser::OptionImpl<"d", "device", "<device>", "Set the device to be used"> {
+      public:
+        bool parseOption(const std::string_view paArgument) override {
+          if (DeviceFactory::setDefaultImpl(StringId::lookup(paArgument))) {
+            return true;
+          }
+          printf("The selected device '%s' is not valid. Select one of the following:\n", paArgument.data());
+          for (const auto name : DeviceFactory::getNames()) {
+            printf("  %s\n", name.data());
+          }
+          return false;
+        }
+    };
+
+    [[maybe_unused]] DeviceOption gDeviceOption;
+  } // namespace
+} // namespace forte

--- a/core/src/ecetfactory.cpp
+++ b/core/src/ecetfactory.cpp
@@ -11,14 +11,8 @@
  *    Martin Erich Jobst - initial implementation
  *******************************************************************************/
 
-#pragma once
+#include "forte/ecetfactory.h"
 
-#include "forte/util/hook.h"
-
-namespace forte {
-  namespace util::hook {
-    extern template class Registry<void, int, char **>;
-  }
-
-  using StartupHookRegistry = util::hook::Registry<void, int, char **>;
-} // namespace forte
+namespace forte::util::factory {
+  template class Factory<FixedEcetImpl, DefaultEcetImpl, CEventChainExecutionThread>;
+}

--- a/core/src/startuphook.cpp
+++ b/core/src/startuphook.cpp
@@ -11,14 +11,8 @@
  *    Martin Erich Jobst - initial implementation
  *******************************************************************************/
 
-#pragma once
+#include "forte/startuphook.h"
 
-#include "forte/util/hook.h"
-
-namespace forte {
-  namespace util::hook {
-    extern template class Registry<void, int, char **>;
-  }
-
-  using StartupHookRegistry = util::hook::Registry<void, int, char **>;
-} // namespace forte
+namespace forte::util::hook {
+  template class Registry<void, int, char **>;
+}

--- a/core/src/timerhandlerfactory.cpp
+++ b/core/src/timerhandlerfactory.cpp
@@ -15,21 +15,27 @@
 
 #include "forte/util/mainparam_utils.h"
 
-namespace {
-  class TimerHandlerOption final
-      : public forte::util::CommandLineParser::OptionImpl<"T", "timer", "<timer>", "Set the timer to be used"> {
-    public:
-      bool parseOption(const std::string_view paArgument) override {
-        if (forte::TimerHandlerFactory::setDefaultImpl(forte::StringId::lookup(paArgument))) {
-          return true;
-        }
-        printf("The selected timer '%s' is not valid. Select one of the following:\n", paArgument.data());
-        for (const auto name : forte::TimerHandlerFactory::getNames()) {
-          printf("  %s\n", name.data());
-        }
-        return false;
-      }
-  };
+namespace forte {
+  namespace util::factory {
+    template class Factory<FixedTimerHandlerImpl, DefaultTimerHandlerImpl, CTimerHandler, CDeviceExecution &>;
+  }
 
-  [[maybe_unused]] TimerHandlerOption gTimerHandlerOption;
-} // namespace
+  namespace {
+    class TimerHandlerOption final
+        : public util::CommandLineParser::OptionImpl<"T", "timer", "<timer>", "Set the timer to be used"> {
+      public:
+        bool parseOption(const std::string_view paArgument) override {
+          if (TimerHandlerFactory::setDefaultImpl(StringId::lookup(paArgument))) {
+            return true;
+          }
+          printf("The selected timer '%s' is not valid. Select one of the following:\n", paArgument.data());
+          for (const auto name : TimerHandlerFactory::getNames()) {
+            printf("  %s\n", name.data());
+          }
+          return false;
+        }
+    };
+
+    [[maybe_unused]] TimerHandlerOption gTimerHandlerOption;
+  } // namespace
+} // namespace forte


### PR DESCRIPTION
This avoids limitations of the dynamic linker on Windows and also helps to reduce shared library sizes on other platforms.