### PR TITLE
Enables ESP32 module and integrates sdkconfig

### DIFF
--- a/modules/esp32/CMakeLists.txt
+++ b/modules/esp32/CMakeLists.txt
@@ -14,22 +14,41 @@
 # FORTE_MODULE_ESP32  integration.
 # ############################################################################
 
-# option to enable OPC UA with cmake
+# option to enable ESP32 with cmake
 option(FORTE_MODULE_ESP32 "Interacting with GPIOs of esp32 devices via gpio" OFF)
 
 if (NOT FORTE_MODULE_ESP32)
     return()
 endif ()
 
-set(ESP32_SDK_CONFIG_DIR
-    ""
-    CACHE PATH "Path to the sdkconfig file to be used for this FORTE build"
-)
-
-if (NOT IS_DIRECTORY ${ESP32_SDK_CONFIG_DIR})
-    message(FATAL_ERROR "The ESP32_SDK_CONFIG_DIR (" ${ESP32_SDK_CONFIG_DIR}
+if (NOT IS_DIRECTORY ${CMAKE_SOURCE_DIR}/${ESP32_SDK_CONFIG_DIR})
+    message(FATAL_ERROR "The ESP32_SDK_CONFIG_DIR (" ${CMAKE_SOURCE_DIR}/${ESP32_SDK_CONFIG_DIR}
                         ") does not exist or is not set"
     )
 endif ()
 
-target_include_directories(forte-esp32 PUBLIC ${ESP32_SDK_CONFIG_DIR})
+
+
+add_library(forte-esp32
+					${CMAKE_SOURCE_DIR}/${ESP32_SDK_CONFIG_DIR}/sdkconfig.h)
+target_link_libraries(forte-esp32 PUBLIC forte-core)
+target_link_libraries(forte PUBLIC forte-esp32)
+
+
+target_sources(forte-esp32 PUBLIC
+        FILE_SET HEADERS
+        BASE_DIRS ${CMAKE_SOURCE_DIR}/${ESP32_SDK_CONFIG_DIR}
+)
+
+target_include_directories(
+	forte-core
+	PUBLIC 
+	$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/${ESP32_SDK_CONFIG_DIR}> 
+	$<INSTALL_INTERFACE:include>
+	)
+
+
+
+
+install(TARGETS forte-esp32 EXPORT forte-export FILE_SET HEADERS)
+


### PR DESCRIPTION
Configures the ESP32 module, allowing interaction with ESP32
devices through GPIO.

It includes the sdkconfig.h file from the specified
ESP32_SDK_CONFIG_DIR to configure the build, and establishes
the necessary library dependencies and include directories.
