### PR TITLE
Fix missing setOption in IntOption of command line parser

### DIFF
--- a/core/include/forte/util/mainparam_utils.h
+++ b/core/include/forte/util/mainparam_utils.h
@@ -94,7 +94,8 @@ namespace forte::util {
                 ptr != paArgument.data() + paArgument.size() || ec != std::errc()) {
               return false;
             }
-            return result;
+            setOption(result);
+            return true;
           }
 
           virtual bool setOption(T t) = 0;


### PR DESCRIPTION
Fixes https://github.com/eclipse-4diac/4diac-forte/issues/649