### PR TITLE
Fixes MUX/DEMUX type lookup

### DIFF
--- a/core/src/typelib.cpp
+++ b/core/src/typelib.cpp
@@ -28,6 +28,12 @@ using namespace std::string_literals;
 
 namespace forte {
   namespace {
+
+    StringId demux = "eclipse4diac::convert::STRUCT_DEMUX"_STRID;
+    StringId demux_1 = "eclipse4diac::convert::STRUCT_DEMUX_1"_STRID;
+    StringId mux = "eclipse4diac::convert::STRUCT_MUX"_STRID;
+    StringId mux_1 = "eclipse4diac::convert::STRUCT_MUX_1"_STRID;
+
     std::vector<CFBTypeEntry *> &getFBTypeLib() {
       static std::vector<CFBTypeEntry *> *fbTypeLib = new std::vector<CFBTypeEntry *>();
       return *fbTypeLib;
@@ -216,7 +222,20 @@ namespace forte {
     }
 
     template<typename T>
-    T *findGenericTypeEntry(std::vector<T *> &vec, const StringId paTypeNameId) {
+    T *findGenericTypeEntry(std::vector<T *> &vec, const StringId paTypeNameId_ro) {
+
+      StringId paTypeNameId = paTypeNameId_ro;
+
+      if(paTypeNameId == mux)
+      {
+        paTypeNameId = mux_1;
+      }
+
+      if(paTypeNameId == demux)
+      {
+        paTypeNameId = demux_1;
+      }
+
       const std::size_t underScore = getFirstNonTypeNameUnderscorePos(paTypeNameId);
       if (underScore == std::string_view::npos) {
         // We found no underscore in the type name, so it can't be a generic type


### PR DESCRIPTION
Corrects the type lookup for MUX and DEMUX function blocks.

The original type lookup logic didn't properly resolve the correct type when using the base type names. This change adds a mapping to ensure that the lookup resolves to the correct derived type (STRUCT_MUX_1, STRUCT_DEMUX_1) when using the base type names (STRUCT_MUX, STRUCT_DEMUX).

This hotfix is necessary to ensure proper functionality of these function blocks.
