### PR TITLE
In case of errors the long response was not embedded into the response

### DIFF
--- a/core/src/resource.cpp
+++ b/core/src/resource.cpp
@@ -178,6 +178,7 @@ namespace forte {
                                                 std::string &paReqResult,
                                                 std::string_view paResponsePrefix) {
       if (paTypeEntry == nullptr) {
+        paReqResult.clear();
         return EMGMResponse::UnsupportedType;
       }
 

--- a/stdfblib/system/src/CommandParser.cpp
+++ b/stdfblib/system/src/CommandParser.cpp
@@ -117,16 +117,18 @@ namespace forte::iec61499::system {
       paResponse.append("\">\n  ");
     } else {
       paResponse.append(">\n  ");
-      if (mCommand.mCMD == EMGMCommandType::Read) {
-        paResponse.append("<Connection Source=\"");
-        appendIdentifierName(paResponse, mCommand.mFirstParam);
-        paResponse.append("\" Destination=\"");
-        paResponse.append(mCommand.mAdditionalParams);
-        paResponse.append("\" />");
-      } else {
-        generateQueryResponse(paResponse);
-      }
     }
+
+    if (mCommand.mCMD == EMGMCommandType::Read) {
+      paResponse.append("<Connection Source=\"");
+      appendIdentifierName(paResponse, mCommand.mFirstParam);
+      paResponse.append("\" Destination=\"");
+      paResponse.append(mCommand.mAdditionalParams);
+      paResponse.append("\" />");
+    } else {
+      generateQueryResponse(paResponse);
+    }
+
     paResponse.append("\n</Response>");
   }
 


### PR DESCRIPTION
@m-meingast can you please check that this behavior also works for the OPC UA deployment.