### PR TITLE
Use explicit intern for compile-time string ids on Windows

### DIFF
--- a/core/include/forte/stringid.h
+++ b/core/include/forte/stringid.h
@@ -71,14 +71,18 @@ namespace forte {
       template<util::fixed_string A>
       static constexpr StringId fixed() {
         (void) &Register<A>::scmRegister;
+#ifdef _WIN32
+        return StringId{intern(A)};
+#else
         return StringId{A};
+#endif
       }
 
     private:
       constexpr explicit StringId(const std::string_view paString) : mString(paString) {
       }
 
-      static void intern(std::string_view paString);
+      static std::string_view intern(std::string_view paString);
 
       std::string_view mString;
   };

--- a/core/src/stringid.cpp
+++ b/core/src/stringid.cpp
@@ -36,9 +36,9 @@ namespace forte {
     }
   } // namespace
 
-  void StringId::intern(const std::string_view paString) {
+  std::string_view StringId::intern(const std::string_view paString) {
     std::unique_lock lock(internMutex());
-    internSet().insert(paString);
+    return *internSet().insert(paString).first;
   }
 
   StringId StringId::lookup(std::string_view paString) {


### PR DESCRIPTION
This avoids limitations of the dynamic linker on Windows where templates may have multiple definitions in different DLLs. It includes https://github.com/eclipse-4diac/4diac-forte/pull/645 to avoid merge conflicts later.