### PR TITLE
Fixed CMake install for several com modules

### DIFF
--- a/com/HTTP/CMakeLists.txt
+++ b/com/HTTP/CMakeLists.txt
@@ -37,3 +37,5 @@ add_library(forte-com-HTTP
 target_include_directories(forte-com-HTTP PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(forte-com-HTTP PUBLIC forte-core)
 target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-com-HTTP,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-com-HTTP>>)
+
+install(TARGETS forte-com-HTTP EXPORT forte-export FILE_SET HEADERS)

--- a/com/can/CMakeLists.txt
+++ b/com/can/CMakeLists.txt
@@ -64,4 +64,6 @@ if(FORTE_COM_CAN)
   target_include_directories(forte-com-CAN PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
   target_link_libraries(forte-com-CAN PUBLIC forte-core)
   target_link_libraries(forte PUBLIC $<LINK_LIBRARY:WHOLE_ARCHIVE,forte-com-CAN>)
+  
+  install(TARGETS forte-com-CAN EXPORT forte-export FILE_SET HEADERS)
 endif(FORTE_COM_CAN)

--- a/com/modbus/CMakeLists.txt
+++ b/com/modbus/CMakeLists.txt
@@ -46,3 +46,5 @@ if (FORTE_COM_MODBUS_LIB_DIR)
     target_link_directories(forte-com-modbus PUBLIC ${FORTE_COM_MODBUS_LIB_DIR}/lib)
 endif ()
 target_link_libraries(forte-com-modbus PRIVATE modbus)
+
+install(TARGETS forte-com-modbus EXPORT forte-export FILE_SET HEADERS)

--- a/com/mqtt_paho/CMakeLists.txt
+++ b/com/mqtt_paho/CMakeLists.txt
@@ -50,3 +50,5 @@ if (WIN32)
     target_link_libraries(forte-com-mqtt_paho PRIVATE crypt32)
 endif ()
 target_link_libraries(forte-com-mqtt_paho PRIVATE ${FORTE_COM_PAHOMQTT_LIB})
+
+install(TARGETS forte-com-mqtt_paho EXPORT forte-export FILE_SET HEADERS)

--- a/com/opc/CMakeLists.txt
+++ b/com/opc/CMakeLists.txt
@@ -58,3 +58,5 @@ target_include_directories(forte-com-opc PRIVATE ${FORTE_COM_OPC_BOOST_ROOT})
 target_include_directories(forte-com-opc PRIVATE ${FORTE_COM_OPC_LIB_ROOT}/include/OPCClientToolKit)
 target_link_directories(forte-com-opc PUBLIC ${FORTE_COM_OPC_LIB_ROOT}/lib)
 target_link_libraries(forte-com-opc PRIVATE OPCClientToolKit)
+
+install(TARGETS forte-com-opc EXPORT forte-export FILE_SET HEADERS)

--- a/com/tsn/CMakeLists.txt
+++ b/com/tsn/CMakeLists.txt
@@ -23,3 +23,5 @@ add_library(forte-com-tsn
 )
 target_link_libraries(forte-com-tsn PUBLIC forte-core)
 target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-com-tsn,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-com-tsn>>)
+
+install(TARGETS forte-com-tsn EXPORT forte-export FILE_SET HEADERS)

--- a/com/xquery/CMakeLists.txt
+++ b/com/xquery/CMakeLists.txt
@@ -37,3 +37,5 @@ target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-com-x
 target_include_directories(forte-com-xquery PRIVATE ${FORTE_BASEX_SRC_DIR})
 
 target_link_libraries(forte-com-xquery PRIVATE ssl crypto)
+
+install(TARGETS forte-com-xquery EXPORT forte-export FILE_SET HEADERS)


### PR DESCRIPTION
Can, HTTP, modbus, mqtt_paho, opc, tsn, and xquery where missing the install command in their CMakeList.txt files.