### PR TITLE
Extended Logging of full Event Queue

### DIFF
--- a/core/include/forte/ecet.h
+++ b/core/include/forte/ecet.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "forte/event.h"
-#include "forte/datatypes/forte_time.h"
 #include "forte/util/ringbuf.h"
 #include "forte/config/forte_config.h"
 #include "forte/arch/forte_thread.h"
@@ -44,7 +43,7 @@ namespace forte {
        */
       void addEventEntry(TEventEntry paEventToAdd) {
         if (!mEventList.push(paEventToAdd)) {
-          DEVLOG_ERROR("Event queue is full, event dropped!\n");
+          logFullEventQueue(paEventToAdd);
         }
 #ifdef FORTE_TRACE_CTF
         else if (paEventToAdd.getPortId() != cgExternalEventID) {
@@ -87,6 +86,8 @@ namespace forte {
       void mainRun();
 
     private:
+      static void logFullEventQueue(TEventEntry paEventToAdd);
+
       /*! \brief The thread run()-method where the events are sent to the FBs and the FBs are executed in.
        *
        * If there is an entry in the Event List the event will be delivered and the FB executed.

--- a/core/include/forte/interfacespec.h
+++ b/core/include/forte/interfacespec.h
@@ -20,6 +20,7 @@
  *******************************************************************************/
 #pragma once
 
+#include "forte/datatype.h"
 #include "forte/event.h"
 #include "forte/stringid.h"
 #include <span>
@@ -116,6 +117,14 @@ namespace forte {
       TPortId getPlugID(StringId paPlugNameId) const;
 
       TPortId getSocketID(StringId paSocketNameId) const;
+
+      StringId getEINameId(TPortId paPortId) const;
+      StringId getEONameId(TPortId paPortId) const;
+      StringId getDINameId(TPortId paPortId) const;
+      StringId getDONameId(TPortId paPortId) const;
+      StringId getDIONameId(TPortId paPortId) const;
+      StringId getSocketNameId(TPortId paPortId) const;
+      StringId getPlugNameId(TPortId paPortId) const;
   };
 
   TPortId getPortId(StringId paPortNameId, std::span<const StringId> paPortNames);

--- a/core/src/ecet.cpp
+++ b/core/src/ecet.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2021 ACIN, Profactor GmbH, fortiss GmbH, Hit robot group
+ * Copyright (c) 2005, 2025 ACIN, Profactor GmbH, fortiss GmbH, Hit robot group
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,11 +14,8 @@
  *    zhaoxin
  *      -  fix that external event queue becomes event locker after it is full
  *******************************************************************************/
-#include "forte/config/forte_config.h"
 #include "forte/ecet.h"
-
 #include "forte/ecetfactory.h"
-#include "forte/esfb.h"
 #include "forte/util/criticalregion.h"
 #include "forte/util/devlog.h"
 
@@ -105,4 +102,18 @@ namespace forte {
       default: break;
     }
   }
+
+  void CEventChainExecutionThread::logFullEventQueue(TEventEntry paEventToAdd) {
+    const SFBInterfaceSpec &interfaceSpec = paEventToAdd.getFB().getFBInterfaceSpec();
+    if (paEventToAdd.getPortId() >= interfaceSpec.getNumEIs()) {
+      DEVLOG_ERROR("Event queue is full, event dropped! Function Block: %s, event num: %d (maxnum: %d)\n",
+                   paEventToAdd.getFB().getFullQualifiedApplicationInstanceName('.').c_str(), paEventToAdd.getPortId(),
+                   interfaceSpec.getNumEIs() - 1);
+    } else {
+      DEVLOG_ERROR("Event queue is full, event dropped! Function Block: %s, event: %s\n",
+                   paEventToAdd.getFB().getFullQualifiedApplicationInstanceName('.').c_str(),
+                   interfaceSpec.getEINameId(paEventToAdd.getPortId()).data());
+    }
+  }
+
 } // namespace forte

--- a/core/src/interfacespec.cpp
+++ b/core/src/interfacespec.cpp
@@ -25,6 +25,16 @@
 using namespace forte::literals;
 
 namespace forte {
+
+  namespace {
+    StringId getPortNameId(TPortId paPortId, std::span<const StringId> paPortNames) {
+      if (paPortId >= paPortNames.size()) {
+        return {};
+      }
+      return paPortNames[paPortId];
+    }
+  } // namespace
+
   TPortId getPortId(StringId paPortNameId, std::span<const StringId> paPortNames) {
     auto it = std::find(paPortNames.begin(), paPortNames.end(), paPortNameId);
     if (it == paPortNames.end()) {
@@ -74,4 +84,33 @@ namespace forte {
   TPortId SFBInterfaceSpec::getSocketID(StringId paSocketNameId) const {
     return getPortId(paSocketNameId, mSocketNames);
   }
+
+  StringId SFBInterfaceSpec::getEINameId(TPortId paPortId) const {
+    return getPortNameId(paPortId, mEINames);
+  }
+
+  StringId SFBInterfaceSpec::getEONameId(TPortId paPortId) const {
+    return getPortNameId(paPortId, mEONames);
+  }
+
+  StringId SFBInterfaceSpec::getDINameId(TPortId paPortId) const {
+    return getPortNameId(paPortId, mDONames);
+  }
+
+  StringId SFBInterfaceSpec::getDONameId(TPortId paPortId) const {
+    return getPortNameId(paPortId, mDONames);
+  }
+
+  StringId SFBInterfaceSpec::getDIONameId(TPortId paPortId) const {
+    return getPortNameId(paPortId, mDIONames);
+  }
+
+  StringId SFBInterfaceSpec::getSocketNameId(TPortId paPortId) const {
+    return getPortNameId(paPortId, mSocketNames);
+  }
+
+  StringId SFBInterfaceSpec::getPlugNameId(TPortId paPortId) const {
+    return getPortNameId(paPortId, mPlugNames);
+  }
+
 } // namespace forte


### PR DESCRIPTION
To help identifying potential issues in networks the fb instance name and input event causing the overflow are logged.