### PR TITLE
Fix compiler warnings and treat warnings as errors in CI build

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -23,9 +23,9 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        build_type: [Debug]
-        c_compiler: [gcc, clang, cl]
+        os: [ ubuntu-latest, windows-latest ]
+        build_type: [ Debug ]
+        c_compiler: [ gcc, clang, cl ]
         include:
           - os: windows-latest
             c_compiler: cl
@@ -48,41 +48,42 @@ jobs:
             c_compiler: cl
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set reusable strings
-      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
-      id: strings
-      shell: bash
-      run: |
-        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-    
-    - name: Install libboost (Linux)
-      if: ${{ matrix.os != 'windows-latest' }}
-      run: sudo apt-get install -y libboost-all-dev
+      - name: Set reusable strings
+        # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+        id: strings
+        shell: bash
+        run: |
+          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-    - name: Install boost (Windows)
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: nuget install boost -Version 1.84.0
+      - name: Install libboost (Linux)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: sudo apt-get install -y libboost-all-dev
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: >
-        cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -S ${{ github.workspace }}
-        --preset ${{ matrix.architecture }}-systemtests
-        ${{ matrix.os == 'windows-latest' && format('-DFORTE_TESTS_INC_DIRS={0}/boost.1.84.0/lib/native/include', github.workspace) || '' }}
+      - name: Install boost (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: nuget install boost -Version 1.84.0
 
-    - name: Build
-      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: >
+          cmake -B ${{ steps.strings.outputs.build-output-dir }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+          -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -S ${{ github.workspace }}
+          --preset ${{ matrix.architecture }}-systemtests
+          ${{ matrix.os == 'windows-latest' && format('-DFORTE_TESTS_INC_DIRS={0}/boost.1.84.0/lib/native/include', github.workspace) || '' }}
 
-    - name: Test
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}
-      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --build-config ${{ matrix.build_type }} --verbose
+      - name: Build
+        # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+      - name: Test
+        working-directory: ${{ steps.strings.outputs.build-output-dir }}
+        # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest --build-config ${{ matrix.build_type }} --verbose

--- a/core/include/forte/datatypes/forte_array_dynamic.h
+++ b/core/include/forte/datatypes/forte_array_dynamic.h
@@ -572,7 +572,7 @@ namespace forte {
           mData = operator new(paArray.size() * mElementSize);
           auto *dest = static_cast<TForteByte *>(mData);
           for (intmax_t i = paArray.getLowerBound(), end = paArray.getUpperBound(); i <= end; ++i) {
-            paArray[i].clone(dest);
+            (void) paArray[i].clone(dest);
             dest += mElementSize;
             mSize++; // increment size one-by-one to track allocated elements for destruction
           }

--- a/core/src/cominfra/structmembercomlayer.cpp
+++ b/core/src/cominfra/structmembercomlayer.cpp
@@ -62,7 +62,7 @@ namespace forte::com_infra {
   }
 
   bool CStructMemberLocalComLayer::parseArrayIndexFromString(const char *paNestedStructString, CIEC_INT &targetIndex) {
-    std::string str(paNestedStructString);
+    std::string_view str(paNestedStructString);
 
     const size_t startIndex = (str.find('[') != std::string::npos) ? str.find('[') + 1 : std::string::npos;
     const size_t stopIndex = str.find(']');
@@ -72,7 +72,7 @@ namespace forte::com_infra {
     }
 
     const char *indexString = str.substr(startIndex, stopIndex - startIndex).data();
-    TForteInt16 index = static_cast<TForteInt16>(util::strtol(indexString, nullptr, 10));
+    const auto index = static_cast<TForteInt16>(util::strtol(indexString, nullptr, 10));
 
     if (errno == ERANGE) {
       return false;

--- a/core/src/cominfra/structmembercomlayer.h
+++ b/core/src/cominfra/structmembercomlayer.h
@@ -54,7 +54,7 @@ namespace forte {
         CStructMemberLocalComLayer(CComLayer *paUpperLayer, CBaseCommFB *paFB);
 
       protected:
-        void setRDs(CBaseCommFB &paSubl, CIEC_ANY **paSDs, TPortId paNumSDs);
+        void setRDs(CBaseCommFB &paSubl, CIEC_ANY **paSDs, TPortId paNumSDs) override;
 
       private:
         using TTargetStructIndexList = std::vector<TForteInt16>;

--- a/tests/core/fbtests/fbtestfixture.cpp
+++ b/tests/core/fbtests/fbtestfixture.cpp
@@ -26,7 +26,7 @@
 
 namespace forte::test {
   //! Helper class allowing to access the can be connected function from the FBTester
-  class CFBTestConn final : public CDataConnection {
+  class CFBTestConn : public CDataConnection {
     public:
       static bool canBeConnected(const CIEC_ANY &paSrcDataPoint, const CIEC_ANY &paDstDataPoint) {
         return CDataConnection::canBeConnected(paSrcDataPoint, paDstDataPoint);
@@ -34,9 +34,6 @@ namespace forte::test {
 
       // you are not allowed to create this class
       CFBTestConn() = delete;
-
-    private:
-      ~CFBTestConn() override;
   };
 
   class CFBTestInputDataConn final : public CDataConnection {


### PR DESCRIPTION
Fix several compiler warnings, including a use-after-free, and treat warnings as errors in CI build