### PR TITLE
Better use the existing termios settings

### DIFF
--- a/core/arch/posix/src/posixsercommlayer.cpp
+++ b/core/arch/posix/src/posixsercommlayer.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 ACIN, fortiss GmbH
+ * Copyright (c) 2012, 2025 ACIN, fortiss GmbH, Johannes Kepler University Linz
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -12,6 +13,7 @@
 #include "posixsercommlayer.h"
 #include "forte/util/devlog.h"
 #include "forte/cominfra/commfb.h"
+#include <termios.h>
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
@@ -25,9 +27,12 @@
 using namespace forte::literals;
 
 namespace forte::arch {
+
   namespace {
+
     [[maybe_unused]] const com_infra::ComLayerManager::EntryImpl<CPosixSerCommLayer> entry("ser"_STRID);
-  }
+
+  } // namespace
 
   CPosixSerCommLayer::CPosixSerCommLayer(CComLayer *paUpperLayer, com_infra::CBaseCommFB *paFB) :
       CSerialComLayerBase(paUpperLayer, paFB) {
@@ -82,117 +87,90 @@ namespace forte::arch {
   com_infra::EComResponse CPosixSerCommLayer::openSerialConnection(
       const SSerialParameters &paSerialParameters,
       CSerialComLayerBase<FORTE_SOCKET_TYPE, FORTE_INVALID_SOCKET>::TSerialHandleType *paHandleResult) {
-    com_infra::EComResponse eRetVal = com_infra::e_ProcessDataNoSocket;
 
     // as first shot take the serial interface device as param (e.g., /dev/ttyS0 )
     CFDSelectHandler::TFileDescriptor fileDescriptor =
         open(paSerialParameters.interfaceName.c_str(), O_RDWR | O_NOCTTY);
 
-    if (CFDSelectHandler::scmInvalidFileDescriptor != fileDescriptor) {
-      tcgetattr(fileDescriptor, &mOldTIO);
-      struct termios stNewTIO;
-      memset(&stNewTIO, 0, sizeof(stNewTIO));
-
-      stNewTIO.c_line = mOldTIO.c_line;
-
-      switch (paSerialParameters.baudRate) {
-        case e50: stNewTIO.c_cflag |= B50; break;
-        case e75: stNewTIO.c_cflag |= B75; break;
-        case e110: stNewTIO.c_cflag |= B110; break;
-        case e134C5: stNewTIO.c_cflag |= B134; break;
-        case e150: stNewTIO.c_cflag |= B150; break;
-        case e200: stNewTIO.c_cflag |= B200; break;
-        case e300: stNewTIO.c_cflag |= B300; break;
-        case e600: stNewTIO.c_cflag |= B600; break;
-        case e1200: stNewTIO.c_cflag |= B1200; break;
-        case e1800: stNewTIO.c_cflag |= B1800; break;
-        case e2400: stNewTIO.c_cflag |= B2400; break;
-        case e4800: stNewTIO.c_cflag |= B4800; break;
-        case e9600: stNewTIO.c_cflag |= B9600; break;
-        case e19200: stNewTIO.c_cflag |= B19200; break;
-        case e38400: stNewTIO.c_cflag |= B38400; break;
-        case e57600: stNewTIO.c_cflag |= B57600; break;
-        case e115200: stNewTIO.c_cflag |= B115200; break;
-        case e1000000: stNewTIO.c_cflag |= B1000000; break;
-        default: return com_infra::e_InitInvalidId; break;
-      }
-
-      cfsetispeed(&stNewTIO, cfgetispeed(&mOldTIO));
-      cfsetospeed(&stNewTIO, cfgetospeed(&mOldTIO));
-
-      switch (paSerialParameters.byteSize) {
-        case e5: stNewTIO.c_cflag |= CS5; break;
-        case e6: stNewTIO.c_cflag |= CS6; break;
-        case e7: stNewTIO.c_cflag |= CS7; break;
-        case e8: stNewTIO.c_cflag |= CS8; break;
-        default: return com_infra::e_InitInvalidId; break;
-      }
-
-      switch (paSerialParameters.stopBits) {
-        case eOneBit: stNewTIO.c_cflag &= ~CSTOPB; break;
-        case eTwoBits: stNewTIO.c_cflag |= CSTOPB; break;
-        default: return com_infra::e_InitInvalidId; break;
-      }
-
-      switch (paSerialParameters.parity) {
-        case eNoParity: stNewTIO.c_cflag &= ~(PARENB | PARODD | CMSPAR); break;
-        case eODD: stNewTIO.c_cflag |= PARENB | PARODD; break;
-        case eEven:
-          stNewTIO.c_cflag |= PARENB;
-          stNewTIO.c_cflag &= ~PARODD;
-          break;
-        default: return com_infra::e_InitInvalidId; break;
-      }
-
-      stNewTIO.c_cflag &= ~CRTSCTS; // no hardware flow control
-
-      stNewTIO.c_cflag |= (CLOCAL | CREAD); /* Local line - do not change "owner" of port |  Enable receiver*/
-
-      stNewTIO.c_iflag = mOldTIO.c_iflag;
-      stNewTIO.c_iflag |= IGNPAR; /* Map CR to NL | IGNPAR (was here before)  Ignore parity error. TODO: Should we
-                                     delete this? It was on the old code*/
-      ;
-      stNewTIO.c_iflag &= ~(IXON | IXOFF | IXANY); // Turn off s/w flow ctrl
-      stNewTIO.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | INPCK |
-                            IUCLC); // Disable any special handling of received bytes
-
-      stNewTIO.c_oflag = mOldTIO.c_oflag;
-      stNewTIO.c_oflag &= ~(OPOST | ONLCR | OCRNL);
-
-      stNewTIO.c_lflag = mOldTIO.c_lflag;
-      stNewTIO.c_lflag &= ~(ICANON | ECHO | ECHOE | ECHONL | ECHOK | ISIG | IEXTEN | CRTSCTS);
-
-      stNewTIO.c_cc[VINTR] = _POSIX_VDISABLE; /* Ctrl-c */
-      stNewTIO.c_cc[VQUIT] = _POSIX_VDISABLE; /* Ctrl-\ */
-      stNewTIO.c_cc[VERASE] = _POSIX_VDISABLE; /* del */
-      stNewTIO.c_cc[VKILL] = _POSIX_VDISABLE; /* @ */
-      stNewTIO.c_cc[VEOF] = _POSIX_VDISABLE; /* Ctrl-d */
-      stNewTIO.c_cc[VTIME] = 10; /* inter-character timer unused */
-      stNewTIO.c_cc[VMIN] = 1; /* blocking read until 1 character arrives */
-      stNewTIO.c_cc[VSWTC] = _POSIX_VDISABLE; /* '\0' */
-      stNewTIO.c_cc[VSTART] = _POSIX_VDISABLE; /* Ctrl-q */
-      stNewTIO.c_cc[VSTOP] = _POSIX_VDISABLE; /* Ctrl-s */
-      stNewTIO.c_cc[VSUSP] = _POSIX_VDISABLE; /* Ctrl-z */
-      stNewTIO.c_cc[VEOL] = _POSIX_VDISABLE; /* '\0' */
-      stNewTIO.c_cc[VREPRINT] = _POSIX_VDISABLE; /* Ctrl-r */
-      stNewTIO.c_cc[VDISCARD] = _POSIX_VDISABLE; /* Ctrl-u */
-      stNewTIO.c_cc[VWERASE] = _POSIX_VDISABLE; /* Ctrl-w */
-      stNewTIO.c_cc[VLNEXT] = _POSIX_VDISABLE; /* Ctrl-v */
-      stNewTIO.c_cc[VEOL2] = _POSIX_VDISABLE; /* '\0' */
-
-      tcflush(fileDescriptor, TCIFLUSH);
-      tcsetattr(fileDescriptor, TCSANOW, &stNewTIO);
-
-      getExtEvHandler<CFDSelectHandler>().addComCallback(fileDescriptor, this);
-      *paHandleResult = fileDescriptor;
-      eRetVal = com_infra::e_InitOk;
-
-    } else {
-      eRetVal = com_infra::e_ProcessDataInvalidObject;
+    if (fileDescriptor == CFDSelectHandler::scmInvalidFileDescriptor) {
       DEVLOG_ERROR("CSerCommLayer: open failed: %s\n", strerror(errno));
+      return com_infra::e_ProcessDataInvalidObject;
     }
 
-    return eRetVal;
+    tcgetattr(fileDescriptor, &mOldTIO);
+    struct termios newTIO = mOldTIO;
+    newTIO.c_cflag = 0;
+
+    speed_t speed = getSpeed(paSerialParameters);
+    if (speed == B0) {
+      return com_infra::e_InitInvalidId;
+    }
+    cfsetispeed(&newTIO, speed);
+    cfsetospeed(&newTIO, speed);
+
+    switch (paSerialParameters.byteSize) {
+      case e5: newTIO.c_cflag |= CS5; break;
+      case e6: newTIO.c_cflag |= CS6; break;
+      case e7: newTIO.c_cflag |= CS7; break;
+      case e8: newTIO.c_cflag |= CS8; break;
+      default: return com_infra::e_InitInvalidId; break;
+    }
+
+    switch (paSerialParameters.stopBits) {
+      case eOneBit: newTIO.c_cflag &= ~CSTOPB; break;
+      case eTwoBits: newTIO.c_cflag |= CSTOPB; break;
+      default: return com_infra::e_InitInvalidId; break;
+    }
+
+    switch (paSerialParameters.parity) {
+      case eNoParity: newTIO.c_cflag &= ~(PARENB | PARODD | CMSPAR); break;
+      case eODD: newTIO.c_cflag |= PARENB | PARODD; break;
+      case eEven:
+        newTIO.c_cflag |= PARENB;
+        newTIO.c_cflag &= ~PARODD;
+        break;
+      default: return com_infra::e_InitInvalidId; break;
+    }
+
+    newTIO.c_cflag &= ~CRTSCTS; // no hardware flow control
+
+    newTIO.c_cflag |= (CLOCAL | CREAD); /* Local line - do not change "owner" of port |  Enable receiver*/
+
+    newTIO.c_iflag |= IGNPAR; /* Map CR to NL | IGNPAR (was here before)  Ignore parity error. TODO: Should we
+                                   delete this? It was on the old code*/
+
+    newTIO.c_iflag &= ~(IXON | IXOFF | IXANY); // Turn off s/w flow ctrl
+    newTIO.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | INPCK |
+                        IUCLC); // Disable any special handling of received bytes
+
+    newTIO.c_oflag &= ~(OPOST | ONLCR | OCRNL);
+
+    newTIO.c_lflag &= ~(ICANON | ECHO | ECHOE | ECHONL | ECHOK | ISIG | IEXTEN | CRTSCTS);
+
+    newTIO.c_cc[VINTR] = _POSIX_VDISABLE; /* Ctrl-c */
+    newTIO.c_cc[VQUIT] = _POSIX_VDISABLE; /* Ctrl-\ */
+    newTIO.c_cc[VERASE] = _POSIX_VDISABLE; /* del */
+    newTIO.c_cc[VKILL] = _POSIX_VDISABLE; /* @ */
+    newTIO.c_cc[VEOF] = _POSIX_VDISABLE; /* Ctrl-d */
+    newTIO.c_cc[VTIME] = 10; /* inter-character timer unused */
+    newTIO.c_cc[VMIN] = 1; /* blocking read until 1 character arrives */
+    newTIO.c_cc[VSWTC] = _POSIX_VDISABLE; /* '\0' */
+    newTIO.c_cc[VSTART] = _POSIX_VDISABLE; /* Ctrl-q */
+    newTIO.c_cc[VSTOP] = _POSIX_VDISABLE; /* Ctrl-s */
+    newTIO.c_cc[VSUSP] = _POSIX_VDISABLE; /* Ctrl-z */
+    newTIO.c_cc[VEOL] = _POSIX_VDISABLE; /* '\0' */
+    newTIO.c_cc[VREPRINT] = _POSIX_VDISABLE; /* Ctrl-r */
+    newTIO.c_cc[VDISCARD] = _POSIX_VDISABLE; /* Ctrl-u */
+    newTIO.c_cc[VWERASE] = _POSIX_VDISABLE; /* Ctrl-w */
+    newTIO.c_cc[VLNEXT] = _POSIX_VDISABLE; /* Ctrl-v */
+    newTIO.c_cc[VEOL2] = _POSIX_VDISABLE; /* '\0' */
+
+    tcflush(fileDescriptor, TCIFLUSH);
+    tcsetattr(fileDescriptor, TCSANOW, &newTIO);
+
+    getExtEvHandler<CFDSelectHandler>().addComCallback(fileDescriptor, this);
+    *paHandleResult = fileDescriptor;
+    return com_infra::e_InitOk;
   }
 
   void CPosixSerCommLayer::closeConnection() {
@@ -202,5 +180,31 @@ namespace forte::arch {
       tcsetattr(fileDescriptor, TCSANOW, &mOldTIO);
       close(fileDescriptor);
     }
+  }
+
+  speed_t CPosixSerCommLayer::getSpeed(const SSerialParameters &paSerialParameters) {
+    speed_t speed;
+    switch (paSerialParameters.baudRate) {
+      case e50: speed = B50; break;
+      case e75: speed = B75; break;
+      case e110: speed |= B110; break;
+      case e134C5: speed = B134; break;
+      case e150: speed = B150; break;
+      case e200: speed = B200; break;
+      case e300: speed = B300; break;
+      case e600: speed = B600; break;
+      case e1200: speed = B1200; break;
+      case e1800: speed = B1800; break;
+      case e2400: speed = B2400; break;
+      case e4800: speed = B4800; break;
+      case e9600: speed = B9600; break;
+      case e19200: speed = B19200; break;
+      case e38400: speed = B38400; break;
+      case e57600: speed = B57600; break;
+      case e115200: speed = B115200; break;
+      case e1000000: speed = B1000000; break;
+      default: speed = B0; break;
+    }
+    return speed;
   }
 } // namespace forte::arch

--- a/core/arch/posix/src/posixsercommlayer.cpp
+++ b/core/arch/posix/src/posixsercommlayer.cpp
@@ -90,7 +90,7 @@ namespace forte::arch {
 
     // as first shot take the serial interface device as param (e.g., /dev/ttyS0 )
     CFDSelectHandler::TFileDescriptor fileDescriptor =
-        open(paSerialParameters.interfaceName.c_str(), O_RDWR | O_NOCTTY);
+        open(paSerialParameters.mInterfaceName.c_str(), O_RDWR | O_NOCTTY);
 
     if (fileDescriptor == CFDSelectHandler::scmInvalidFileDescriptor) {
       DEVLOG_ERROR("CSerCommLayer: open failed: %s\n", strerror(errno));
@@ -108,7 +108,7 @@ namespace forte::arch {
     cfsetispeed(&newTIO, speed);
     cfsetospeed(&newTIO, speed);
 
-    switch (paSerialParameters.byteSize) {
+    switch (paSerialParameters.mByteSize) {
       case e5: newTIO.c_cflag |= CS5; break;
       case e6: newTIO.c_cflag |= CS6; break;
       case e7: newTIO.c_cflag |= CS7; break;
@@ -116,13 +116,13 @@ namespace forte::arch {
       default: return com_infra::e_InitInvalidId; break;
     }
 
-    switch (paSerialParameters.stopBits) {
+    switch (paSerialParameters.mStopBits) {
       case eOneBit: newTIO.c_cflag &= ~CSTOPB; break;
       case eTwoBits: newTIO.c_cflag |= CSTOPB; break;
       default: return com_infra::e_InitInvalidId; break;
     }
 
-    switch (paSerialParameters.parity) {
+    switch (paSerialParameters.mParity) {
       case eNoParity: newTIO.c_cflag &= ~(PARENB | PARODD | CMSPAR); break;
       case eODD: newTIO.c_cflag |= PARENB | PARODD; break;
       case eEven:
@@ -184,7 +184,7 @@ namespace forte::arch {
 
   speed_t CPosixSerCommLayer::getSpeed(const SSerialParameters &paSerialParameters) {
     speed_t speed;
-    switch (paSerialParameters.baudRate) {
+    switch (paSerialParameters.mBaudRate) {
       case e50: speed = B50; break;
       case e75: speed = B75; break;
       case e110: speed |= B110; break;

--- a/core/arch/posix/src/posixsercommlayer.h
+++ b/core/arch/posix/src/posixsercommlayer.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 ACIN, fortiss GmbH
+ * Copyright (c) 2012, 2025 ACIN, fortiss GmbH, Johannes Kepler University Linz
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -31,6 +32,8 @@ namespace forte::arch {
           const SSerialParameters &paSerialParameters,
           CSerialComLayerBase<FORTE_SOCKET_TYPE, FORTE_INVALID_SOCKET>::TSerialHandleType *paHandleResult) override;
       void closeConnection() override;
+
+      static speed_t getSpeed(const SSerialParameters &paSerialParameters);
 
       struct termios mOldTIO; //!< buffer for the existing sercom settings
   };

--- a/core/arch/win32/src/serlayer/cwin32sercomlayer.cpp
+++ b/core/arch/win32/src/serlayer/cwin32sercomlayer.cpp
@@ -74,7 +74,7 @@ namespace forte::arch {
   CWin32SerComLayer::openSerialConnection(const SSerialParameters &paSerialParameters,
                                           CSerialComLayerBase<HANDLE>::TSerialHandleType *paHandleResult) {
 
-    HANDLE serialHandle = CreateFile(paSerialParameters.interfaceName.c_str(), GENERIC_READ | GENERIC_WRITE, 0, 0,
+    HANDLE serialHandle = CreateFile(paSerialParameters.mInterfaceName.c_str(), GENERIC_READ | GENERIC_WRITE, 0, 0,
                                      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
 
     if (INVALID_HANDLE_VALUE == serialHandle) {
@@ -92,8 +92,8 @@ namespace forte::arch {
       return forte::com_infra::e_ProcessDataNoSocket;
     }
 
-    dcbSerialParams.BaudRate = static_cast<DWORD>(paSerialParameters.baudRate);
-    switch (paSerialParameters.baudRate) {
+    dcbSerialParams.BaudRate = static_cast<DWORD>(paSerialParameters.mBaudRate);
+    switch (paSerialParameters.mBaudRate) {
         // These are ok baud rates
       case e110: break;
       case e300: break;
@@ -113,15 +113,15 @@ namespace forte::arch {
       default: return forte::com_infra::e_InitInvalidId; break;
     }
 
-    dcbSerialParams.ByteSize = paSerialParameters.byteSize;
+    dcbSerialParams.ByteSize = paSerialParameters.mByteSize;
 
-    switch (paSerialParameters.stopBits) {
+    switch (paSerialParameters.mStopBits) {
       case EForteSerialStopBits::eOneBit: dcbSerialParams.StopBits = ONESTOPBIT; break;
       case EForteSerialStopBits::eOne5Bits: dcbSerialParams.StopBits = ONE5STOPBITS; break;
       case EForteSerialStopBits::eTwoBits: dcbSerialParams.StopBits = TWOSTOPBITS; break;
     }
 
-    switch (paSerialParameters.parity) {
+    switch (paSerialParameters.mParity) {
       case EForteSerialParity::eNoParity: dcbSerialParams.Parity = NOPARITY; break;
       case EForteSerialParity::eODD: dcbSerialParams.Parity = ODDPARITY; break;
       case EForteSerialParity::eEven: dcbSerialParams.Parity = EVENPARITY; break;

--- a/core/include/forte/cominfra/serialcomlayerbase.h
+++ b/core/include/forte/cominfra/serialcomlayerbase.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017 ACIN, fortiss GmbH
+ * Copyright (c) 2017, 2025 ACIN, fortiss GmbH, Johannes Kepler University Linz
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -82,11 +83,11 @@ namespace forte::arch {
       enum EForteSerialParity { eNoParity = 0, eODD = 1, eEven = 2, eMark, eSpace };
 
       struct SSerialParameters {
-          CIEC_STRING interfaceName;
-          EForteSerialBaudRate baudRate;
-          EForteSerialByteSize byteSize;
-          EForteSerialStopBits stopBits;
-          EForteSerialParity parity;
+          CIEC_STRING mInterfaceName;
+          EForteSerialBaudRate mBaudRate;
+          EForteSerialByteSize mByteSize;
+          EForteSerialStopBits mStopBits;
+          EForteSerialParity mParity;
       };
 
       char mTerminationSymbol[3]; //**< Space for CR, LF, or CR/LF + Terminating \0
@@ -165,11 +166,11 @@ namespace forte::arch {
     }
 
     SSerialParameters parsedParameters;
-    parsedParameters.interfaceName = CIEC_STRING(parser[eInterface], strlen(parser[eInterface]));
+    parsedParameters.mInterfaceName = CIEC_STRING(parser[eInterface], strlen(parser[eInterface]));
 
     // Check baud rate setting
-    parsedParameters.baudRate = static_cast<EForteSerialBaudRate>(atoi(parser[eBaudrate]));
-    switch (parsedParameters.baudRate) {
+    parsedParameters.mBaudRate = static_cast<EForteSerialBaudRate>(atoi(parser[eBaudrate]));
+    switch (parsedParameters.mBaudRate) {
       // These are ok baud rates
       case e50: break;
       case e75: break;
@@ -198,33 +199,33 @@ namespace forte::arch {
     }
 
     // Check byte size setting
-    parsedParameters.byteSize = static_cast<EForteSerialByteSize>(atoi(parser[eByteSize]));
-    if (4 > parsedParameters.byteSize || 8 < parsedParameters.byteSize) {
+    parsedParameters.mByteSize = static_cast<EForteSerialByteSize>(atoi(parser[eByteSize]));
+    if (4 > parsedParameters.mByteSize || 8 < parsedParameters.mByteSize) {
       return com_infra::e_InitInvalidId;
     }
 
     // Check stopbits setting
     if (0 == strcmp(parser[eStopBits], "1")) {
-      parsedParameters.stopBits = eOneBit;
+      parsedParameters.mStopBits = eOneBit;
     } else if (0 == strcmp(parser[eStopBits], "1.5")) {
-      parsedParameters.stopBits = eOne5Bits;
+      parsedParameters.mStopBits = eOne5Bits;
     } else if (0 == strcmp(parser[eStopBits], "2")) {
-      parsedParameters.stopBits = eTwoBits;
+      parsedParameters.mStopBits = eTwoBits;
     } else {
       return com_infra::e_InitInvalidId;
     }
 
     // Check parity setting
     if (0 == strcmp(parser[eParity], "NONE")) {
-      parsedParameters.parity = eNoParity;
+      parsedParameters.mParity = eNoParity;
     } else if (0 == strcmp(parser[eParity], "ODD")) {
-      parsedParameters.parity = eODD;
+      parsedParameters.mParity = eODD;
     } else if (0 == strcmp(parser[eParity], "EVEN")) {
-      parsedParameters.parity = eEven;
+      parsedParameters.mParity = eEven;
     } else if (0 == strcmp(parser[eParity], "MARK")) {
-      parsedParameters.parity = eMark;
+      parsedParameters.mParity = eMark;
     } else if (0 == strcmp(parser[eParity], "SPACE")) {
-      parsedParameters.parity = eSpace;
+      parsedParameters.mParity = eSpace;
     } else {
       return com_infra::e_InitInvalidId;
     }


### PR DESCRIPTION
By copying the full existing termios settings several lines of asigments can be avoided. Furhtermore implementation specific settings are better hidden.