### PR TITLE
core/src/util: also use LOGINFO log level in RelWithDebInfo builds

### DIFF
--- a/core/src/util/CMakeLists.txt
+++ b/core/src/util/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 include(CMakeDependentOption)
 
-set(FORTE_LOGLEVEL "$<IF:$<CONFIG:Debug>,LOGINFO,LOGERROR>" CACHE STRING "Loglevel to use")
+set(FORTE_LOGLEVEL "$<IF:$<CONFIG:Debug,RelWithDebInfo>,LOGINFO,LOGERROR>" CACHE STRING "Loglevel to use")
 set_property(CACHE FORTE_LOGLEVEL PROPERTY STRINGS LOGDEBUG LOGERROR LOGWARNING LOGINFO NOLOG)
 
 cmake_dependent_option(FORTE_STACKTRACE "Include stacktrace when logging errors" OFF "NOT FORTE_LOGLEVEL STREQUAL NOLOG" OFF)


### PR DESCRIPTION
In FBE-3.0, debug builds are huge: 1-2GB build dir, 150-250MB forte executable, and this is after enabling debug symbol compression. Therefore FBE will have good support for RelWithDebInfo configurations as a middle ground. Since these are optimised for high-level debuggability (reduced debug info: backtraces, line numbers, but not local variables/macros), a log level of LOGINFO makes sense for them.
