### PR TITLE
Add explicit --no-as-needed linker flag on Posix

### DIFF
--- a/core/arch/posix/CMakeLists.txt
+++ b/core/arch/posix/CMakeLists.txt
@@ -22,7 +22,10 @@ target_link_libraries(forte-core PUBLIC
 
 set(FORTE_POSIX_GENERATE_MAP_FILE FALSE CACHE BOOL "Enable the generation of map files")
 mark_as_advanced(FORTE_POSIX_GENERATE_MAP_FILE)
-target_link_options(forte-core PUBLIC $<$<BOOL:${FORTE_POSIX_GENERATE_MAP_FILE}>:-Wl,-M,-Map,forte.map,-cref>)
+target_link_options(forte-core PUBLIC
+        LINKER:--no-as-needed # restore default behavior of including "unused" shared library dependencies on Ubuntu/Debian
+        $<$<BOOL:${FORTE_POSIX_GENERATE_MAP_FILE}>:-Wl,-M,-Map,forte.map,-cref>
+)
 
 add_subdirectory(include)
 add_subdirectory(src)


### PR DESCRIPTION
This is needed to restore the default behavior of including "unused" shared library dependencies on Ubuntu/Debian.