### PR TITLE
Fix query for generic type entries without configuration suffix

### DIFF
--- a/core/src/typelib.cpp
+++ b/core/src/typelib.cpp
@@ -217,10 +217,10 @@ namespace forte {
 
     template<typename T>
     T *findGenericTypeEntry(std::vector<T *> &vec, const StringId paTypeNameId) {
-      const std::size_t underScore = getFirstNonTypeNameUnderscorePos(paTypeNameId);
+      std::size_t underScore = getFirstNonTypeNameUnderscorePos(paTypeNameId);
       if (underScore == std::string_view::npos) {
-        // We found no underscore in the type name, so it can't be a generic type
-        return nullptr;
+        // We found no underscore in the type name, so attempt the full name for a match
+        underScore = paTypeNameId.size();
       }
 
       std::string genFBName;


### PR DESCRIPTION
The `QUERY` for configurable types, such as `STRUCT_(DE)MUX`, does not include the type suffix. This attempts to find an entry based on the full type name if no suffix exists instead of aborting prematurely.