### PR TITLE
Clean-up some code in the time-out blocks

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/ARTimeOut_adp.h
+++ b/stdfblib/events/include/forte/iec61499/events/ARTimeOut_adp.h
@@ -52,7 +52,7 @@ namespace forte::iec61499::events {
         return getParentAdapterListEventID() + scmEventSTOPID;
       }
 
-      virtual ~FORTE_ARTimeOut() override = default;
+      ~FORTE_ARTimeOut() override = default;
 
     protected:
       FORTE_ARTimeOut(CFBContainer &paContainer,

--- a/stdfblib/events/include/forte/iec61499/events/ATimeOut_adp.h
+++ b/stdfblib/events/include/forte/iec61499/events/ATimeOut_adp.h
@@ -52,29 +52,23 @@ namespace forte::iec61499::events {
       ~FORTE_ATimeOut() override = default;
   };
 
-  class FORTE_ATimeOut_Socket;
-
   class FORTE_ATimeOut_Plug final : public FORTE_ATimeOut {
     public:
       FORTE_ATimeOut_Plug(StringId paInstanceNameId, CFBContainer &paContainer, TForteUInt8 paParentAdapterlistID);
       ~FORTE_ATimeOut_Plug() override = default;
-
-      void readInputData(TEventID paEIID) override;
-      void writeOutputData(TEventID paEIID) override;
 
       CEventConnection conn_TimeOUT;
 
       CDataConnection *conn_DT;
 
     protected:
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
       CEventConnection *getEOConUnchecked(TPortId paEONum) override;
       CIEC_ANY *getDI(TPortId paDINum) override;
       CDataConnection **getDIConUnchecked(TPortId paDINum) override;
       CDataConnection *getDOConUnchecked(TPortId paDONum) override;
       CIEC_ANY *getDO(TPortId paDONum) override;
-
-    private:
-      FORTE_ATimeOut_Socket *getSocket();
   };
 
   class FORTE_ATimeOut_Socket final : public FORTE_ATimeOut {
@@ -82,24 +76,18 @@ namespace forte::iec61499::events {
       FORTE_ATimeOut_Socket(StringId paInstanceNameId, CFBContainer &paContainer, TForteUInt8 paParentAdapterlistID);
       ~FORTE_ATimeOut_Socket() override = default;
 
-      void readInputData(TEventID paEIID) override;
-      void writeOutputData(TEventID paEIID) override;
-
       CEventConnection conn_START;
       CEventConnection conn_STOP;
 
       COutDataConnection<CIEC_TIME> conn_DT;
 
-    protected:
+    private:
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
       CEventConnection *getEOConUnchecked(TPortId paEONum) override;
       CIEC_ANY *getDI(TPortId paDINum) override;
       CDataConnection **getDIConUnchecked(TPortId paDINum) override;
       CDataConnection *getDOConUnchecked(TPortId paDONum) override;
       CIEC_ANY *getDO(TPortId paDONum) override;
-
-    private:
-      FORTE_ATimeOut_Plug *getPlug() {
-        return static_cast<FORTE_ATimeOut_Plug *>(getPeer());
-      }
   };
 } // namespace forte::iec61499::events

--- a/stdfblib/events/src/ATimeOut_adp.cpp
+++ b/stdfblib/events/src/ATimeOut_adp.cpp
@@ -50,6 +50,7 @@ namespace forte::iec61499::events {
   DEFINE_ADAPTER_TYPE(FORTE_ATimeOut, "iec61499::events::ATimeOut"_STRID)
 
   void FORTE_ATimeOut::setInitialValues() {
+    forte::CAdapter::setInitialValues();
     var_DT = 0_TIME;
   }
 
@@ -64,14 +65,15 @@ namespace forte::iec61499::events {
                                            CFBContainer &paContainer,
                                            TForteUInt8 paParentAdapterlistID) :
       FORTE_ATimeOut(paContainer, cFBInterfaceSpecPlug, paInstanceNameId, paParentAdapterlistID),
-      conn_TimeOUT(*this, 0) {
+      conn_TimeOUT(*this, 0),
+      conn_DT(nullptr) {
   }
 
   void FORTE_ATimeOut_Plug::readInputData(TEventID paEIID) {
     if (paEIID == scmEventSTARTID) {
       readData(0, var_DT, conn_DT);
-      if (getPeer() != nullptr) {
-        getSocket()->var_DT = var_DT;
+      if (auto peer = static_cast<FORTE_ATimeOut_Socket *>(getPeer()); peer) {
+        peer->var_DT = var_DT;
       }
     }
   }
@@ -97,10 +99,6 @@ namespace forte::iec61499::events {
 
   CIEC_ANY *FORTE_ATimeOut_Plug::getDO(TPortId) {
     return nullptr;
-  }
-
-  FORTE_ATimeOut_Socket *FORTE_ATimeOut_Plug::getSocket() {
-    return static_cast<FORTE_ATimeOut_Socket *>(getPeer());
   }
 
   FORTE_ATimeOut_Socket::FORTE_ATimeOut_Socket(StringId paInstanceNameId,


### PR DESCRIPTION
This clean-up is trying to bring the minimal changes needed from the export into these two adatpers.

This try to minimize the noise from PR #730 