### PR TITLE
Corrects E_SWITCH transition in E_TON_fbt

### DIFF
--- a/stdfblib/events/src/timers/E_TON_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TON_fbt.cpp
@@ -51,7 +51,7 @@ namespace forte::iec61499::events::timers {
         {{}, "REQ"_STRID, "E_SWITCH"_STRID, "EI"_STRID},
         {"E_SWITCH"_STRID, "EO1"_STRID, "E_DELAY"_STRID, "START"_STRID},
         {"E_SWITCH"_STRID, "EO0"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
-        {"E_SWITCH"_STRID, "EO1"_STRID, "E_RS"_STRID, "R"_STRID},
+        {"E_SWITCH"_STRID, "EO0"_STRID, "E_RS"_STRID, "R"_STRID},
         {"E_DELAY"_STRID, "EO"_STRID, "E_RS"_STRID, "S"_STRID},
         {"E_RS"_STRID, "EO"_STRID, {}, "CNF"_STRID},
     });


### PR DESCRIPTION
Corrects the transition from E_SWITCH to E_RS when R is triggered to EO0
instead of EO1. This ensures correct behaviour for the E_TON timer.
