### PR TITLE
Fix ST output parameter with generic types

### DIFF
--- a/core/include/forte/datatypes/forte_any.h
+++ b/core/include/forte/datatypes/forte_any.h
@@ -26,6 +26,7 @@
 #include <bit>
 #include <span>
 #include <limits>
+#include <type_traits>
 #include "forte/typelib.h"
 #include "forte/iec61131_cast_helper.h"
 #include "forte/config/forte_config.h"
@@ -606,4 +607,27 @@ namespace forte {
       static constexpr StringId scmDataTypeName{};
   };
 
+  /*!
+   * \brief A type trait marking generic data types
+   * \tparam T The data type
+   */
+  template<typename T>
+  struct is_generic_datatype : std::false_type {};
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY> : std::true_type {};
+
+  /*!
+   * \brief Helper variable template for is_generic_datatype
+   * \tparam T The data type
+   */
+  template<typename T>
+  inline constexpr bool is_generic_datatype_v = is_generic_datatype<T>::value;
+
+  /*!
+   * \brief A concept for generic data types
+   * \tparam T The data type
+   */
+  template<typename T>
+  concept generic_datatype = is_generic_datatype_v<std::remove_cvref_t<T>>;
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_bit.h
+++ b/core/include/forte/datatypes/forte_any_bit.h
@@ -35,4 +35,7 @@ namespace forte {
     protected:
       CIEC_ANY_BIT() = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_BIT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_bit_variant.h
+++ b/core/include/forte/datatypes/forte_any_bit_variant.h
@@ -87,4 +87,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_BIT_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_BIT_VARIANT, const CIEC_ANY_BIT &>);
   static_assert(std::is_destructible_v<CIEC_ANY_BIT_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_BIT_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_char.h
+++ b/core/include/forte/datatypes/forte_any_char.h
@@ -39,4 +39,7 @@ namespace forte {
     protected:
       CIEC_ANY_CHAR() = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_CHAR> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_char_variant.h
+++ b/core/include/forte/datatypes/forte_any_char_variant.h
@@ -82,4 +82,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_CHAR_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_CHAR_VARIANT, const CIEC_ANY_CHAR &>);
   static_assert(std::is_destructible_v<CIEC_ANY_CHAR_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_CHAR_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_chars.h
+++ b/core/include/forte/datatypes/forte_any_chars.h
@@ -37,4 +37,7 @@ namespace forte {
 
       static void dollarEscapeChar(std::string &paTargetBuf, char paSymbol, const EDataTypeID paTypeID);
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_CHARS> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_chars_variant.h
+++ b/core/include/forte/datatypes/forte_any_chars_variant.h
@@ -87,4 +87,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_CHARS_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_CHARS_VARIANT, const CIEC_ANY_CHARS &>);
   static_assert(std::is_destructible_v<CIEC_ANY_CHARS_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_CHARS_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_date.h
+++ b/core/include/forte/datatypes/forte_any_date.h
@@ -87,4 +87,7 @@ namespace forte {
     private:
       static TForteInt32 smTimeZoneOffset;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_DATE> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_date_variant.h
+++ b/core/include/forte/datatypes/forte_any_date_variant.h
@@ -89,4 +89,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_DATE_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_DATE_VARIANT, const CIEC_ANY_DATE &>);
   static_assert(std::is_destructible_v<CIEC_ANY_DATE_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_DATE_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_derived.h
+++ b/core/include/forte/datatypes/forte_any_derived.h
@@ -28,4 +28,7 @@ namespace forte {
     protected:
       CIEC_ANY_DERIVED() = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_DERIVED> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_duration.h
+++ b/core/include/forte/datatypes/forte_any_duration.h
@@ -117,4 +117,7 @@ namespace forte {
       CIEC_ANY_DURATION() = default;
       void timeElementsToString(std::string &paTargetBuf, int64_t paTimeElement, const std::string &paUnit) const;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_DURATION> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_duration_variant.h
+++ b/core/include/forte/datatypes/forte_any_duration_variant.h
@@ -82,4 +82,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_DURATION_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_DURATION_VARIANT, const CIEC_ANY_DURATION &>);
   static_assert(std::is_destructible_v<CIEC_ANY_DURATION_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_DURATION_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_elementary.h
+++ b/core/include/forte/datatypes/forte_any_elementary.h
@@ -47,4 +47,7 @@ namespace forte {
       bool isTypeSpecifier(const char *paValue, const char *paHashPosition) const;
       bool isCastable(StringId paTypeNameId) const;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_ELEMENTARY> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_elementary_variant.h
+++ b/core/include/forte/datatypes/forte_any_elementary_variant.h
@@ -169,4 +169,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_ELEMENTARY_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_ELEMENTARY_VARIANT, const CIEC_ANY_ELEMENTARY &>);
   static_assert(std::is_destructible_v<CIEC_ANY_ELEMENTARY_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_ELEMENTARY_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_int.h
+++ b/core/include/forte/datatypes/forte_any_int.h
@@ -55,4 +55,7 @@ namespace forte {
 
       CIEC_ANY_INT() = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_INT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_int_variant.h
+++ b/core/include/forte/datatypes/forte_any_int_variant.h
@@ -97,4 +97,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_INT_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_INT_VARIANT, const CIEC_ANY_INT &>);
   static_assert(std::is_destructible_v<CIEC_ANY_INT_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_INT_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_magnitude.h
+++ b/core/include/forte/datatypes/forte_any_magnitude.h
@@ -33,4 +33,7 @@ namespace forte {
     protected:
       CIEC_ANY_MAGNITUDE() = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_MAGNITUDE> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_magnitude_variant.h
+++ b/core/include/forte/datatypes/forte_any_magnitude_variant.h
@@ -107,4 +107,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_MAGNITUDE_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_MAGNITUDE_VARIANT, const CIEC_ANY_MAGNITUDE &>);
   static_assert(std::is_destructible_v<CIEC_ANY_MAGNITUDE_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_MAGNITUDE_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_num.h
+++ b/core/include/forte/datatypes/forte_any_num.h
@@ -32,4 +32,7 @@ namespace forte {
     protected:
       CIEC_ANY_NUM() = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_NUM> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_num_variant.h
+++ b/core/include/forte/datatypes/forte_any_num_variant.h
@@ -102,4 +102,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_NUM_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_NUM_VARIANT, const CIEC_ANY_NUM &>);
   static_assert(std::is_destructible_v<CIEC_ANY_NUM_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_NUM_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_real.h
+++ b/core/include/forte/datatypes/forte_any_real.h
@@ -30,4 +30,7 @@ namespace forte {
 
       static void normalizeToStringRepresentation(std::string &paTargetBuf, size_t paStartPos);
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_REAL> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_real_variant.h
+++ b/core/include/forte/datatypes/forte_any_real_variant.h
@@ -83,4 +83,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_REAL_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_REAL_VARIANT, const CIEC_ANY_REAL &>);
   static_assert(std::is_destructible_v<CIEC_ANY_REAL_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_REAL_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_signed.h
+++ b/core/include/forte/datatypes/forte_any_signed.h
@@ -33,4 +33,7 @@ namespace forte {
 
       ~CIEC_ANY_SIGNED() override = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_SIGNED> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_signed_variant.h
+++ b/core/include/forte/datatypes/forte_any_signed_variant.h
@@ -89,4 +89,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_SIGNED_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_SIGNED_VARIANT, const CIEC_ANY_SIGNED &>);
   static_assert(std::is_destructible_v<CIEC_ANY_SIGNED_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_SIGNED_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_string.h
+++ b/core/include/forte/datatypes/forte_any_string.h
@@ -157,4 +157,7 @@ namespace forte {
 
       CIEC_ANY_STRING() = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_STRING> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_string_variant.h
+++ b/core/include/forte/datatypes/forte_any_string_variant.h
@@ -82,4 +82,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_STRING_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_STRING_VARIANT, const CIEC_ANY_STRING &>);
   static_assert(std::is_destructible_v<CIEC_ANY_STRING_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_STRING_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_unsigned.h
+++ b/core/include/forte/datatypes/forte_any_unsigned.h
@@ -33,4 +33,7 @@ namespace forte {
 
       ~CIEC_ANY_UNSIGNED() override = default;
   };
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_UNSIGNED> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_unsigned_variant.h
+++ b/core/include/forte/datatypes/forte_any_unsigned_variant.h
@@ -89,4 +89,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_UNSIGNED_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_UNSIGNED_VARIANT, const CIEC_ANY_UNSIGNED &>);
   static_assert(std::is_destructible_v<CIEC_ANY_UNSIGNED_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_UNSIGNED_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/datatypes/forte_any_variant.h
+++ b/core/include/forte/datatypes/forte_any_variant.h
@@ -147,4 +147,7 @@ namespace forte {
   static_assert(std::is_copy_assignable_v<CIEC_ANY_VARIANT>);
   static_assert(std::is_assignable_v<CIEC_ANY_VARIANT, const CIEC_ANY &>);
   static_assert(std::is_destructible_v<CIEC_ANY_VARIANT>);
+
+  template<>
+  struct is_generic_datatype<CIEC_ANY_VARIANT> : std::true_type {};
 } // namespace forte

--- a/core/include/forte/forte_st_util.h
+++ b/core/include/forte/forte_st_util.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <concepts>
+#include <type_traits>
 
 #include "forte/datatypes/forte_any.h"
 #include "forte/datatypes/forte_any_bit.h"
@@ -45,8 +46,7 @@ namespace forte {
   class COutputGuard;
 
   template<typename T>
-    requires(std::default_initializable<T> && !std::derived_from<T, CIEC_ANY_BIT> ||
-             std::is_same_v<T, CIEC_ANY_BIT_VARIANT>)
+    requires(std::default_initializable<T> && (!std::derived_from<T, CIEC_ANY_BIT> || forte::generic_datatype<T>) )
   class COutputParameter {
       friend COutputGuard<COutputParameter>;
 
@@ -54,11 +54,11 @@ namespace forte {
       COutputParameter() : mOutput(nullptr) {
       }
 
-      template<typename U,
-               std::enable_if_t<std::is_base_of_v<CIEC_ANY, std::remove_reference_t<U>> &&
-                                    std::is_assignable_v<std::remove_reference_t<U>, T>,
-                                bool> = true>
-      COutputParameter(U &&paOutput) : mOutput(&paOutput) {
+      template<typename U>
+        requires(std::derived_from<std::remove_reference_t<U>, CIEC_ANY> &&
+                 (std::is_assignable_v<std::remove_reference_t<U>, T> ||
+                  (forte::generic_datatype<T> && std::is_assignable_v<T, std::remove_reference_t<U>>) ))
+      explicit(false) COutputParameter(U &&paOutput) : mOutput(&paOutput) {
       }
 
       T *get() noexcept {
@@ -76,7 +76,7 @@ namespace forte {
     private:
       void writeBack() {
         if (mOutput) {
-          mOutput->setValue(mValue);
+          mOutput->setValue(mValue.unwrap());
         }
       }
 
@@ -85,8 +85,7 @@ namespace forte {
   };
 
   template<typename T>
-    requires(std::default_initializable<T> && std::derived_from<T, CIEC_ANY_BIT> &&
-             !std::is_same_v<T, CIEC_ANY_BIT_VARIANT>)
+    requires(std::default_initializable<T> && std::derived_from<T, CIEC_ANY_BIT> && !forte::generic_datatype<T>)
   class CAnyBitOutputParameter {
       friend COutputGuard<CAnyBitOutputParameter>;
 
@@ -94,17 +93,15 @@ namespace forte {
       CAnyBitOutputParameter() : mOutput(nullptr), mNegate(false) {
       }
 
-      template<typename U,
-               std::enable_if_t<std::is_base_of_v<CIEC_ANY, std::remove_reference_t<U>> &&
-                                    std::is_assignable_v<std::remove_reference_t<U>, T>,
-                                bool> = true>
-      CAnyBitOutputParameter(U &&paOutput) : mOutput(&paOutput), mNegate(false) {
+      template<typename U>
+        requires(std::derived_from<std::remove_reference_t<U>, CIEC_ANY> &&
+                 std::is_assignable_v<std::remove_reference_t<U>, T>)
+      explicit(false) CAnyBitOutputParameter(U &&paOutput) : mOutput(&paOutput), mNegate(false) {
       }
 
-      template<typename U,
-               std::enable_if_t<std::is_base_of_v<CIEC_ANY, std::remove_reference_t<U>> &&
-                                    std::is_assignable_v<std::remove_reference_t<U>, T>,
-                                bool> = true>
+      template<typename U>
+        requires(std::derived_from<std::remove_reference_t<U>, CIEC_ANY> &&
+                 std::is_assignable_v<std::remove_reference_t<U>, T>)
       CAnyBitOutputParameter(U &&paOutput, const bool paNegate) : mOutput(&paOutput), mNegate(paNegate) {
       }
 

--- a/modules/IEC61131-3/include/forte/iec61131/counters/FB_CTD_UDINT_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/counters/FB_CTD_UDINT_fbt.h
@@ -83,8 +83,11 @@ namespace forte::iec61131::counters {
         *paCV = var_CV;
       }
 
-      void operator()(
-          const CIEC_BOOL &paCD, const CIEC_BOOL &paLD, const CIEC_UDINT &paPV, CIEC_BOOL &paQ, CIEC_UDINT &paCV) {
+      void operator()(const CIEC_BOOL &paCD,
+                      const CIEC_BOOL &paLD,
+                      const CIEC_UDINT &paPV,
+                      CAnyBitOutputParameter<CIEC_BOOL> paQ,
+                      COutputParameter<CIEC_UDINT> paCV) {
         evt_REQ(paCD, paLD, paPV, paQ, paCV);
       }
   };

--- a/modules/IEC61131-3/include/forte/iec61131/counters/FB_CTD_ULINT_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/counters/FB_CTD_ULINT_fbt.h
@@ -83,8 +83,11 @@ namespace forte::iec61131::counters {
         *paCV = var_CV;
       }
 
-      void operator()(
-          const CIEC_BOOL &paCD, const CIEC_BOOL &paLD, const CIEC_ULINT &paPV, CIEC_BOOL &paQ, CIEC_ULINT &paCV) {
+      void operator()(const CIEC_BOOL &paCD,
+                      const CIEC_BOOL &paLD,
+                      const CIEC_ULINT &paPV,
+                      CAnyBitOutputParameter<CIEC_BOOL> paQ,
+                      COutputParameter<CIEC_ULINT> paCV) {
         evt_REQ(paCD, paLD, paPV, paQ, paCV);
       }
   };

--- a/modules/IEC61131-3/include/forte/iec61131/counters/FB_CTU_UDINT_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/counters/FB_CTU_UDINT_fbt.h
@@ -83,8 +83,11 @@ namespace forte::iec61131::counters {
         *paCV = var_CV;
       }
 
-      void operator()(
-          const CIEC_BOOL &paCU, const CIEC_BOOL &paR, const CIEC_UDINT &paPV, CIEC_BOOL &paQ, CIEC_UDINT &paCV) {
+      void operator()(const CIEC_BOOL &paCU,
+                      const CIEC_BOOL &paR,
+                      const CIEC_UDINT &paPV,
+                      CAnyBitOutputParameter<CIEC_BOOL> paQ,
+                      COutputParameter<CIEC_UDINT> paCV) {
         evt_REQ(paCU, paR, paPV, paQ, paCV);
       }
   };

--- a/modules/IEC61131-3/include/forte/iec61131/counters/FB_CTU_ULINT_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/counters/FB_CTU_ULINT_fbt.h
@@ -83,8 +83,11 @@ namespace forte::iec61131::counters {
         *paCV = var_CV;
       }
 
-      void operator()(
-          const CIEC_BOOL &paCU, const CIEC_BOOL &paR, const CIEC_ULINT &paPV, CIEC_BOOL &paQ, CIEC_ULINT &paCV) {
+      void operator()(const CIEC_BOOL &paCU,
+                      const CIEC_BOOL &paR,
+                      const CIEC_ULINT &paPV,
+                      CAnyBitOutputParameter<CIEC_BOOL> paQ,
+                      COutputParameter<CIEC_ULINT> paCV) {
         evt_REQ(paCU, paR, paPV, paQ, paCV);
       }
   };

--- a/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/FIELDBUS_PERCENT_TO_WORD_fct.h
+++ b/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/FIELDBUS_PERCENT_TO_WORD_fct.h
@@ -63,10 +63,10 @@ namespace forte::eclipse4diac::signalprocessing {
         COutputGuard guard_pa(pa);
         var_RI = paRI;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
-      void operator()(const CIEC_REAL &paRI, CIEC_WORD &pa) {
+      void operator()(const CIEC_REAL &paRI, CAnyBitOutputParameter<CIEC_WORD> &pa) {
         evt_REQ(paRI, pa);
       }
   };

--- a/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/FIELDBUS_WORD_TO_PERCENT_fct.h
+++ b/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/FIELDBUS_WORD_TO_PERCENT_fct.h
@@ -67,11 +67,11 @@ namespace forte::eclipse4diac::signalprocessing {
 
         var_WI = paWI;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
         *paWO = var_WO;
       }
 
-      void operator()(const CIEC_WORD &paWI, CIEC_REAL &pa, CIEC_WORD &paWO) {
+      void operator()(const CIEC_WORD &paWI, COutputParameter<CIEC_REAL> &pa, CAnyBitOutputParameter<CIEC_WORD> &paWO) {
         evt_REQ(paWI, pa, paWO);
       }
   };

--- a/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/SCALE_LIM_fct.h
+++ b/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/SCALE_LIM_fct.h
@@ -94,7 +94,7 @@ namespace forte::eclipse4diac::signalprocessing {
         var_MAX_OUT_FIX = paMAX_OUT_FIX;
         var_MIN_OUT_FIX = paMIN_OUT_FIX;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_REAL &paIN,
@@ -106,7 +106,7 @@ namespace forte::eclipse4diac::signalprocessing {
                       const CIEC_REAL &paMIN_OUT,
                       const CIEC_REAL &paMAX_OUT_FIX,
                       const CIEC_REAL &paMIN_OUT_FIX,
-                      CIEC_REAL &pa) {
+                      COutputParameter<CIEC_REAL> &pa) {
         evt_REQ(paIN, paMAX_IN, paMIN_IN, paMAX_IN_LIM, paMIN_IN_LIM, paMAX_OUT, paMIN_OUT, paMAX_OUT_FIX,
                 paMIN_OUT_FIX, pa);
       }

--- a/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/SCALE_fct.h
+++ b/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/SCALE_fct.h
@@ -78,7 +78,7 @@ namespace forte::eclipse4diac::signalprocessing {
         var_MAX_OUT = paMAX_OUT;
         var_MIN_OUT = paMIN_OUT;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_REAL &paIN,
@@ -86,7 +86,7 @@ namespace forte::eclipse4diac::signalprocessing {
                       const CIEC_REAL &paMIN_IN,
                       const CIEC_REAL &paMAX_OUT,
                       const CIEC_REAL &paMIN_OUT,
-                      CIEC_REAL &pa) {
+                      COutputParameter<CIEC_REAL> &pa) {
         evt_REQ(paIN, paMAX_IN, paMIN_IN, paMAX_OUT, paMIN_OUT, pa);
       }
   };

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_BYTE_FROM_BOOLS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_BYTE_FROM_BOOLS_fct.h
@@ -94,7 +94,7 @@ namespace forte::eclipse4diac::utils::assembling {
         var_BIT_06 = paBIT_06;
         var_BIT_07 = paBIT_07;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BOOL &paBIT_00,
@@ -105,7 +105,7 @@ namespace forte::eclipse4diac::utils::assembling {
                       const CIEC_BOOL &paBIT_05,
                       const CIEC_BOOL &paBIT_06,
                       const CIEC_BOOL &paBIT_07,
-                      CIEC_BYTE &pa) {
+                      CAnyBitOutputParameter<CIEC_BYTE> &pa) {
         evt_REQ(paBIT_00, paBIT_01, paBIT_02, paBIT_03, paBIT_04, paBIT_05, paBIT_06, paBIT_07, pa);
       }
   };

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_BYTE_FROM_QUARTERS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_BYTE_FROM_QUARTERS_fct.h
@@ -77,14 +77,14 @@ namespace forte::eclipse4diac::utils::assembling {
         var_QUARTER_BYTE_02 = paQUARTER_BYTE_02;
         var_QUARTER_BYTE_03 = paQUARTER_BYTE_03;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BYTE &paQUARTER_BYTE_00,
                       const CIEC_BYTE &paQUARTER_BYTE_01,
                       const CIEC_BYTE &paQUARTER_BYTE_02,
                       const CIEC_BYTE &paQUARTER_BYTE_03,
-                      CIEC_BYTE &pa) {
+                      CAnyBitOutputParameter<CIEC_BYTE> &pa) {
         evt_REQ(paQUARTER_BYTE_00, paQUARTER_BYTE_01, paQUARTER_BYTE_02, paQUARTER_BYTE_03, pa);
       }
   };

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BOOLS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BOOLS_fct.h
@@ -190,7 +190,7 @@ namespace forte::eclipse4diac::utils::assembling {
         var_BIT_30 = paBIT_30;
         var_BIT_31 = paBIT_31;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BOOL &paBIT_00,
@@ -225,7 +225,7 @@ namespace forte::eclipse4diac::utils::assembling {
                       const CIEC_BOOL &paBIT_29,
                       const CIEC_BOOL &paBIT_30,
                       const CIEC_BOOL &paBIT_31,
-                      CIEC_DWORD &pa) {
+                      CAnyBitOutputParameter<CIEC_DWORD> &pa) {
         evt_REQ(paBIT_00, paBIT_01, paBIT_02, paBIT_03, paBIT_04, paBIT_05, paBIT_06, paBIT_07, paBIT_08, paBIT_09,
                 paBIT_10, paBIT_11, paBIT_12, paBIT_13, paBIT_14, paBIT_15, paBIT_16, paBIT_17, paBIT_18, paBIT_19,
                 paBIT_20, paBIT_21, paBIT_22, paBIT_23, paBIT_24, paBIT_25, paBIT_26, paBIT_27, paBIT_28, paBIT_29,

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BYTES_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BYTES_fct.h
@@ -78,14 +78,14 @@ namespace forte::eclipse4diac::utils::assembling {
         var_BYTE_02 = paBYTE_02;
         var_BYTE_03 = paBYTE_03;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BYTE &paBYTE_00,
                       const CIEC_BYTE &paBYTE_01,
                       const CIEC_BYTE &paBYTE_02,
                       const CIEC_BYTE &paBYTE_03,
-                      CIEC_DWORD &pa) {
+                      CAnyBitOutputParameter<CIEC_DWORD> &pa) {
         evt_REQ(paBYTE_00, paBYTE_01, paBYTE_02, paBYTE_03, pa);
       }
   };

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_QUARTERS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_QUARTERS_fct.h
@@ -126,7 +126,7 @@ namespace forte::eclipse4diac::utils::assembling {
         var_QUARTER_BYTE_14 = paQUARTER_BYTE_14;
         var_QUARTER_BYTE_15 = paQUARTER_BYTE_15;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BYTE &paQUARTER_BYTE_00,
@@ -145,7 +145,7 @@ namespace forte::eclipse4diac::utils::assembling {
                       const CIEC_BYTE &paQUARTER_BYTE_13,
                       const CIEC_BYTE &paQUARTER_BYTE_14,
                       const CIEC_BYTE &paQUARTER_BYTE_15,
-                      CIEC_DWORD &pa) {
+                      CAnyBitOutputParameter<CIEC_DWORD> &pa) {
         evt_REQ(paQUARTER_BYTE_00, paQUARTER_BYTE_01, paQUARTER_BYTE_02, paQUARTER_BYTE_03, paQUARTER_BYTE_04,
                 paQUARTER_BYTE_05, paQUARTER_BYTE_06, paQUARTER_BYTE_07, paQUARTER_BYTE_08, paQUARTER_BYTE_09,
                 paQUARTER_BYTE_10, paQUARTER_BYTE_11, paQUARTER_BYTE_12, paQUARTER_BYTE_13, paQUARTER_BYTE_14,

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_WORDS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_WORDS_fct.h
@@ -68,10 +68,10 @@ namespace forte::eclipse4diac::utils::assembling {
         var_WORD_00 = paWORD_00;
         var_WORD_01 = paWORD_01;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
-      void operator()(const CIEC_WORD &paWORD_00, const CIEC_WORD &paWORD_01, CIEC_DWORD &pa) {
+      void operator()(const CIEC_WORD &paWORD_00, const CIEC_WORD &paWORD_01, CAnyBitOutputParameter<CIEC_DWORD> &pa) {
         evt_REQ(paWORD_00, paWORD_01, pa);
       }
   };

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_LWORD_FROM_BOOLS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_LWORD_FROM_BOOLS_fct.h
@@ -318,7 +318,7 @@ namespace forte::eclipse4diac::utils::assembling {
         var_BIT_62 = paBIT_62;
         var_BIT_63 = paBIT_63;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BOOL &paBIT_00,
@@ -385,7 +385,7 @@ namespace forte::eclipse4diac::utils::assembling {
                       const CIEC_BOOL &paBIT_61,
                       const CIEC_BOOL &paBIT_62,
                       const CIEC_BOOL &paBIT_63,
-                      CIEC_LWORD &pa) {
+                      CAnyBitOutputParameter<CIEC_LWORD> &pa) {
         evt_REQ(paBIT_00, paBIT_01, paBIT_02, paBIT_03, paBIT_04, paBIT_05, paBIT_06, paBIT_07, paBIT_08, paBIT_09,
                 paBIT_10, paBIT_11, paBIT_12, paBIT_13, paBIT_14, paBIT_15, paBIT_16, paBIT_17, paBIT_18, paBIT_19,
                 paBIT_20, paBIT_21, paBIT_22, paBIT_23, paBIT_24, paBIT_25, paBIT_26, paBIT_27, paBIT_28, paBIT_29,

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_LWORD_FROM_QUARTERS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_LWORD_FROM_QUARTERS_fct.h
@@ -190,7 +190,7 @@ namespace forte::eclipse4diac::utils::assembling {
         var_QUARTER_BYTE_30 = paQUARTER_BYTE_30;
         var_QUARTER_BYTE_31 = paQUARTER_BYTE_31;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BYTE &paQUARTER_BYTE_00,
@@ -225,7 +225,7 @@ namespace forte::eclipse4diac::utils::assembling {
                       const CIEC_BYTE &paQUARTER_BYTE_29,
                       const CIEC_BYTE &paQUARTER_BYTE_30,
                       const CIEC_BYTE &paQUARTER_BYTE_31,
-                      CIEC_LWORD &pa) {
+                      CAnyBitOutputParameter<CIEC_LWORD> &pa) {
         evt_REQ(paQUARTER_BYTE_00, paQUARTER_BYTE_01, paQUARTER_BYTE_02, paQUARTER_BYTE_03, paQUARTER_BYTE_04,
                 paQUARTER_BYTE_05, paQUARTER_BYTE_06, paQUARTER_BYTE_07, paQUARTER_BYTE_08, paQUARTER_BYTE_09,
                 paQUARTER_BYTE_10, paQUARTER_BYTE_11, paQUARTER_BYTE_12, paQUARTER_BYTE_13, paQUARTER_BYTE_14,

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_WORD_FROM_BOOLS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_WORD_FROM_BOOLS_fct.h
@@ -126,7 +126,7 @@ namespace forte::eclipse4diac::utils::assembling {
         var_BIT_14 = paBIT_14;
         var_BIT_15 = paBIT_15;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BOOL &paBIT_00,
@@ -145,7 +145,7 @@ namespace forte::eclipse4diac::utils::assembling {
                       const CIEC_BOOL &paBIT_13,
                       const CIEC_BOOL &paBIT_14,
                       const CIEC_BOOL &paBIT_15,
-                      CIEC_WORD &pa) {
+                      CAnyBitOutputParameter<CIEC_WORD> &pa) {
         evt_REQ(paBIT_00, paBIT_01, paBIT_02, paBIT_03, paBIT_04, paBIT_05, paBIT_06, paBIT_07, paBIT_08, paBIT_09,
                 paBIT_10, paBIT_11, paBIT_12, paBIT_13, paBIT_14, paBIT_15, pa);
       }

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_WORD_FROM_BYTES_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_WORD_FROM_BYTES_fct.h
@@ -68,10 +68,10 @@ namespace forte::eclipse4diac::utils::assembling {
         var_BYTE_00 = paBYTE_00;
         var_BYTE_01 = paBYTE_01;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
-      void operator()(const CIEC_BYTE &paBYTE_00, const CIEC_BYTE &paBYTE_01, CIEC_WORD &pa) {
+      void operator()(const CIEC_BYTE &paBYTE_00, const CIEC_BYTE &paBYTE_01, CAnyBitOutputParameter<CIEC_WORD> &pa) {
         evt_REQ(paBYTE_00, paBYTE_01, pa);
       }
   };

--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_WORD_FROM_QUARTERS_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_WORD_FROM_QUARTERS_fct.h
@@ -94,7 +94,7 @@ namespace forte::eclipse4diac::utils::assembling {
         var_QUARTER_BYTE_06 = paQUARTER_BYTE_06;
         var_QUARTER_BYTE_07 = paQUARTER_BYTE_07;
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
       void operator()(const CIEC_BYTE &paQUARTER_BYTE_00,
@@ -105,7 +105,7 @@ namespace forte::eclipse4diac::utils::assembling {
                       const CIEC_BYTE &paQUARTER_BYTE_05,
                       const CIEC_BYTE &paQUARTER_BYTE_06,
                       const CIEC_BYTE &paQUARTER_BYTE_07,
-                      CIEC_WORD &pa) {
+                      CAnyBitOutputParameter<CIEC_WORD> &pa) {
         evt_REQ(paQUARTER_BYTE_00, paQUARTER_BYTE_01, paQUARTER_BYTE_02, paQUARTER_BYTE_03, paQUARTER_BYTE_04,
                 paQUARTER_BYTE_05, paQUARTER_BYTE_06, paQUARTER_BYTE_07, pa);
       }

--- a/modules/utils/include/forte/eclipse4diac/utils/timing/F_NOW_MONOTONIC_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/timing/F_NOW_MONOTONIC_fct.h
@@ -57,10 +57,10 @@ namespace forte::eclipse4diac::utils::timing {
       void evt_REQ(COutputParameter<CIEC_TIME> pa) {
         COutputGuard guard_pa(pa);
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
-      void operator()(CIEC_TIME &pa) {
+      void operator()(COutputParameter<CIEC_TIME> pa) {
         evt_REQ(pa);
       }
   };

--- a/modules/utils/include/forte/eclipse4diac/utils/timing/F_NOW_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/timing/F_NOW_fct.h
@@ -57,10 +57,10 @@ namespace forte::eclipse4diac::utils::timing {
       void evt_REQ(COutputParameter<CIEC_DATE_AND_TIME> pa) {
         COutputGuard guard_pa(pa);
         executeEvent(scmEventREQID, nullptr);
-        pa = var_;
+        *pa = var_;
       }
 
-      void operator()(CIEC_DATE_AND_TIME &pa) {
+      void operator()(COutputParameter<CIEC_DATE_AND_TIME> pa) {
         evt_REQ(pa);
       }
   };

--- a/stdfblib/io/include/forte/eclipse4diac/io/IB_fbt.h
+++ b/stdfblib/io/include/forte/eclipse4diac/io/IB_fbt.h
@@ -68,8 +68,11 @@ namespace forte::eclipse4diac::io {
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
 
-      void evt_INIT(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_BYTE &paIN) {
+      void evt_INIT(const CIEC_BOOL &paQI,
+                    const CIEC_STRING &paPARAMS,
+                    CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                    COutputParameter<CIEC_STRING> &paSTATUS,
+                    CAnyBitOutputParameter<CIEC_BYTE> &paIN) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         receiveInputEvent(scmEventINITID, nullptr);
@@ -78,8 +81,11 @@ namespace forte::eclipse4diac::io {
         *paIN = var_IN;
       }
 
-      void evt_REQ(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_BYTE &paIN) {
+      void evt_REQ(const CIEC_BOOL &paQI,
+                   const CIEC_STRING &paPARAMS,
+                   CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                   COutputParameter<CIEC_STRING> &paSTATUS,
+                   CAnyBitOutputParameter<CIEC_BYTE> &paIN) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         receiveInputEvent(scmEventREQID, nullptr);
@@ -88,8 +94,11 @@ namespace forte::eclipse4diac::io {
         *paIN = var_IN;
       }
 
-      void operator()(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_BYTE &paIN) {
+      void operator()(const CIEC_BOOL &paQI,
+                      const CIEC_STRING &paPARAMS,
+                      CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                      COutputParameter<CIEC_STRING> &paSTATUS,
+                      CAnyBitOutputParameter<CIEC_BYTE> &paIN) {
         evt_INIT(paQI, paPARAMS, paQO, paSTATUS, paIN);
       }
   };

--- a/stdfblib/io/include/forte/eclipse4diac/io/IW_fbt.h
+++ b/stdfblib/io/include/forte/eclipse4diac/io/IW_fbt.h
@@ -94,8 +94,11 @@ namespace forte::eclipse4diac::io {
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
 
-      void evt_INIT(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_WORD &paIN) {
+      void evt_INIT(const CIEC_BOOL &paQI,
+                    const CIEC_STRING &paPARAMS,
+                    CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                    COutputParameter<CIEC_STRING> &paSTATUS,
+                    CAnyBitOutputParameter<CIEC_WORD> &paIN) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         receiveInputEvent(scmEventINITID, nullptr);
@@ -104,8 +107,11 @@ namespace forte::eclipse4diac::io {
         *paIN = var_IN;
       }
 
-      void evt_REQ(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_WORD &paIN) {
+      void evt_REQ(const CIEC_BOOL &paQI,
+                   const CIEC_STRING &paPARAMS,
+                   CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                   COutputParameter<CIEC_STRING> &paSTATUS,
+                   CAnyBitOutputParameter<CIEC_WORD> &paIN) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         receiveInputEvent(scmEventREQID, nullptr);
@@ -114,8 +120,11 @@ namespace forte::eclipse4diac::io {
         *paIN = var_IN;
       }
 
-      void operator()(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_WORD &paIN) {
+      void operator()(const CIEC_BOOL &paQI,
+                      const CIEC_STRING &paPARAMS,
+                      CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                      COutputParameter<CIEC_STRING> &paSTATUS,
+                      CAnyBitOutputParameter<CIEC_WORD> &paIN) {
         evt_INIT(paQI, paPARAMS, paQO, paSTATUS, paIN);
       }
   };

--- a/stdfblib/io/include/forte/eclipse4diac/io/IX_fbt.h
+++ b/stdfblib/io/include/forte/eclipse4diac/io/IX_fbt.h
@@ -93,8 +93,11 @@ namespace forte::eclipse4diac::io {
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
 
-      void evt_INIT(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_BOOL &paIN) {
+      void evt_INIT(const CIEC_BOOL &paQI,
+                    const CIEC_STRING &paPARAMS,
+                    CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                    COutputParameter<CIEC_STRING> &paSTATUS,
+                    CAnyBitOutputParameter<CIEC_BOOL> &paIN) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         receiveInputEvent(scmEventINITID, nullptr);
@@ -103,8 +106,11 @@ namespace forte::eclipse4diac::io {
         *paIN = var_IN;
       }
 
-      void evt_REQ(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_BOOL &paIN) {
+      void evt_REQ(const CIEC_BOOL &paQI,
+                   const CIEC_STRING &paPARAMS,
+                   CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                   COutputParameter<CIEC_STRING> &paSTATUS,
+                   CAnyBitOutputParameter<CIEC_BOOL> &paIN) {
         var_QI = paQI;
         var_PARAMS = paPARAMS;
         receiveInputEvent(scmEventREQID, nullptr);
@@ -113,8 +119,11 @@ namespace forte::eclipse4diac::io {
         *paIN = var_IN;
       }
 
-      void operator()(
-          const CIEC_BOOL &paQI, const CIEC_STRING &paPARAMS, CIEC_BOOL &paQO, CIEC_STRING &paSTATUS, CIEC_BOOL &paIN) {
+      void operator()(const CIEC_BOOL &paQI,
+                      const CIEC_STRING &paPARAMS,
+                      CAnyBitOutputParameter<CIEC_BOOL> &paQO,
+                      COutputParameter<CIEC_STRING> &paSTATUS,
+                      CAnyBitOutputParameter<CIEC_BOOL> &paIN) {
         evt_INIT(paQI, paPARAMS, paQO, paSTATUS, paIN);
       }
   };

--- a/tests/core/iec61131_functionstests.cpp
+++ b/tests/core/iec61131_functionstests.cpp
@@ -29,6 +29,7 @@
 
 #include "forte/iec61131_functions.h"
 
+#include "forte/datatypes/forte_any_variant.h"
 #include "forte/datatypes/forte_char.h"
 #include "forte/datatypes/forte_string.h"
 #include "forte/datatypes/forte_string_fixed.h"
@@ -144,6 +145,12 @@ namespace forte::test {
     COutputGuard paOutGuard(paOut);
 
     *paOut = paIn;
+  }
+
+  void testSTInIsOutAnyDummyFunction(const CIEC_ANY &paIn, COutputParameter<CIEC_ANY_VARIANT> paOut) {
+    COutputGuard paOutGuard(paOut);
+
+    paOut->setValue(paIn.unwrap());
   }
 
   BOOST_AUTO_TEST_SUITE(IEC61131_functions)
@@ -2184,6 +2191,13 @@ namespace forte::test {
     CIEC_STRING out;
     testSTInIsOutCharDummyFunction(in[1], out[1]);
     BOOST_TEST(static_cast<CIEC_STRING::TValueType>(out) == "a"s);
+  }
+
+  BOOST_AUTO_TEST_CASE(output_any_test) {
+    CIEC_DINT in(17);
+    CIEC_LINT out;
+    testSTInIsOutAnyDummyFunction(in, out);
+    BOOST_TEST(static_cast<CIEC_LINT::TValueType>(out) == 17);
   }
 
   BOOST_AUTO_TEST_CASE(is_valid_REAL) {


### PR DESCRIPTION
The ST output parameters now allow properly supports assignments from generic parameters to non-generic arguments. Also add concept and type trait for generic data types and fix ST output parameters in event accessors.