### PR TITLE
modules: add explicit error messages for code that is currently not expected to be working

### DIFF
--- a/com/xquery/CMakeLists.txt
+++ b/com/xquery/CMakeLists.txt
@@ -25,6 +25,8 @@ set(FORTE_BASEX_SRC_DIR
         CACHE PATH "Path to BaseX library directory"
 )
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 add_library(forte-com-xquery
         $<$<BOOL:${FORTE_COM_XqueryClient}>:xqueryClientLayer.cpp>
         $<$<BOOL:${FORTE_COM_XqueryClient}>:xqueryClientLayer.h>

--- a/modules/ads/CMakeLists.txt
+++ b/modules/ads/CMakeLists.txt
@@ -14,6 +14,9 @@ option(FORTE_MODULE_ADS "Interacting with ADS servers" OFF)
 if (NOT FORTE_MODULE_ADS)
   return()
 endif ()
+
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 set(FORTE_MODULE_ADS_PI_ADS_ROOT
     ""
     CACHE PATH "Path to ADS library source root directory"

--- a/modules/arrowhead/CMakeLists.txt
+++ b/modules/arrowhead/CMakeLists.txt
@@ -18,6 +18,8 @@ if (NOT FORTE_MODULE_Arrowhead)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 add_library(forte-arrowhead)
 target_link_libraries(forte-arrowhead PUBLIC forte-core)
 target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-arrowhead,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-arrowhead>>)

--- a/modules/conmeleon_c1/CMakeLists.txt
+++ b/modules/conmeleon_c1/CMakeLists.txt
@@ -19,6 +19,8 @@ if (NOT FORTE_MODULE_CONMELEON_C1)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 message(CHECK_START
         "Module Conmeleon C1 is deprecated and may be removed in future releases"
 )

--- a/modules/i2c_dev/CMakeLists.txt
+++ b/modules/i2c_dev/CMakeLists.txt
@@ -19,6 +19,8 @@ if (NOT FORTE_MODULE_I2C_Dev)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 # ############################################################################
 # i2c-dev
 # ############################################################################

--- a/modules/lms_ev3/CMakeLists.txt
+++ b/modules/lms_ev3/CMakeLists.txt
@@ -19,6 +19,8 @@ if (NOT FORTE_MODULE_LMS_EV3)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 # ############################################################################
 # LMS_EV3
 # ############################################################################

--- a/modules/mlpi/CMakeLists.txt
+++ b/modules/mlpi/CMakeLists.txt
@@ -22,6 +22,8 @@ if (NOT FORTE_MODULE_MLPI)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 set(FORTE_COM_MLPI_DIR
     ""
     CACHE PATH "Path to MLPI src directory"

--- a/modules/odroid/CMakeLists.txt
+++ b/modules/odroid/CMakeLists.txt
@@ -19,6 +19,8 @@ if (NOT FORTE_MODULE_Odroid)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 # ############################################################################
 # SysFs
 # ############################################################################

--- a/modules/piface/CMakeLists.txt
+++ b/modules/piface/CMakeLists.txt
@@ -22,6 +22,8 @@ if (NOT FORTE_MODULE_PiFace)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 forte_set_process_interface("PiFace" IX QX)
 add_library(forte-piface
             processinterface.h processinterface.cpp

--- a/modules/raspberry_sps/CMakeLists.txt
+++ b/modules/raspberry_sps/CMakeLists.txt
@@ -19,6 +19,8 @@ if (NOT FORTE_MODULE_Raspberry_SPS)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 # ############################################################################
 # i2c-dev
 # ############################################################################

--- a/modules/umic/CMakeLists.txt
+++ b/modules/umic/CMakeLists.txt
@@ -19,6 +19,8 @@ if (NOT FORTE_MODULE_uMIC)
     return()
 endif ()
 
+message(FATAL_ERROR "This module has not yet been ported to 4diac FORTE 3.0")
+
 # ############################################################################
 # uMIC
 # ############################################################################


### PR DESCRIPTION
Since we won't be able to port everything for the initial 3.0 release, let unsupported modules fail early. Otherwise, users get obscure error messages.