### PR TITLE
Adds handle removal functionality

### DIFF
--- a/core/include/forte/io/device/io_controller.h
+++ b/core/include/forte/io/device/io_controller.h
@@ -104,6 +104,14 @@ namespace forte::io {
        */
       virtual void updateHandleList(std::string const &paId, IOHandle *paHandle);
 
+      /*! @brief Removes an IO handle from the controller and the IOMapper by ID
+       *
+       * The handle is removed from all internal lists.
+       *
+       * @param paId ID of the handle to remove
+       */
+      virtual void removeHandle(std::string const &paId);
+
     protected:
       explicit IODeviceController(CDeviceExecution &paDeviceExecution);
 
@@ -241,6 +249,8 @@ namespace forte::io {
       int mInitDelay;
 
       void addHandle(THandleList &paList, std::string const &paId, std::unique_ptr<IOHandle> paHandle);
+
+      void removeHandle(THandleList &paList, IOHandle *paRawHandle);
 
       // Functions needed for the external event handler interface
       void enableHandler() override {

--- a/core/include/forte/io/mapper/io_mapper.h
+++ b/core/include/forte/io/mapper/io_mapper.h
@@ -37,6 +37,13 @@ namespace forte::io {
       void deregisterHandle(IOHandle &paHandle);
       void deregisterHandle(std::string const &paId);
 
+      /*! @brief Get the handle instance with the given ID.
+       *
+       * @param paId The ID of the IOHandle.
+       * @return Pointer to the IOHandle instance, or nullptr if not found.
+       */
+      IOHandle *getHandle(std::string const &paId);
+
       bool registerObserver(std::string const &paId, IOObserver *paObserver);
       void deregisterObserver(IOObserver *paObserver);
 

--- a/core/src/io/device/io_controller.cpp
+++ b/core/src/io/device/io_controller.cpp
@@ -78,32 +78,61 @@ namespace forte::io {
     }
   }
 
-  void IODeviceController::updateHandleList(std::string const &paId, IOHandle *paHandle) {
-    for (auto it = mDiverseHandles.begin(); it != mDiverseHandles.end();) {
-      if (it->get() == paHandle) {
-        auto handleDirection = (*it)->getDirection();
-        switch (handleDirection) {
-          case IOMapper::In: {
-            util::CCriticalRegion criticalRegion(mHandleMutex);
-            mInputHandles.push_back(std::move(*it));
-            it = mDiverseHandles.erase(it);
-            break;
-          }
-          case IOMapper::Out: {
-            util::CCriticalRegion criticalRegion(mHandleMutex);
-            mOutputHandles.push_back(std::move(*it));
-            it = mDiverseHandles.erase(it);
-            break;
-          }
-          default:
-            DEVLOG_ERROR("[updateHandleList] %s's direction is neither `In` nor `Out`.\r\n", paId.c_str());
-            ++it;
-            break;
-        }
-        return;
-      } else {
-        ++it;
+  void IODeviceController::removeHandle(std::string const &paId) {
+    IOMapper &mapper = IOMapper::getInstance();
+    if (IOHandle *rawHandle = mapper.getHandle(paId); rawHandle) {
+      switch (rawHandle->getDirection()) {
+        case IOMapper::In: removeHandle(mInputHandles, rawHandle); return;
+        case IOMapper::Out: removeHandle(mOutputHandles, rawHandle); return;
+        case IOMapper::InOut: removeHandle(mDiverseHandles, rawHandle); return;
+        case IOMapper::UnknownDirection: removeHandle(mDiverseHandles, rawHandle); return;
+        default: break;
       }
+    }
+    DEVLOG_WARNING("[IODeviceController] Handle with ID '%s' not found in IOMapper for removal. Cannot remove from "
+                   "controller lists.\n",
+                   paId.c_str());
+  }
+
+  void IODeviceController::removeHandle(THandleList &paList, IOHandle *paRawHandle) {
+    util::CCriticalRegion criticalRegion(mHandleMutex);
+
+    IOMapper &mapper = IOMapper::getInstance();
+
+    auto new_end = std::remove_if(paList.begin(), paList.end(), [&](const std::unique_ptr<IOHandle> &handle) {
+      if (handle.get() == paRawHandle) {
+        mapper.deregisterHandle(*handle);
+        return true; // remove
+      }
+      return false;
+    });
+
+    paList.erase(new_end, paList.end());
+  }
+
+  void IODeviceController::updateHandleList(std::string const &paId, IOHandle *paHandle) {
+    auto it = std::find_if(mDiverseHandles.begin(), mDiverseHandles.end(),
+                           [&](const std::unique_ptr<IOHandle> &handle) { return handle.get() == paHandle; });
+
+    if (it == mDiverseHandles.end()) {
+      DEVLOG_INFO("[updateHandleList] %s's is no member of mDiverseHandles.\r\n", paId.c_str());
+      return;
+    }
+    auto handleDirection = (*it)->getDirection();
+    switch (handleDirection) {
+      case IOMapper::In: {
+        util::CCriticalRegion criticalRegion(mHandleMutex);
+        mInputHandles.push_back(std::move(*it));
+        mDiverseHandles.erase(it);
+        break;
+      }
+      case IOMapper::Out: {
+        util::CCriticalRegion criticalRegion(mHandleMutex);
+        mOutputHandles.push_back(std::move(*it));
+        mDiverseHandles.erase(it);
+        break;
+      }
+      default: DEVLOG_ERROR("[updateHandleList] %s's direction is neither `In` nor `Out`.\r\n", paId.c_str()); break;
     }
     DEVLOG_INFO("[updateHandleList] %s's is no member of mDiverseHandles.\r\n", paId.c_str());
   }

--- a/core/src/io/mapper/io_mapper.cpp
+++ b/core/src/io/mapper/io_mapper.cpp
@@ -86,6 +86,16 @@ namespace forte::io {
     }
   }
 
+  IOHandle *IOMapper::getHandle(std::string const &paId) {
+    util::CCriticalRegion criticalRegion(mSyncMutex);
+
+    if (auto handleIt = mHandles.find(paId); handleIt != mHandles.end()) {
+      DEVLOG_DEBUG("[IOMapper] Retrieved handle %s\n", paId.c_str());
+      return handleIt->second;
+    }
+    return nullptr;
+  }
+
   bool IOMapper::registerObserver(std::string const &paId, IOObserver *paObserver) {
     util::CCriticalRegion criticalRegion(mSyncMutex);
 


### PR DESCRIPTION
Adds the ability to remove IO handles from the controller.
This functionality ensures proper deregistration from the
IOMapper, preventing memory leaks and maintaining data consistency.

The `updateHandleList` function is also refactored to use
`std::find_if` and `erase` for improved readability and efficiency.
