### PR TITLE
com/modbus: do not add invalid compiler search paths

### DIFF
--- a/com/modbus/CMakeLists.txt
+++ b/com/modbus/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(forte-com-modbus
 target_link_libraries(forte-com-modbus PUBLIC forte-core)
 target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-com-modbus,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-com-modbus>>)
 
-target_include_directories(forte-com-modbus PRIVATE ${FORTE_COM_MODBUS_LIB_DIR}/include/modbus)
-target_link_directories(forte-com-modbus PUBLIC ${FORTE_COM_MODBUS_LIB_DIR}/lib)
+if (FORTE_COM_MODBUS_LIB_DIR)
+    target_include_directories(forte-com-modbus PRIVATE ${FORTE_COM_MODBUS_LIB_DIR}/include/modbus)
+    target_link_directories(forte-com-modbus PUBLIC ${FORTE_COM_MODBUS_LIB_DIR}/lib)
+endif ()
 target_link_libraries(forte-com-modbus PRIVATE modbus)


### PR DESCRIPTION
if unset, this adds  `/lib` to the search path, which may result in invalid libaries being linked in cross-compile scenarios