### PR TITLE
Adds generic E_MERGE function block

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
+++ b/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(forte-events PUBLIC
         E_TRIG_fbt.h
         GEN_E_DEMUX_fbt.h
         GEN_E_MUX_fbt.h
+        GEN_E_MERGE_fbt.h
         GEN_E_SPLIT_fbt.h
         timedfb.h
 )

--- a/stdfblib/events/include/forte/iec61499/events/GEN_E_MERGE_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/GEN_E_MERGE_fbt.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 HR Agartechnik GmbH
+ * Copyright (c) 2025 HR Agartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,10 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Franz Höpfinger
- *     - implement Generic GEN_E_SPLIT_fbt
- *   Coding-Assistent
- *    - added detailed English comments for consistency
+ *   Coding-Assistent Gemini and Franz Höpfinger
+ *    - implement Generic GEN_E_MERGE_fbt based on GEN_E_SPLIT
  *******************************************************************************/
 
 #pragma once
@@ -22,22 +20,22 @@
 
 namespace forte::iec61499::events {
   /**
-   * @brief A generic function block to split a single event input into multiple event outputs.
+   * @brief A generic function block to merge multiple event inputs into one event output.
    *
-   * The number of event outputs is determined by the instance name, e.g., an instance
-   * named "E_SPLIT_5" will have 5 event outputs (EO1, EO2, ..., EO5).
+   * The number of event inputs is determined by the instance name, e.g., an instance
+   * named "E_MERGE_5" will have 5 event inputs (EI1, EI2, ..., EI5).
    */
-  class GEN_E_SPLIT final : public CGenFunctionBlock<CFunctionBlock> {
-      DECLARE_GENERIC_FIRMWARE_FB(GEN_E_SPLIT)
+  class GEN_E_MERGE final : public CGenFunctionBlock<CFunctionBlock> {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_E_MERGE)
 
     private:
-      /** The ID of the single event input EI. */
-      static const TEventID scmEventEIID = 0;
+      /** The ID of the single event output EO. */
+      static const TEventID scmEventEOID = 0;
 
       /**
-       * @brief Executes when an event is received on the EI port.
+       * @brief Executes when an event is received on any of the EI ports.
        *
-       * It forwards the event to all configured EO ports.
+       * It forwards the event to the single EO port.
        * @param paEIID The ID of the input event that triggered the execution.
        * @param paECET The event chain execution thread.
        */
@@ -50,19 +48,19 @@ namespace forte::iec61499::events {
       /**
        * @brief Creates the interface specification based on the configuration string.
        *
-       * It parses the number from the end of the config string (e.g., "5" from "E_SPLIT_5")
-       * to determine the number of event outputs.
+       * It parses the number from the end of the config string (e.g., "5" from "E_MERGE_5")
+       * to determine the number of event inputs.
        * @param paConfigString The configuration string (typically the FB instance name).
        * @param paInterfaceSpec The interface specification structure to be filled.
        * @return true on success, false otherwise.
        */
       bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
 
-      /** A vector to hold the dynamically generated StringIds for the event output names. */
-      std::vector<StringId> mEventOutputNames;
+      /** A vector to hold the dynamically generated StringIds for the event input names. */
+      std::vector<StringId> mEventInputNames;
 
     public:
-      GEN_E_SPLIT(StringId paInstanceNameId, CFBContainer &paContainer);
+      GEN_E_MERGE(StringId paInstanceNameId, CFBContainer &paContainer);
 
       /** Functions to get data connections, returning nullptr as there are none. */
       CIEC_ANY *getDI(size_t) override;

--- a/stdfblib/events/src/CMakeLists.txt
+++ b/stdfblib/events/src/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(forte-events PRIVATE
         E_TRIG_fbt.cpp
         GEN_E_DEMUX_fbt.cpp
         GEN_E_MUX_fbt.cpp
+        GEN_E_MERGE_fbt.cpp
         GEN_E_SPLIT_fbt.cpp
         timedfb.cpp
 )

--- a/stdfblib/events/src/GEN_E_MERGE_fbt.cpp
+++ b/stdfblib/events/src/GEN_E_MERGE_fbt.cpp
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2025 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Coding-Assistent Gemini and Franz Höpfinger
+ *    - implement Generic GEN_E_MERGE_fbt based on GEN_E_SPLIT
+ *******************************************************************************/
+
+#include "forte/iec61499/events/GEN_E_MERGE_fbt.h"
+#include "forte/util/string_utils.h"
+
+using namespace forte::literals;
+
+namespace forte::iec61499::events {
+  // Registers the generic FB with the name "GEN_E_MERGE"
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_E_MERGE, "iec61499::events::GEN_E_MERGE"_STRID)
+
+  namespace {
+    // Defines the constant name for the single event output.
+    const auto cEventOutputNames = std::array{"EO"_STRID};
+  } // namespace
+
+  GEN_E_MERGE::GEN_E_MERGE(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CGenFunctionBlock<CFunctionBlock>(paContainer, paInstanceNameId) {};
+
+  void GEN_E_MERGE::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    // Any event input triggers the single event output.
+    // We don't need to check which input it was (paEIID is unused).
+    sendOutputEvent(scmEventEOID, paECET);
+  }
+
+  void GEN_E_MERGE::readInputData(TEventID) {
+    // Nothing to do, as there are no data inputs.
+  }
+
+  void GEN_E_MERGE::writeOutputData(TEventID) {
+    // Nothing to do, as there are no data outputs.
+  }
+
+  bool GEN_E_MERGE::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    // Find the last underscore in the name, e.g., "E_MERGE_5".
+    const char *acPos = strrchr(paConfigString, '_');
+
+    if (nullptr != acPos) {
+      ++acPos; // Move pointer to the character after the underscore.
+
+      // Convert the numeric part to an integer. This is the number of event inputs.
+      size_t numEIs = static_cast<TEventID>(util::strtoul(acPos, nullptr, 10));
+
+      // Check if the number of inputs is within the valid range.
+      if (numEIs < scmMaxInterfaceEvents && numEIs >= 2) {
+        // Use the utility function to generate names like "EI1", "EI2", etc.
+        generateGenericInterfacePointNameArray("EI", mEventInputNames, numEIs);
+
+        // Assign the generated input names and the constant output name to the interface.
+        paInterfaceSpec.mEINames = mEventInputNames;
+        paInterfaceSpec.mEONames = cEventOutputNames;
+        return true; // Success
+      } else {
+        // Log errors if the number is out of bounds.
+        if (numEIs >= scmMaxInterfaceEvents) {
+          DEVLOG_ERROR("Cannot configure FB-Instance E_MERGE_%d. Number of event inputs exceeds maximum of %d.\n",
+                       numEIs, CFunctionBlock::scmMaxInterfaceEvents);
+        } else {
+          DEVLOG_ERROR("Cannot configure FB-Instance E_MERGE_%d. Number of event inputs smaller than minimum of 2.\n",
+                       numEIs);
+        }
+      }
+    }
+    return false; // Failure
+  }
+
+  // The following functions return nullptr because this FB does not handle data.
+  CIEC_ANY *GEN_E_MERGE::getDI(size_t) {
+    return nullptr;
+  }
+
+  CIEC_ANY *GEN_E_MERGE::getDO(size_t) {
+    return nullptr;
+  }
+
+  CDataConnection **GEN_E_MERGE::getDIConUnchecked(TPortId) {
+    return nullptr;
+  }
+
+  CDataConnection *GEN_E_MERGE::getDOConUnchecked(TPortId) {
+    return nullptr;
+  }
+} // namespace forte::iec61499::events

--- a/stdfblib/events/src/GEN_E_SPLIT_fbt.cpp
+++ b/stdfblib/events/src/GEN_E_SPLIT_fbt.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 HR Agartechnik GmbH
+ * Copyright (c) 2024, 2025 HR Agartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +10,8 @@
  * Contributors:
  *   Franz Höpfinger
  *     - implement Generic GEN_E_SPLIT_fbt
+ *   Coding-Assistent
+ *    - added detailed English comments for consistency
  *******************************************************************************/
 
 #include "forte/iec61499/events/GEN_E_SPLIT_fbt.h"
@@ -18,18 +20,22 @@
 using namespace forte::literals;
 
 namespace forte::iec61499::events {
+  // Registers the generic FB with the name "GEN_E_SPLIT" in the FORTE type library.
   DEFINE_GENERIC_FIRMWARE_FB(GEN_E_SPLIT, "iec61499::events::GEN_E_SPLIT"_STRID)
 
   namespace {
+    // Defines the constant name for the single event input.
     const auto cEventInputNames = std::array{"EI"_STRID};
-  }
+  } // namespace
 
   GEN_E_SPLIT::GEN_E_SPLIT(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CGenFunctionBlock<CFunctionBlock>(paContainer, paInstanceNameId) {};
 
   void GEN_E_SPLIT::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    // Check if the received event is the expected input event 'EI'.
     switch (paEIID) {
       case scmEventEIID:
+        // If it is, iterate through all configured event outputs and send an event.
         for (TEventID i = 0; i < getFBInterfaceSpec().getNumEOs(); ++i) {
           sendOutputEvent(i, paECET);
         }
@@ -38,28 +44,34 @@ namespace forte::iec61499::events {
   }
 
   void GEN_E_SPLIT::readInputData(TEventID) {
-    // nothing to do
+    // Nothing to do, as there are no data inputs.
   }
 
   void GEN_E_SPLIT::writeOutputData(TEventID) {
-    // nothing to do
+    // Nothing to do, as there are no data outputs.
   }
 
   bool GEN_E_SPLIT::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    // Find the last underscore in the name, e.g., "E_SPLIT_5".
     const char *acPos = strrchr(paConfigString, '_');
 
     if (nullptr != acPos) {
-      ++acPos; // move after underscore
-      // we have an underscore
+      ++acPos; // Move pointer to the character after the underscore.
+
+      // Convert the numeric part to an integer. This is the number of event outputs.
       size_t numEOs = static_cast<TEventID>(util::strtoul(acPos, nullptr, 10));
 
+      // Check if the number of outputs is within the valid range.
       if (numEOs < scmMaxInterfaceEvents && numEOs >= 2) {
+        // Use the utility function to generate names like "EO1", "EO2", etc.
         generateGenericInterfacePointNameArray("EO", mEventOutputNames, numEOs);
 
+        // Assign the constant input name and the generated output names to the interface.
         paInterfaceSpec.mEINames = cEventInputNames;
         paInterfaceSpec.mEONames = mEventOutputNames;
-        return true;
+        return true; // Success
       } else {
+        // Log errors if the number is out of bounds.
         if (numEOs >= scmMaxInterfaceEvents) {
           DEVLOG_ERROR("Cannot configure FB-Instance E_SPLIT_%d. Number of event outputs exceeds maximum of %d.\n",
                        numEOs, CFunctionBlock::scmMaxInterfaceEvents);
@@ -69,9 +81,10 @@ namespace forte::iec61499::events {
         }
       }
     }
-    return false;
+    return false; // Failure
   }
 
+  // The following functions return nullptr because this FB does not handle data.
   CIEC_ANY *GEN_E_SPLIT::getDI(size_t) {
     return nullptr;
   }


### PR DESCRIPTION
Implements a generic event merge function block (GEN_E_MERGE) that
merges multiple event inputs into a single event output. The number
of inputs is configurable via the instance name (e.g., E_MERGE_5).

This new FB complements the existing E_SPLIT FB, providing a
complete set of event manipulation tools.
