### PR TITLE
Allow to use installed modbus lib

### DIFF
--- a/com/modbus/CMakeLists.txt
+++ b/com/modbus/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(forte-com-modbus PUBLIC forte-core)
 target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-com-modbus,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-com-modbus>>)
 
 if (FORTE_COM_MODBUS_LIB_DIR)
-    target_include_directories(forte-com-modbus PRIVATE ${FORTE_COM_MODBUS_LIB_DIR}/include/modbus)
+    target_include_directories(forte-com-modbus PRIVATE ${FORTE_COM_MODBUS_LIB_DIR}/include)
     target_link_directories(forte-com-modbus PUBLIC ${FORTE_COM_MODBUS_LIB_DIR}/lib)
 endif ()
 target_link_libraries(forte-com-modbus PRIVATE modbus)

--- a/com/modbus/modbusconnection.h
+++ b/com/modbus/modbusconnection.h
@@ -13,7 +13,7 @@
  *******************************************************************************/
 #pragma once
 
-#include <modbus.h>
+#include <modbus/modbus.h>
 #include "forte/arch/forte_thread.h"
 #include "modbushandler.h"
 #include "modbusioblock.h"

--- a/com/modbus/modbuspoll.cpp
+++ b/com/modbus/modbuspoll.cpp
@@ -14,7 +14,7 @@
 #include "modbuspoll.h"
 #include "modbushandler.h"
 #include "modbusioblock.h"
-#include <modbus.h>
+#include <modbus/modbus.h>
 
 namespace forte::com_infra::modbus {
 

--- a/com/modbus/modbustimedevent.h
+++ b/com/modbus/modbustimedevent.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "forte/datatype.h"
-#include <modbus.h>
+#include <modbus/modbus.h>
 
 namespace forte::com_infra::modbus {
 


### PR DESCRIPTION
By adding the include prefix to the C++ files one can also easily use pre-installed modbus libraries.