### PR TITLE
Replaces header guards with #pragma once

### DIFF
--- a/com/HTTP/httplayer.h
+++ b/com/HTTP/httplayer.h
@@ -14,8 +14,7 @@
  *    Martin Melik Merkumians - change CIEC_STRING to std::string
  ********************************************************************************/
 
-#ifndef _HTTPCOMLAYER_H_
-#define _HTTPCOMLAYER_H_
+#pragma once
 
 #include "forte/config/forte_config.h"
 #include "forte/arch/forte_sem.h"
@@ -118,5 +117,3 @@ namespace forte::com_infra::http {
   };
 
 } // namespace forte::com_infra::http
-
-#endif /* _HTTPCOMLAYER_H_ */

--- a/com/can/CANHandler.h
+++ b/com/can/CANHandler.h
@@ -11,8 +11,7 @@
  *  Malte Grave - Adapt the CAN handler to the new 4diac-FORTE structure
  *******************************************************************************/
 
-#ifndef CANHANDLER_H_
-#define CANHANDLER_H_
+#pragma once
 
 #include <linux/can.h>
 #include <linux/can/raw.h>
@@ -66,5 +65,3 @@ namespace forte::com_infra {
       bool mConnectionListChanged;
   };
 } // namespace forte::com_infra
-
-#endif

--- a/com/modbus/modbusclientconnection.h
+++ b/com/modbus/modbusclientconnection.h
@@ -10,8 +10,7 @@
  *   Filip Andren - initial API and implementation and/or initial documentation
  *   Davor Cihlar - multiple FBs sharing a single Modbus connection
  *******************************************************************************/
-#ifndef _MODBUSCLIENTCONNECTION_H_
-#define _MODBUSCLIENTCONNECTION_H_
+#pragma once
 
 #include <vector>
 #include "modbusconnection.h"
@@ -68,5 +67,3 @@ class CModbusClientConnection : public CModbusConnection {
 
     CSyncObject mModbusLock;
 };
-
-#endif

--- a/com/modbus/modbusconnection.h
+++ b/com/modbus/modbusconnection.h
@@ -10,8 +10,7 @@
  *   Filip Andren, Alois Zoitl - initial API and implementation and/or initial documentation
  *   Davor Cihlar - multiple FBs sharing a single Modbus connection
  *******************************************************************************/
-#ifndef _MODBUSCONNECTION_H_
-#define _MODBUSCONNECTION_H_
+#pragma once
 
 #include <modbus.h>
 #include "forte/arch/forte_thread.h"
@@ -91,5 +90,3 @@ class CModbusConnection : public CThread {
     unsigned int mResponseTimeout;
     unsigned int mByteTimeout;
 };
-
-#endif // _MODBUSCONNECTION_H_

--- a/com/modbus/modbusenums.h
+++ b/com/modbus/modbusenums.h
@@ -9,8 +9,7 @@
  * Contributors:
  *   Davor Cihlar - multiple FBs sharing a single Modbus connection
  *******************************************************************************/
-#ifndef _MODBUSENUMS_H_
-#define _MODBUSENUMS_H_
+#pragma once
 
 enum EModbusFunction { eDiscreteInput = 0, eCoil, eInputRegister, eHoldingRegister };
 
@@ -21,5 +20,3 @@ enum EModbusFlowControl {
   eFlowDelay,
   eFlowLongDelay,
 };
-
-#endif

--- a/com/modbus/modbushandler.h
+++ b/com/modbus/modbushandler.h
@@ -10,8 +10,7 @@
  *   Filip Andren, Alois Zoitl - initial API and implementation and/or initial documentation
  *   Davor Cihlar - multiple FBs sharing a single Modbus connection
  *******************************************************************************/
-#ifndef _MODBUSHANDLER_H_
-#define _MODBUSHANDLER_H_
+#pragma once
 
 #include "forte/config/forte_config.h"
 #include "forte/extevhan.h"
@@ -34,5 +33,3 @@ class CModbusHandler : public CExternalEventHandler, public RegisterExternalEven
 
     void executeComCallback(forte::com_infra::CModbusComLayer *paComCallback);
 };
-
-#endif // _MODBUSHANDLER_H_

--- a/com/modbus/modbusioblock.h
+++ b/com/modbus/modbusioblock.h
@@ -9,8 +9,7 @@
  * Contributors:
  *   Davor Cihlar - multiple FBs sharing a single Modbus connection
  *******************************************************************************/
-#ifndef _MODBUSIOBLOCK_H_
-#define _MODBUSIOBLOCK_H_
+#pragma once
 
 #include <vector>
 #include "modbusenums.h"
@@ -69,5 +68,3 @@ class CModbusIOBlock {
     unsigned int mReadSize;
     unsigned int mSendSize;
 };
-
-#endif

--- a/com/modbus/modbuslayer.h
+++ b/com/modbus/modbuslayer.h
@@ -10,8 +10,7 @@
  *   Filip Andren, Alois Zoitl - initial API and implementation and/or initial documentation
  *   Davor Cihlar - multiple FBs sharing a single Modbus connection
  *******************************************************************************/
-#ifndef MODBUSCOMLAYER_H_
-#define MODBUSCOMLAYER_H_
+#pragma once
 
 #include <vector>
 #include "forte/config/forte_config.h"
@@ -108,5 +107,3 @@ namespace forte {
   } // namespace com_infra
 
 } // namespace forte
-
-#endif /* MODBUSCOMLAYER_H_ */

--- a/com/modbus/modbuspoll.h
+++ b/com/modbus/modbuspoll.h
@@ -10,8 +10,7 @@
  *   Filip Andren - initial API and implementation and/or initial documentation
  *   Davor Cihlar - multiple FBs sharing a single Modbus connection
  *******************************************************************************/
-#ifndef MODBUSPOLL_H_
-#define MODBUSPOLL_H_
+#pragma once
 
 #include "modbustimedevent.h"
 #include <vector>
@@ -34,5 +33,3 @@ class CModbusPoll : public CModbusTimedEvent {
 
     int readOneBlock(modbus_t *paModbusConn, CModbusIOBlock *paIOBlock);
 };
-
-#endif /* MODBUSPOLL_H_ */

--- a/com/modbus/modbustimedevent.h
+++ b/com/modbus/modbustimedevent.h
@@ -9,8 +9,7 @@
  * Contributors:
  *   Filip Andren - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef _MODBUSTIMEDEVENT_H_
-#define _MODBUSTIMEDEVENT_H_
+#pragma once
 
 #include "forte/timerha.h"
 #include <modbus.h>
@@ -48,5 +47,3 @@ class CModbusTimedEvent {
     bool mSingleShotEvent;
     bool mIsStarted;
 };
-
-#endif // _MODBUSTIMEDEVENT_H_

--- a/com/mqtt_paho/MQTTClient.h
+++ b/com/mqtt_paho/MQTTClient.h
@@ -11,8 +11,7 @@
  * Markus Meingast - refactoring and adaption to new Client class, enabling connection to multiple servers
  *******************************************************************************/
 
-#ifndef CMQTTCLIENT_H
-#define CMQTTCLIENT_H
+#pragma once
 
 #include "MQTTHandler.h"
 #include <string>
@@ -106,5 +105,3 @@ namespace forte::com_infra::mqtt_paho {
   };
 
 } // namespace forte::com_infra::mqtt_paho
-
-#endif /*CMQTTCLIENT_H*/

--- a/com/mqtt_paho/MQTTClientConfigParser.h
+++ b/com/mqtt_paho/MQTTClientConfigParser.h
@@ -11,8 +11,7 @@
  *    Jose Cabral - initial implementation
  *******************************************************************************/
 
-#ifndef SRC_MODULES_OPC_UA_OPCUA_CLIENT_CONFIG_PARSER_H_
-#define SRC_MODULES_OPC_UA_OPCUA_CLIENT_CONFIG_PARSER_H_
+#pragma once
 
 #include "forte/datatypes/forte_string.h"
 #include <string>
@@ -75,5 +74,3 @@ namespace forte::com_infra::mqtt_paho {
   };
 
 } // namespace forte::com_infra::mqtt_paho
-
-#endif /* SRC_MODULES_OPC_UA_OPCUA_CLIENT_CONFIG_PARSER_H_ */

--- a/com/mqtt_paho/MQTTComLayer.h
+++ b/com/mqtt_paho/MQTTComLayer.h
@@ -11,8 +11,7 @@
  *                         - Change CIEC_STRING to std::string
  *******************************************************************************/
 
-#ifndef MQTTCOMLAYER_H_
-#define MQTTCOMLAYER_H_
+#pragma once
 
 #include "forte/cominfra/comlayer.h"
 #include "forte/datatypes/forte_string.h"
@@ -67,6 +66,5 @@ namespace forte::com_infra::mqtt_paho {
 
       enum Parameters { Address, ClientID, Topic };
   };
-} // namespace forte::com_infra::mqtt_paho
 
-#endif /* MQTTCOMLAYER_H_ */
+} // namespace forte::com_infra::mqtt_paho

--- a/com/mqtt_paho/MQTTHandler.h
+++ b/com/mqtt_paho/MQTTHandler.h
@@ -15,8 +15,7 @@
  *                           enabling connection to multiple servers
  *******************************************************************************/
 
-#ifndef MQTTHANDLER_H_
-#define MQTTHANDLER_H_
+#pragma once
 
 #include "forte/extevhan.h"
 #include "MQTTComLayer.h"
@@ -70,5 +69,3 @@ namespace forte::com_infra::mqtt_paho {
   };
 
 } // namespace forte::com_infra::mqtt_paho
-
-#endif /* MQTTHANDLER_H_ */

--- a/com/opc/Cmd_AddConnection.h
+++ b/com/opc/Cmd_AddConnection.h
@@ -12,8 +12,7 @@
  *   Tibalt Zhao  - Merge additem into opc connect
  *   Ketut Kumajaya - Code refactoring from char* to std::string
  *******************************************************************************/
-#ifndef CMDADDCONNECTION_H_
-#define CMDADDCONNECTION_H_
+#pragma once
 #include "ICmd.h"
 #include "forte/cominfra/comlayer.h"
 #include <vector>
@@ -43,5 +42,3 @@ class CCmd_AddConnection : public ICmd {
     std::vector<std::string> mReadItems;
     std::vector<std::string> mWriteItems;
 };
-
-#endif // CMDADDCONNECTION_H_

--- a/com/opc/Cmd_RemoveConnection.h
+++ b/com/opc/Cmd_RemoveConnection.h
@@ -12,8 +12,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *   Ketut Kumajaya - Remove groups and items on disconnect
  *******************************************************************************/
-#ifndef CMDREMOVECONNECTION_H_
-#define CMDREMOVECONNECTION_H_
+#pragma once
 #include "ICmd.h"
 #include "forte/cominfra/comlayer.h"
 #include <vector>
@@ -42,5 +41,3 @@ class CCmd_RemoveConnection : public ICmd {
     const std::string mGroupName;
     bool mDisconnect;
 };
-
-#endif // CMDREMOVECONNECTION_H_

--- a/com/opc/Cmd_SetProcessVarValue.h
+++ b/com/opc/Cmd_SetProcessVarValue.h
@@ -10,8 +10,7 @@
  *   Filip Andren - initial API and implementation and/or initial documentation
  *   Tibalt Zhao  - get rid of opcprocessvar from commfb
  *******************************************************************************/
-#ifndef CMDSETPROCESSVARVALUE_H_
-#define CMDSETPROCESSVARVALUE_H_
+#pragma once
 
 #include "ICmd.h"
 
@@ -40,5 +39,3 @@ class CCmd_SetProcessVarValue : public ICmd {
     const std::string mItemName;
     Variant mVar;
 };
-
-#endif // CMDSETPROCESSVARVALUE_H_

--- a/com/opc/ICmd.h
+++ b/com/opc/ICmd.h
@@ -9,8 +9,7 @@
  * Contributors:
  *   Filip Andren - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef ICMD_H_
-#define ICMD_H_
+#pragma once
 
 class ICmd {
   public:
@@ -20,5 +19,3 @@ class ICmd {
     virtual void runCommand() = 0;
     virtual const char *getCommandName() const = 0;
 };
-
-#endif // ICMD_H_

--- a/com/opc/Variant.h
+++ b/com/opc/Variant.h
@@ -9,8 +9,7 @@
  * Contributors:
  *   Werner Tremmel - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef VARIANTNEW_H_
-#define VARIANTNEW_H_
+#pragma once
 
 #include <boost/lexical_cast.hpp>
 
@@ -319,5 +318,3 @@ struct Variant : public VARIANT {
       a[1.2] = 0;
     }
 };
-
-#endif // VARIANTNEW_H_

--- a/com/opc/opccomlayer.h
+++ b/com/opc/opccomlayer.h
@@ -12,8 +12,7 @@
  *   Tibalt Zhao - replace forte list with stl vector
  *   Ketut Kumajaya - Code refactoring from char* to std::string
  *******************************************************************************/
-#ifndef OPCCOMLAYER_H_
-#define OPCCOMLAYER_H_
+#pragma once
 
 #include "forte/config/forte_config.h"
 #include "forte/cominfra/comlayer.h"
@@ -76,5 +75,3 @@ namespace forte {
   } // namespace com_infra
 
 } // namespace forte
-
-#endif /* OPCCOMLAYER_H_ */

--- a/com/opc/opcconnection.h
+++ b/com/opc/opcconnection.h
@@ -12,8 +12,7 @@
  *   Ketut Kumajaya - switch to OPCClientToolKit with 64bit support
  *                  - Code refactoring from char* to std::string
  *******************************************************************************/
-#ifndef OPCCONNECTION_H_
-#define OPCCONNECTION_H_
+#pragma once
 
 #include "forte/cominfra/comlayer.h"
 #include "forte/arch/forte_sync.h"
@@ -191,5 +190,3 @@ class COpcConnection {
     COpcConnection(const COpcConnection &);
     COpcConnection &operator=(const COpcConnection &);
 };
-
-#endif // OPCCONNECTION_H_

--- a/com/opc/opcconnectionhandler.h
+++ b/com/opc/opcconnectionhandler.h
@@ -11,8 +11,7 @@
  *   Filip Andren, Alois Zoitl - initial API and implementation and/or initial documentation
  *   Ketut Kumajaya - Code refactoring from char* to std::string
  *******************************************************************************/
-#ifndef OPCCONNECTIONHANDLER_H_
-#define OPCCONNECTIONHANDLER_H_
+#pragma once
 
 #include "forte/util/singlet.h"
 #include "forte/cominfra/comlayer.h"
@@ -43,5 +42,3 @@ class COpcConnectionHandler {
     typedef CSinglyLinkedList<COpcConnection *> TOpcConnectionList;
     TOpcConnectionList mOpcConnectionList;
 };
-
-#endif // OPCCONNECTIONHANDLER_H_

--- a/com/opc/opcconnectionimpl.h
+++ b/com/opc/opcconnectionimpl.h
@@ -12,8 +12,7 @@
  *   Ketut Kumajaya - switch to OPCClientToolKit with 64bit support
  *                  - Code refactoring from char* to std::string
  *******************************************************************************/
-#ifndef OPCCONNECTIONIMPL_H_
-#define OPCCONNECTIONIMPL_H_
+#pragma once
 
 #include "opcprocessvar.h"
 // Includes from OPC library
@@ -86,5 +85,3 @@ class COpcConnectionImpl : public IAsyncDataCallback {
     const std::string mServerName;
     bool mConnected;
 };
-
-#endif // OPCCONNECTIONIMPL_H_

--- a/com/opc/opceventhandler.h
+++ b/com/opc/opceventhandler.h
@@ -13,8 +13,7 @@
  *   Ketut Kumajaya - Clear command in queue on exit
  *                  - Fix disconnection issue on exit
  *******************************************************************************/
-#ifndef OPCEVENTHANDLER_H_
-#define OPCEVENTHANDLER_H_
+#pragma once
 
 #include "forte/extevhan.h"
 #include "forte/arch/forte_thread.h"
@@ -98,5 +97,3 @@ class COpcEventHandler : public CExternalEventHandler,
     typedef CSinglyLinkedList<ICmd *> TCommandQueue;
     TCommandQueue mCommandQueue;
 };
-
-#endif // OPCEVENTHANDLER_H_

--- a/com/opc/opcprocessvar.h
+++ b/com/opc/opcprocessvar.h
@@ -12,8 +12,7 @@
  *   Tibalt Zhao - use stl deque and polish the logs
  *   Ketut Kumajaya - Code refactoring from char* to std::string
  *******************************************************************************/
-#ifndef OPCPROCESSVAR_H_
-#define OPCPROCESSVAR_H_
+#pragma once
 
 #include "windows.h"
 #include "Variant.h"
@@ -60,5 +59,3 @@ class COpcProcessVar {
 
     EOpcProcessVarFunctions mFunction;
 };
-
-#endif // OPCPROCESSVAR_H_

--- a/com/opc_ua/src/detail/lds_me_handler.h
+++ b/com/opc_ua/src/detail/lds_me_handler.h
@@ -12,8 +12,7 @@
  *      - initial integration of the OPC-UA protocol
  *******************************************************************************/
 
-#ifndef SRC_COM_OPC_UA_DETAIL_LDSMEHANDLER_H_
-#define SRC_COM_OPC_UA_DETAIL_LDSMEHANDLER_H_
+#pragma once
 
 #include <open62541.h>
 
@@ -96,5 +95,3 @@ namespace forte::com_infra::opc_ua::detail {
       std::vector<UA_StringRAII> mRegisteredServers;
   };
 } // namespace forte::com_infra::opc_ua::detail
-
-#endif // SRC_COM_OPC_UA_DETAIL_LDSMEHANDLER_H_

--- a/com/opc_ua/src/opcua_action_info.h
+++ b/com/opc_ua/src/opcua_action_info.h
@@ -12,8 +12,7 @@
  *    Martin Melik Merkumians - Change CIEC_STRING to std::string
  *******************************************************************************/
 
-#ifndef SRC_MODULES_OPC_UA_OPCUA_ACTION_INFO_H_
-#define SRC_MODULES_OPC_UA_OPCUA_ACTION_INFO_H_
+#pragma once
 
 #include "forte/arch/forte_sem.h"
 #include "opcua_layer.h"
@@ -386,4 +385,3 @@ namespace forte::com_infra::opc_ua {
       arch::CSemaphore mResultIsReady;
   };
 } // namespace forte::com_infra::opc_ua
-#endif /* SRC_MODULES_OPC_UA_OPCUA_ACTION_INFO_H_ */

--- a/com/opc_ua/src/opcua_client_config_parser.h
+++ b/com/opc_ua/src/opcua_client_config_parser.h
@@ -11,8 +11,7 @@
  *    Jose Cabral - initial implementation
  *******************************************************************************/
 
-#ifndef SRC_MODULES_OPC_UA_OPCUA_CLIENT_CONFIG_PARSER_H_
-#define SRC_MODULES_OPC_UA_OPCUA_CLIENT_CONFIG_PARSER_H_
+#pragma once
 
 #include "forte/datatypes/forte_string.h"
 #include "open62541.h"
@@ -96,4 +95,3 @@ namespace forte::com_infra::opc_ua {
 #endif // UA_ENABLE_ENCRYPTION
   };
 } // namespace forte::com_infra::opc_ua
-#endif /* SRC_MODULES_OPC_UA_OPCUA_CLIENT_CONFIG_PARSER_H_ */

--- a/com/opc_ua/src/opcua_client_information.h
+++ b/com/opc_ua/src/opcua_client_information.h
@@ -12,8 +12,7 @@
  *    Martin Melik Merkumians - Change CIEC_STRING to std::string
  *******************************************************************************/
 
-#ifndef SRC_MODULES_OPC_UA_OPCUA_CLIENT_INFORMATION_H_
-#define SRC_MODULES_OPC_UA_OPCUA_CLIENT_INFORMATION_H_
+#pragma once
 
 #include "opcua_action_info.h"
 
@@ -469,4 +468,3 @@ namespace forte::com_infra::opc_ua {
       static const UA_UInt32 scmClientTimeoutInMilli = static_cast<UA_UInt32>(5E3); // 5s
   };
 } // namespace forte::com_infra::opc_ua
-#endif /* SRC_MODULES_OPC_UA_OPCUA_CLIENT_INFORMATION_H_ */

--- a/com/opc_ua/src/opcua_handler_abstract.h
+++ b/com/opc_ua/src/opcua_handler_abstract.h
@@ -10,8 +10,7 @@
  * Contributors:
  *    Jose Cabral - initial implementation
  *******************************************************************************/
-#ifndef SRC_MODULES_OPC_UA_OPCUA_HANDLER_ABSTRACT_H_
-#define SRC_MODULES_OPC_UA_OPCUA_HANDLER_ABSTRACT_H_
+#pragma once
 
 #include "forte/extevhan.h"
 #include "forte/esfb.h"
@@ -80,4 +79,3 @@ namespace forte::com_infra::opc_ua {
       static const size_t mMaxLogLength = 400;
   };
 } // namespace forte::com_infra::opc_ua
-#endif /* SRC_MODULES_OPC_UA_OPCUA_HANDLER_ABSTRACT_H_ */

--- a/com/opc_ua/src/opcua_helper.h
+++ b/com/opc_ua/src/opcua_helper.h
@@ -13,8 +13,7 @@
  *    Martin Melik Merkumians - Change CIEC_STRING to std::string
  *******************************************************************************/
 
-#ifndef FORTE_OPCUA_HELPER_H
-#define FORTE_OPCUA_HELPER_H
+#pragma once
 
 #include <open62541.h>
 #include "forte/datatypes/forte_any.h"
@@ -236,4 +235,3 @@ namespace forte {
     };
   } // namespace com_infra::opc_ua
 } // namespace forte
-#endif // FORTE_OPCUA_HELPER_H

--- a/com/opc_ua/src/opcua_layer.h
+++ b/com/opc_ua/src/opcua_layer.h
@@ -18,8 +18,7 @@
  *      - add support for Object Structs
  *******************************************************************************/
 
-#ifndef SRC_MODULES_OPC_UA_OPCUA_LAYER_H_
-#define SRC_MODULES_OPC_UA_OPCUA_LAYER_H_
+#pragma once
 
 #include "forte/cominfra/comlayer.h"
 #include "opcua_helper.h"
@@ -157,4 +156,3 @@ namespace forte::com_infra::opc_ua {
       arch::CSyncObject mRDBufferMutex;
   };
 } // namespace forte::com_infra::opc_ua
-#endif /* SRC_MODULES_OPC_UA_OPCUA_LAYER_H_ */

--- a/com/opc_ua/src/opcua_local_handler.h
+++ b/com/opc_ua/src/opcua_local_handler.h
@@ -21,8 +21,7 @@
  *      - Add support for Object Structs
  *******************************************************************************/
 
-#ifndef SRC_MODULES_OPC_UA_OPCUALOCALHANDLER_H_
-#define SRC_MODULES_OPC_UA_OPCUALOCALHANDLER_H_
+#pragma once
 
 #include "forte/arch/forte_thread.h"
 #include "forte/conn.h"
@@ -794,4 +793,3 @@ namespace forte::com_infra::opc_ua {
       static const char *const mDefaultDescriptionForVariableNodes;
   };
 } // namespace forte::com_infra::opc_ua
-#endif /* SRC_MODULES_OPC_UA_OPCUALOCALHANDLER_H_ */

--- a/com/opc_ua/src/opcua_remote_handler.h
+++ b/com/opc_ua/src/opcua_remote_handler.h
@@ -13,8 +13,7 @@
  *    Martin Melik Merkumians - Change CIEC_STRING to std::string
  *******************************************************************************/
 
-#ifndef SRC_MODULES_OPC_UA_OPCUACLIENTHANDLER_H_
-#define SRC_MODULES_OPC_UA_OPCUACLIENTHANDLER_H_
+#pragma once
 
 #include "forte/arch/forte_thread.h"
 #include "forte/config/forte_config.h"
@@ -309,4 +308,3 @@ namespace forte::com_infra::opc_ua {
       arch::CSyncObject mAllClientListMutex;
   };
 } // namespace forte::com_infra::opc_ua
-#endif /* SRC_MODULES_OPC_UA_OPCUACLIENTHANDLER_H_ */

--- a/com/opc_ua/src/types/forte_localizedtext.h
+++ b/com/opc_ua/src/types/forte_localizedtext.h
@@ -11,8 +11,7 @@
  *   Jose Cabral - initial implementation
  *******************************************************************************/
 
-#ifndef _FORTE_LOCALIZEDTEXT_H_
-#define _FORTE_LOCALIZEDTEXT_H_
+#pragma once
 
 #include "forte/datatypes/forte_struct.h"
 #include "forte/datatypes/forte_string.h"
@@ -44,4 +43,3 @@ namespace forte::com_infra::opc_ua {
       static const StringId scmElementNames[];
   };
 } // namespace forte::com_infra::opc_ua
-#endif //_FORTE_LOCALIZEDTEXT_H_

--- a/com/tsn/tsn_layer.h
+++ b/com/tsn/tsn_layer.h
@@ -10,8 +10,7 @@
  *    Ben Schneider - Initial contribution; vlan and prio configuration to support tsn for pub/sub
  *******************************************************************************/
 
-#ifndef TSN_LAYER_H_
-#define TSN_LAYER_H_
+#pragma once
 
 #include "core/cominfra/ipcomlayer.h"
 
@@ -67,5 +66,3 @@ namespace forte {
     };
   } // namespace com_infra
 } // namespace forte
-
-#endif /* TSN_LAYER_H_ */

--- a/com/xquery/xqueryClientLayer.h
+++ b/com/xquery/xqueryClientLayer.h
@@ -8,8 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-#ifndef SRC_MODULES_XQUERY_XQUERYCLIENT_H_
-#define SRC_MODULES_XQUERY_XQUERYCLIENT_H_
+#pragma once
 
 #include "forte/cominfra/comlayer.h"
 #include "forte/extevhan.h"
@@ -48,5 +47,3 @@ class CXqueryClientLayer : public CComLayer {
     std::string mCommand;
     static const char *scmParameterSeperator;
 };
-
-#endif /* SRC_MODULES_XQUERY_XQUERYCLIENT_H_ */

--- a/com/xquery/xqueryHandler.h
+++ b/com/xquery/xqueryHandler.h
@@ -8,8 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-#ifndef XQUERY_XQUERYHANDLER_H_
-#define XQUERY_XQUERYHANDLER_H_
+#pragma once
 
 #include "forte/extevhan.h"
 #include "forte/arch/forte_thread.h"
@@ -44,5 +43,3 @@ class CXqueryHandler : public CExternalEventHandler,
   protected:
     void run() override;
 };
-
-#endif /* XQUERY_XQUERYHANDLER_H_ */

--- a/core/arch/common/include/forte/arch/forte_fileio.h
+++ b/core/arch/common/include/forte/arch/forte_fileio.h
@@ -10,8 +10,7 @@
   Dirk O. Kaar - initial API and implementation and/or initial documentation
  ************************************************************************************/
 
-#ifndef SRC_ARCH_FORTE_FILEIO_H_
-#define SRC_ARCH_FORTE_FILEIO_H_
+#pragma once
 
 #include <stdio.h>
 
@@ -42,5 +41,3 @@ char *forte_fgets(char *str, int count, void *file);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SRC_ARCH_FORTE_FILEIO_H_ */

--- a/core/arch/common/include/forte/arch/forte_printer.h
+++ b/core/arch/common/include/forte/arch/forte_printer.h
@@ -10,8 +10,7 @@
  *  Jose Cabral - initial API and implementation and/or initial documentation
  *******************************************************************************/
 
-#ifndef SRC_ARCH_FORTE_PRINTER_H_
-#define SRC_ARCH_FORTE_PRINTER_H_
+#pragma once
 
 #include <stddef.h>
 #include <stdarg.h>
@@ -19,5 +18,3 @@
 int forte_snprintf(char *pa_stream, size_t pa_size, const char *pa_format, ...);
 
 int forte_vsnprintf(char *pa_stream, size_t pa_size, const char *pa_format, va_list pa_local_argv);
-
-#endif /* SRC_ARCH_WIN32_FORTE_PRINTER_H_ */

--- a/core/arch/common/src/forte_stringFunctions.h
+++ b/core/arch/common/src/forte_stringFunctions.h
@@ -9,8 +9,7 @@
  * Contributors:
  *  Ketut Kumajaya - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef SRC_ARCH_FORTE_STRINGFUNCTIONS_H_
-#define SRC_ARCH_FORTE_STRINGFUNCTIONS_H_
+#pragma once
 
 #include <string>
 #include <codecvt>
@@ -40,5 +39,3 @@ inline std::string forte_wstringToString(const std::wstring &paVal) {
   dst.resize(to_next - dst.data());
   return dst;
 }
-
-#endif /* SRC_ARCH_FORTE_STRINGFUNCTIONS_H_ */

--- a/core/arch/common/src/utils/timespec_utils.h
+++ b/core/arch/common/src/utils/timespec_utils.h
@@ -11,8 +11,7 @@
  *    - initial API and implementation and/or initial documentation
  *******************************************************************************/
 
-#ifndef SRC_ARCH_UTILS_TIMESPEC_UTILS_H_
-#define SRC_ARCH_UTILS_TIMESPEC_UTILS_H_
+#pragma once
 
 void timespecSub(const struct timespec *const minuend,
                  const struct timespec *const subtrahend,
@@ -21,5 +20,3 @@ void timespecSub(const struct timespec *const minuend,
 void timespecAdd(const struct timespec *const start, const struct timespec *const end, struct timespec *const result);
 
 bool timespecLessThan(const struct timespec *const start, const struct timespec *const end);
-
-#endif /* SRC_ARCH_UTILS_TIMESPEC_UTILS_H_ */

--- a/modules/IEC61131-3/include/forte/iec61131/arithmetic/GEN_ADD_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/arithmetic/GEN_ADD_fbt.h
@@ -18,8 +18,7 @@ class for better handling generic FBs
  *     - add generic readInputData and writeOutputData
  *******************************************************************************/
 
-#ifndef _GEN_ADD_H_
-#define _GEN_ADD_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_any_magnitude_variant.h"
@@ -66,5 +65,3 @@ namespace forte::iec61131::arithmetic {
       ~GEN_ADD() override = default;
   };
 } // namespace forte::iec61131::arithmetic
-
-#endif // _GEN_ADD_H_

--- a/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_AND_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_AND_fbt.h
@@ -17,8 +17,7 @@ class for better handling generic FBs
  *     - refactor for ANY variant
  *******************************************************************************/
 
-#ifndef _GEN_AND_H_
-#define _GEN_AND_H_
+#pragma once
 
 #include "genbitbase_fbt.h"
 
@@ -34,5 +33,3 @@ namespace forte::iec61131::bitwiseOperators {
       ~GEN_AND() override = default;
   };
 } // namespace forte::iec61131::bitwiseOperators
-
-#endif //_GEN_AND_H_

--- a/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_OR_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_OR_fbt.h
@@ -17,8 +17,7 @@ class for better handling generic FBs
  *     - refactor for ANY variant
  *******************************************************************************/
 
-#ifndef _GEN_OR_H_
-#define _GEN_OR_H_
+#pragma once
 
 #include "genbitbase_fbt.h"
 
@@ -34,5 +33,3 @@ namespace forte::iec61131::bitwiseOperators {
       ~GEN_OR() override = default;
   };
 } // namespace forte::iec61131::bitwiseOperators
-
-#endif //_GEN_OR_H_

--- a/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_XOR_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/GEN_XOR_fbt.h
@@ -17,8 +17,7 @@ class for better handling generic FBs
  *     - refactor for ANY variant
  *******************************************************************************/
 
-#ifndef _GEN_XOR_H_
-#define _GEN_XOR_H_
+#pragma once
 
 #include "genbitbase_fbt.h"
 
@@ -34,5 +33,3 @@ namespace forte::iec61131::bitwiseOperators {
       ~GEN_XOR() override = default;
   };
 } // namespace forte::iec61131::bitwiseOperators
-
-#endif //_GEN_XOR_H_

--- a/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/genbitbase_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/bitwiseOperators/genbitbase_fbt.h
@@ -14,8 +14,7 @@
  *     - refactor for ANY variant
  *     - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GENBITBASE_H_
-#define _GENBITBASE_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_any_bit_variant.h"
@@ -67,5 +66,3 @@ namespace forte::iec61131::bitwiseOperators {
       COutDataConnection<CIEC_ANY_BIT_VARIANT> conn_OUT;
   };
 } // namespace forte::iec61131::bitwiseOperators
-
-#endif /* _GENBITBASE_H_ */

--- a/modules/convert/include/forte/eclipse4diac/convert/GEN_STRUCT_DEMUX_fbt.h
+++ b/modules/convert/include/forte/eclipse4diac/convert/GEN_STRUCT_DEMUX_fbt.h
@@ -13,8 +13,7 @@
  *   Martin Jobst - add generic readInputData and writeOutputData
  *   Markus Meingast - add support for configured struct demux instances
  *******************************************************************************/
-#ifndef _GEN_STRUCT_DEMUX_H_
-#define _GEN_STRUCT_DEMUX_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_struct.h"
@@ -72,5 +71,3 @@ namespace forte::eclipse4diac::convert {
       ~GEN_STRUCT_DEMUX() override = default;
   };
 } // namespace forte::eclipse4diac::convert
-
-#endif //_GEN_STRUCT_DEMUX_H_

--- a/modules/convert/include/forte/eclipse4diac/convert/GEN_STRUCT_MUX_fbt.h
+++ b/modules/convert/include/forte/eclipse4diac/convert/GEN_STRUCT_MUX_fbt.h
@@ -12,8 +12,7 @@
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *   Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_STRUCT_MUX_H_
-#define _GEN_STRUCT_MUX_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_struct.h"
@@ -62,5 +61,3 @@ namespace forte::eclipse4diac::convert {
       static StringId getStructNameId(std::string_view paConfigString);
   };
 } // namespace forte::eclipse4diac::convert
-
-#endif //_GEN_STRUCT_MUX_H_

--- a/modules/utils/include/forte/eclipse4diac/utils/GEN_ARRAY2ARRAY_fbt.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/GEN_ARRAY2ARRAY_fbt.h
@@ -16,8 +16,7 @@
 class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_ARRAY2ARRAY_H_
-#define _GEN_ARRAY2ARRAY_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_array_dynamic.h"
@@ -69,5 +68,3 @@ namespace forte::eclipse4diac::utils {
       ~GEN_ARRAY2ARRAY() override = default;
   };
 } // namespace forte::eclipse4diac::utils
-
-#endif //_GEN_ARRAY2ARRAY_H_

--- a/modules/utils/include/forte/eclipse4diac/utils/GEN_ARRAY2VALUES_fbt.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/GEN_ARRAY2VALUES_fbt.h
@@ -16,8 +16,7 @@
 class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_ARRAY2VALUES_H_
-#define _GEN_ARRAY2VALUES_H_
+#pragma once
 
 #include "forte/genfb.h"
 
@@ -74,5 +73,3 @@ namespace forte::eclipse4diac::utils {
       ~GEN_ARRAY2VALUES() override = default;
   };
 } // namespace forte::eclipse4diac::utils
-
-#endif //_GEN_ARRAY2VALUES_H_

--- a/modules/utils/include/forte/eclipse4diac/utils/GEN_CSV_WRITER_fbt.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/GEN_CSV_WRITER_fbt.h
@@ -16,8 +16,7 @@ class for better handling generic FBs
  *   Martin Jobst - add generic readInputData and writeOutputData
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
-#ifndef _GEN_CSV_WRITER_H_
-#define _GEN_CSV_WRITER_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include <stdio.h>
@@ -102,5 +101,3 @@ namespace forte::eclipse4diac::utils {
       static const CIEC_STRING scmFileNotOpened;
   };
 } // namespace forte::eclipse4diac::utils
-
-#endif //_GEN_CSV_WRITER_H_

--- a/modules/utils/include/forte/eclipse4diac/utils/GEN_VALUES2ARRAY_fbt.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/GEN_VALUES2ARRAY_fbt.h
@@ -14,8 +14,7 @@
 class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_VALUES2ARRAY_H_
-#define _GEN_VALUES2ARRAY_H_
+#pragma once
 
 #include "forte/genfb.h"
 
@@ -66,5 +65,3 @@ namespace forte::eclipse4diac::utils {
       ~GEN_VALUES2ARRAY() override = default;
   };
 } // namespace forte::eclipse4diac::utils
-
-#endif //_GEN_VALUES2ARRAY_H_

--- a/stdfblib/events/include/forte/iec61499/events/E_CYCLE_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_CYCLE_fbt.h
@@ -12,8 +12,7 @@
  *     - initial API and implementation and/or initial documentation
  *   Alois Zoitl  - Reworked to new timer handler interface
  *******************************************************************************/
-#ifndef _E_CYCLE_H_
-#define _E_CYCLE_H_
+#pragma once
 
 #include "forte/iec61499/events/timedfb.h"
 
@@ -32,6 +31,5 @@ namespace forte::iec61499::events {
     private:
       void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
   };
-} // namespace forte::iec61499::events
 
-#endif /*E_CYCLE_H_*/
+} // namespace forte::iec61499::events

--- a/stdfblib/events/include/forte/iec61499/events/E_DELAY_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_DELAY_fbt.h
@@ -10,8 +10,7 @@
  *   Alois Zoitl, Gerhard Ebenhofer
  *     - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef _E_DELAY_H_
-#define _E_DELAY_H_
+#pragma once
 
 #include "forte/iec61499/events/timedfb.h"
 
@@ -32,6 +31,5 @@ namespace forte::iec61499::events {
       FORTE_E_DELAY(const StringId paInstanceNameId, CFBContainer &paContainer);
       ~FORTE_E_DELAY() override = default;
   };
-} // namespace forte::iec61499::events
 
-#endif /*E_DELAY_H_*/
+} // namespace forte::iec61499::events

--- a/stdfblib/events/include/forte/iec61499/events/E_RDELAY_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_RDELAY_fbt.h
@@ -9,8 +9,7 @@
  * Contributors:
  *   Alois Zoitl - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef _E_RDELAY_H_
-#define _E_RDELAY_H_
+#pragma once
 
 #include "forte/iec61499/events/timedfb.h"
 
@@ -26,6 +25,5 @@ namespace forte::iec61499::events {
       FORTE_E_RDELAY(const StringId paInstanceNameId, CFBContainer &paContainer);
       ~FORTE_E_RDELAY() override = default;
   };
-} // namespace forte::iec61499::events
 
-#endif /*E_RDELAY_H_*/
+} // namespace forte::iec61499::events

--- a/stdfblib/events/include/forte/iec61499/events/GEN_E_DEMUX_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/GEN_E_DEMUX_fbt.h
@@ -16,8 +16,7 @@
 class for better handling generic FBs
  *    Martin Jobst - add generic readInputData and writeOutputData
  *******************************************************************************/
-#ifndef _GEN_E_DEMUX_H_
-#define _GEN_E_DEMUX_H_
+#pragma once
 
 #include "forte/genfb.h"
 #include "forte/datatypes/forte_uint.h"
@@ -56,4 +55,3 @@ namespace forte::iec61499::events {
       ~GEN_E_DEMUX() override = default;
   };
 } // namespace forte::iec61499::events
-#endif //_GEN_E_DEMUX_H_

--- a/stdfblib/net/include/forte/iec61499/net/GEN_CLIENT_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_CLIENT_fbt.h
@@ -14,8 +14,7 @@
  *   Martin Erich Jobst
  *    - add generic event accessors
  *******************************************************************************/
-#ifndef _GEN_CLIENT_H_
-#define _GEN_CLIENT_H_
+#pragma once
 
 #include "forte/cominfra/commfb.h"
 
@@ -51,6 +50,5 @@ namespace forte::iec61499::net {
         evt_INIT(std::forward<Args>(paArgs)...);
       }
   };
-} // namespace forte::iec61499::net
 
-#endif //_GEN_CLIENT_H_
+} // namespace forte::iec61499::net

--- a/stdfblib/net/include/forte/iec61499/net/GEN_PUBLISH_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_PUBLISH_fbt.h
@@ -14,8 +14,7 @@
  *   Martin Erich Jobst
  *    - add generic event accessors
  *******************************************************************************/
-#ifndef _GEN_PUBLISH_H_
-#define _GEN_PUBLISH_H_
+#pragma once
 
 #include "forte/cominfra/commfb.h"
 
@@ -50,6 +49,5 @@ namespace forte::iec61499::net {
         evt_INIT(std::forward<Args>(paArgs)...);
       }
   };
-} // namespace forte::iec61499::net
 
-#endif //_GEN_PUBLISH_H_
+} // namespace forte::iec61499::net

--- a/stdfblib/net/include/forte/iec61499/net/GEN_PUBL_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_PUBL_fbt.h
@@ -11,8 +11,7 @@
  *   Martin Melik Merkumians
  *    - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef GEN_PUBL_H_
-#define GEN_PUBL_H_
+#pragma once
 
 #include "forte/iec61499/net/GEN_PUBLISH_fbt.h"
 
@@ -35,6 +34,5 @@ namespace forte::iec61499::net {
     private:
       char *getDefaultIDString(const char *paID) override;
   };
-} // namespace forte::iec61499::net
 
-#endif /*GEN_PUBL_H_*/
+} // namespace forte::iec61499::net

--- a/stdfblib/net/include/forte/iec61499/net/GEN_SERVER_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_SERVER_fbt.h
@@ -14,8 +14,7 @@
  *   Martin Erich Jobst
  *    - add generic event accessors
  *******************************************************************************/
-#ifndef _GEN_SERVER_H_
-#define _GEN_SERVER_H_
+#pragma once
 
 #include "forte/cominfra/commfb.h"
 
@@ -50,6 +49,5 @@ namespace forte::iec61499::net {
         evt_INIT(std::forward<Args>(paArgs)...);
       }
   };
-} // namespace forte::iec61499::net
 
-#endif //_GEN_SERVER_H_
+} // namespace forte::iec61499::net

--- a/stdfblib/net/include/forte/iec61499/net/GEN_SUBL_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_SUBL_fbt.h
@@ -11,8 +11,7 @@
  *   Martin Melik Merkumians
  *    - initial API and implementation and/or initial documentation
  *******************************************************************************/
-#ifndef GEN_SUBL_H_
-#define GEN_SUBL_H_
+#pragma once
 
 #include "forte/iec61499/net/GEN_SUBSCRIBE_fbt.h"
 
@@ -35,6 +34,5 @@ namespace forte::iec61499::net {
     private:
       char *getDefaultIDString(const char *paID) override;
   };
-} // namespace forte::iec61499::net
 
-#endif /*GEN_SUBL_H_*/
+} // namespace forte::iec61499::net

--- a/stdfblib/net/include/forte/iec61499/net/GEN_SUBSCRIBE_fbt.h
+++ b/stdfblib/net/include/forte/iec61499/net/GEN_SUBSCRIBE_fbt.h
@@ -14,8 +14,7 @@
  *   Martin Erich Jobst
  *    - add generic event accessors
  *******************************************************************************/
-#ifndef _GEN_SUBSCRIBE_H_
-#define _GEN_SUBSCRIBE_H_
+#pragma once
 
 #include "forte/cominfra/commfb.h"
 
@@ -50,6 +49,5 @@ namespace forte::iec61499::net {
         evt_INIT(std::forward<Args>(paArgs)...);
       }
   };
-} // namespace forte::iec61499::net
 
-#endif //_GEN_SUBSCRIBE_H_
+} // namespace forte::iec61499::net


### PR DESCRIPTION
Replaces header guards in `GEN_STRUCT_DEMUX_fbt.h` and
`GEN_STRUCT_MUX_fbt.h` with `#pragma once` to prevent multiple
inclusions and improve compilation speed.
