### PR TITLE
core: small fixes for clang compatibility

### DIFF
--- a/core/arch/posix/src/com/impl/tcp_listen.cpp
+++ b/core/arch/posix/src/com/impl/tcp_listen.cpp
@@ -14,6 +14,7 @@
 #include "tcp_listen.h"
 #include "net.h"
 
+#include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 

--- a/core/src/datatypes/CMakeLists.txt
+++ b/core/src/datatypes/CMakeLists.txt
@@ -71,4 +71,10 @@ target_sources(forte-core PRIVATE
         unicode_utils.h
 )
 
+# std::codecvt<char16_t, char, std::mbstate_t> in forte_wstring.h is
+# deprecated, and clang libc++ loudly complains about this fact. There is no
+# standardised replacement, not even planned, so we can't upgrade to a clean
+# API. Just silence the useless warnings for now.
+target_compile_definitions(forte-core PUBLIC _LIBCPP_DISABLE_DEPRECATION_WARNINGS)
+
 add_subdirectory(convert)


### PR DESCRIPTION
`unistd.h` is needed for `::close()`

The other change has a comment for future reference. The API in question might get removed in C++26, creating a future problem, but for now just make sure that clang users are not overwhelmed by tens of thousands of warnings.