### PR TITLE
Adds SPLIT_DWORD_INTO_BYTES functionality

### DIFF
--- a/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BYTES_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BYTES_fct.h
@@ -8,20 +8,22 @@
  ***
  *** FORTE Library Element
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.0.0.202512201229!
  ***
  *** Name: ASSEMBLE_DWORD_FROM_BYTES
- *** Description: this Function combines the 2 BYTES to a DWORD
+ *** Description: this Function combines the 4 BYTES to a DWORD
  *** Version:
- ***     1.0: 2024-02-22/Franz Höpfinger - HR Agrartechnik - initial Implementation
+ ***     3.0.1: 2025-12-21/Franz Höpfinger - HR Agrartechnik - fix 2 --> 4
+ ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.1: 2024-07-28/Moritz Ortmeier - HR Agrartechnik - rename Function and change Input/Output Variables
+ ***     1.0: 2024-02-22/Franz Höpfinger - HR Agrartechnik - initial Implementation
  *************************************************************************/
 
 #pragma once
 
 #include "forte/funcbloc.h"
-#include "forte/datatypes/forte_dword.h"
 #include "forte/datatypes/forte_byte.h"
+#include "forte/datatypes/forte_dword.h"
 #include "forte/iec61131_functions.h"
 #include "forte/datatypes/forte_array_common.h"
 #include "forte/datatypes/forte_array.h"
@@ -33,8 +35,8 @@ namespace forte::eclipse4diac::utils::assembling {
       DECLARE_FIRMWARE_FB(FORTE_ASSEMBLE_DWORD_FROM_BYTES)
 
     private:
-      static const TEventID scmEventREQID = 0;
       static const TEventID scmEventCNFID = 0;
+      static const TEventID scmEventREQID = 0;
 
       void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
@@ -43,7 +45,7 @@ namespace forte::eclipse4diac::utils::assembling {
       void setInitialValues() override;
 
     public:
-      FORTE_ASSEMBLE_DWORD_FROM_BYTES(forte::StringId paInstanceNameId, CFBContainer &paContainer);
+      FORTE_ASSEMBLE_DWORD_FROM_BYTES(StringId paInstanceNameId, CFBContainer &paContainer);
 
       CIEC_BYTE var_BYTE_00;
       CIEC_BYTE var_BYTE_01;
@@ -67,31 +69,19 @@ namespace forte::eclipse4diac::utils::assembling {
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
 
-      void evt_REQ(const CIEC_BYTE &paBYTE_00,
-                   const CIEC_BYTE &paBYTE_01,
-                   const CIEC_BYTE &paBYTE_02,
-                   const CIEC_BYTE &paBYTE_03,
-                   CAnyBitOutputParameter<CIEC_DWORD> pa) {
-        COutputGuard guard_pa(pa);
+      void evt_REQ(const CIEC_BYTE &paBYTE_00, const CIEC_BYTE &paBYTE_01, const CIEC_BYTE &paBYTE_02, const CIEC_BYTE &paBYTE_03) {
         var_BYTE_00 = paBYTE_00;
         var_BYTE_01 = paBYTE_01;
         var_BYTE_02 = paBYTE_02;
         var_BYTE_03 = paBYTE_03;
         executeEvent(scmEventREQID, nullptr);
-        *pa = var_;
       }
 
-      void operator()(const CIEC_BYTE &paBYTE_00,
-                      const CIEC_BYTE &paBYTE_01,
-                      const CIEC_BYTE &paBYTE_02,
-                      const CIEC_BYTE &paBYTE_03,
-                      CAnyBitOutputParameter<CIEC_DWORD> &pa) {
-        evt_REQ(paBYTE_00, paBYTE_01, paBYTE_02, paBYTE_03, pa);
+      void operator()(const CIEC_BYTE &paBYTE_00, const CIEC_BYTE &paBYTE_01, const CIEC_BYTE &paBYTE_02, const CIEC_BYTE &paBYTE_03) {
+        evt_REQ(std::forward<const CIEC_BYTE &>(paBYTE_00), std::forward<const CIEC_BYTE &>(paBYTE_01), std::forward<const CIEC_BYTE &>(paBYTE_02), std::forward<const CIEC_BYTE &>(paBYTE_03));
       }
   };
 
-  CIEC_DWORD func_ASSEMBLE_DWORD_FROM_BYTES(CIEC_BYTE st_lv_BYTE_00,
-                                            CIEC_BYTE st_lv_BYTE_01,
-                                            CIEC_BYTE st_lv_BYTE_02,
-                                            CIEC_BYTE st_lv_BYTE_03);
-} // namespace forte::eclipse4diac::utils::assembling
+  CIEC_DWORD func_ASSEMBLE_DWORD_FROM_BYTES(const CIEC_BYTE &st_lv_BYTE_00, const CIEC_BYTE &st_lv_BYTE_01, const CIEC_BYTE &st_lv_BYTE_02, const CIEC_BYTE &st_lv_BYTE_03);
+}
+

--- a/modules/utils/include/forte/eclipse4diac/utils/splitting/CMakeLists.txt
+++ b/modules/utils/include/forte/eclipse4diac/utils/splitting/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(forte-utils PUBLIC
         SPLIT_BYTE_INTO_BOOLS_fct.h
         SPLIT_BYTE_INTO_QUARTERS_fct.h
         SPLIT_DWORD_INTO_BOOLS_fct.h
+        SPLIT_DWORD_INTO_BYTES_fct.h
         SPLIT_DWORD_INTO_QUARTERS_fct.h
         SPLIT_DWORD_INTO_WORDS_fct.h
         SPLIT_LWORD_INTO_BOOLS_fct.h

--- a/modules/utils/include/forte/eclipse4diac/utils/splitting/SPLIT_DWORD_INTO_BYTES_fct.h
+++ b/modules/utils/include/forte/eclipse4diac/utils/splitting/SPLIT_DWORD_INTO_BYTES_fct.h
@@ -1,0 +1,89 @@
+/*************************************************************************
+ *** Copyright (c) 2025 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.0.0.202512201229!
+ ***
+ *** Name: SPLIT_DWORD_INTO_BYTES
+ *** Description: this Function extracts the 4 BYTE from a dword
+ *** Version:
+ ***     1.0: 2025-12-21/Franz Höpfinger - HR Agrartechnik - initial Version
+ *************************************************************************/
+
+#pragma once
+
+#include "forte/funcbloc.h"
+#include "forte/datatypes/forte_byte.h"
+#include "forte/datatypes/forte_dword.h"
+#include "forte/iec61131_functions.h"
+#include "forte/datatypes/forte_array_common.h"
+#include "forte/datatypes/forte_array.h"
+#include "forte/datatypes/forte_array_fixed.h"
+#include "forte/datatypes/forte_array_variable.h"
+
+namespace forte::eclipse4diac::utils::splitting {
+  class FORTE_SPLIT_DWORD_INTO_BYTES final : public CFunctionBlock {
+      DECLARE_FIRMWARE_FB(FORTE_SPLIT_DWORD_INTO_BYTES)
+
+    private:
+      static const TEventID scmEventCNFID = 0;
+      static const TEventID scmEventREQID = 0;
+
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    public:
+      FORTE_SPLIT_DWORD_INTO_BYTES(StringId paInstanceNameId, CFBContainer &paContainer);
+
+      CIEC_DWORD var_IN;
+
+      CIEC_BYTE var_BYTE_00;
+      CIEC_BYTE var_BYTE_01;
+      CIEC_BYTE var_BYTE_02;
+      CIEC_BYTE var_BYTE_03;
+
+      CEventConnection conn_CNF;
+
+      CDataConnection *conn_IN;
+
+      COutDataConnection<CIEC_BYTE> conn_BYTE_00;
+      COutDataConnection<CIEC_BYTE> conn_BYTE_01;
+      COutDataConnection<CIEC_BYTE> conn_BYTE_02;
+      COutDataConnection<CIEC_BYTE> conn_BYTE_03;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+
+      void evt_REQ(const CIEC_DWORD &paIN, CAnyBitOutputParameter<CIEC_BYTE> paBYTE_00, CAnyBitOutputParameter<CIEC_BYTE> paBYTE_01, CAnyBitOutputParameter<CIEC_BYTE> paBYTE_02, CAnyBitOutputParameter<CIEC_BYTE> paBYTE_03) {
+        COutputGuard guard_BYTE_00(paBYTE_00);
+        COutputGuard guard_BYTE_01(paBYTE_01);
+        COutputGuard guard_BYTE_02(paBYTE_02);
+        COutputGuard guard_BYTE_03(paBYTE_03);
+        var_IN = paIN;
+        executeEvent(scmEventREQID, nullptr);
+        *paBYTE_00 = var_BYTE_00;
+        *paBYTE_01 = var_BYTE_01;
+        *paBYTE_02 = var_BYTE_02;
+        *paBYTE_03 = var_BYTE_03;
+      }
+
+      void operator()(const CIEC_DWORD &paIN, CAnyBitOutputParameter<CIEC_BYTE> paBYTE_00, CAnyBitOutputParameter<CIEC_BYTE> paBYTE_01, CAnyBitOutputParameter<CIEC_BYTE> paBYTE_02, CAnyBitOutputParameter<CIEC_BYTE> paBYTE_03) {
+        evt_REQ(std::forward<const CIEC_DWORD &>(paIN), std::forward<CAnyBitOutputParameter<CIEC_BYTE>>(paBYTE_00), std::forward<CAnyBitOutputParameter<CIEC_BYTE>>(paBYTE_01), std::forward<CAnyBitOutputParameter<CIEC_BYTE>>(paBYTE_02), std::forward<CAnyBitOutputParameter<CIEC_BYTE>>(paBYTE_03));
+      }
+  };
+
+  void func_SPLIT_DWORD_INTO_BYTES(const CIEC_DWORD &st_lv_IN, CAnyBitOutputParameter<CIEC_BYTE> st_lv_BYTE_00, CAnyBitOutputParameter<CIEC_BYTE> st_lv_BYTE_01, CAnyBitOutputParameter<CIEC_BYTE> st_lv_BYTE_02, CAnyBitOutputParameter<CIEC_BYTE> st_lv_BYTE_03);
+}
+

--- a/modules/utils/src/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BYTES_fct.cpp
+++ b/modules/utils/src/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BYTES_fct.cpp
@@ -8,21 +8,21 @@
  ***
  *** FORTE Library Element
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.0.0.202512201229!
  ***
  *** Name: ASSEMBLE_DWORD_FROM_BYTES
- *** Description: this Function combines the 2 BYTES to a DWORD
+ *** Description: this Function combines the 4 BYTES to a DWORD
  *** Version:
- ***     1.0: 2024-02-22/Franz Höpfinger - HR Agrartechnik - initial Implementation
+ ***     3.0.1: 2025-12-21/Franz Höpfinger - HR Agrartechnik - fix 2 --> 4
+ ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.1: 2024-07-28/Moritz Ortmeier - HR Agrartechnik - rename Function and change Input/Output Variables
+ ***     1.0: 2024-02-22/Franz Höpfinger - HR Agrartechnik - initial Implementation
  *************************************************************************/
 
 #include "forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BYTES_fct.h"
 
-using namespace forte::literals;
-
-#include "forte/datatypes/forte_dword.h"
 #include "forte/datatypes/forte_byte.h"
+#include "forte/datatypes/forte_dword.h"
 #include "forte/iec61131_functions.h"
 #include "forte/datatypes/forte_array_common.h"
 #include "forte/datatypes/forte_array.h"
@@ -30,33 +30,39 @@ using namespace forte::literals;
 #include "forte/datatypes/forte_array_variable.h"
 #include "forte/eclipse4diac/utils/assembling/ASSEMBLE_DWORD_FROM_BYTES_fct.h"
 
+using namespace std::literals;
+using namespace forte::literals;
+
 namespace forte::eclipse4diac::utils::assembling {
   namespace {
+    constexpr std::string_view TypeHash =""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
     const auto cDataInputNames = std::array{"BYTE_00"_STRID, "BYTE_01"_STRID, "BYTE_02"_STRID, "BYTE_03"_STRID};
     const auto cDataOutputNames = std::array{""_STRID};
-    const auto cEventInputNames = std::array{"REQ"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
-        .mEITypeNames = cEventInputTypeIds,
+        .mEITypeNames = {},
         .mEONames = cEventOutputNames,
-        .mEOTypeNames = cEventOutputTypeIds,
+        .mEOTypeNames = {},
         .mDINames = cDataInputNames,
         .mDONames = cDataOutputNames,
         .mDIONames = {},
         .mSocketNames = {},
         .mPlugNames = {},
     };
-  } // namespace
+  }
 
-  DEFINE_FIRMWARE_FB(FORTE_ASSEMBLE_DWORD_FROM_BYTES,
-                     "eclipse4diac::utils::assembling::ASSEMBLE_DWORD_FROM_BYTES"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_ASSEMBLE_DWORD_FROM_BYTES, "eclipse4diac::utils::assembling::ASSEMBLE_DWORD_FROM_BYTES"_STRID, TypeHash)
 
-  FORTE_ASSEMBLE_DWORD_FROM_BYTES::FORTE_ASSEMBLE_DWORD_FROM_BYTES(const forte::StringId paInstanceNameId,
-                                                                   CFBContainer &paContainer) :
+  FORTE_ASSEMBLE_DWORD_FROM_BYTES::FORTE_ASSEMBLE_DWORD_FROM_BYTES(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CFunctionBlock(paContainer, cFBInterfaceSpec, paInstanceNameId),
+      var_BYTE_00(0_BYTE),
+      var_BYTE_01(0_BYTE),
+      var_BYTE_02(0_BYTE),
+      var_BYTE_03(0_BYTE),
+      var_(0_DWORD),
       conn_CNF(*this, 0),
       conn_BYTE_00(nullptr),
       conn_BYTE_01(nullptr),
@@ -66,6 +72,7 @@ namespace forte::eclipse4diac::utils::assembling {
   }
 
   void FORTE_ASSEMBLE_DWORD_FROM_BYTES::setInitialValues() {
+    CFunctionBlock::setInitialValues();
     var_BYTE_00 = 0_BYTE;
     var_BYTE_01 = 0_BYTE;
     var_BYTE_02 = 0_BYTE;
@@ -74,7 +81,7 @@ namespace forte::eclipse4diac::utils::assembling {
   }
 
   void FORTE_ASSEMBLE_DWORD_FROM_BYTES::readInputData(const TEventID paEIID) {
-    switch (paEIID) {
+    switch(paEIID) {
       case scmEventREQID: {
         readData(0, var_BYTE_00, conn_BYTE_00);
         readData(1, var_BYTE_01, conn_BYTE_01);
@@ -82,22 +89,24 @@ namespace forte::eclipse4diac::utils::assembling {
         readData(3, var_BYTE_03, conn_BYTE_03);
         break;
       }
-      default: break;
+      default:
+        break;
     }
   }
 
   void FORTE_ASSEMBLE_DWORD_FROM_BYTES::writeOutputData(const TEventID paEIID) {
-    switch (paEIID) {
+    switch(paEIID) {
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, var_, conn_);
+        writeData(4, var_, conn_);
         break;
       }
-      default: break;
+      default:
+        break;
     }
   }
 
   CIEC_ANY *FORTE_ASSEMBLE_DWORD_FROM_BYTES::getDI(const size_t paIndex) {
-    switch (paIndex) {
+    switch(paIndex) {
       case 0: return &var_BYTE_00;
       case 1: return &var_BYTE_01;
       case 2: return &var_BYTE_02;
@@ -107,21 +116,21 @@ namespace forte::eclipse4diac::utils::assembling {
   }
 
   CIEC_ANY *FORTE_ASSEMBLE_DWORD_FROM_BYTES::getDO(const size_t paIndex) {
-    switch (paIndex) {
+    switch(paIndex) {
       case 0: return &var_;
     }
     return nullptr;
   }
 
   CEventConnection *FORTE_ASSEMBLE_DWORD_FROM_BYTES::getEOConUnchecked(const TPortId paIndex) {
-    switch (paIndex) {
+    switch(paIndex) {
       case 0: return &conn_CNF;
     }
     return nullptr;
   }
 
   CDataConnection **FORTE_ASSEMBLE_DWORD_FROM_BYTES::getDIConUnchecked(const TPortId paIndex) {
-    switch (paIndex) {
+    switch(paIndex) {
       case 0: return &conn_BYTE_00;
       case 1: return &conn_BYTE_01;
       case 2: return &conn_BYTE_02;
@@ -131,7 +140,7 @@ namespace forte::eclipse4diac::utils::assembling {
   }
 
   CDataConnection *FORTE_ASSEMBLE_DWORD_FROM_BYTES::getDOConUnchecked(const TPortId paIndex) {
-    switch (paIndex) {
+    switch(paIndex) {
       case 0: return &conn_;
     }
     return nullptr;
@@ -142,21 +151,19 @@ namespace forte::eclipse4diac::utils::assembling {
     sendOutputEvent(scmEventCNFID, paECET);
   }
 
-  CIEC_DWORD func_ASSEMBLE_DWORD_FROM_BYTES(CIEC_BYTE st_lv_BYTE_00,
-                                            CIEC_BYTE st_lv_BYTE_01,
-                                            CIEC_BYTE st_lv_BYTE_02,
-                                            CIEC_BYTE st_lv_BYTE_03) {
+  CIEC_DWORD func_ASSEMBLE_DWORD_FROM_BYTES(const CIEC_BYTE &st_lv_BYTE_00, const CIEC_BYTE &st_lv_BYTE_01, const CIEC_BYTE &st_lv_BYTE_02, const CIEC_BYTE &st_lv_BYTE_03) {
     CIEC_DWORD st_ret_val = 0_DWORD;
 
-#line 11 "ASSEMBLE_DWORD_FROM_BYTES.fct"
+    #line 11 "ASSEMBLE_DWORD_FROM_BYTES.fct"
     st_ret_val.partial<CIEC_BYTE>(0) = st_lv_BYTE_00;
-#line 12 "ASSEMBLE_DWORD_FROM_BYTES.fct"
+    #line 12 "ASSEMBLE_DWORD_FROM_BYTES.fct"
     st_ret_val.partial<CIEC_BYTE>(1) = st_lv_BYTE_01;
-#line 13 "ASSEMBLE_DWORD_FROM_BYTES.fct"
+    #line 13 "ASSEMBLE_DWORD_FROM_BYTES.fct"
     st_ret_val.partial<CIEC_BYTE>(2) = st_lv_BYTE_02;
-#line 14 "ASSEMBLE_DWORD_FROM_BYTES.fct"
+    #line 14 "ASSEMBLE_DWORD_FROM_BYTES.fct"
     st_ret_val.partial<CIEC_BYTE>(3) = st_lv_BYTE_03;
 
     return st_ret_val;
   }
-} // namespace forte::eclipse4diac::utils::assembling
+
+}

--- a/modules/utils/src/eclipse4diac/utils/splitting/CMakeLists.txt
+++ b/modules/utils/src/eclipse4diac/utils/splitting/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(forte-utils PRIVATE
         SPLIT_BYTE_INTO_BOOLS_fct.cpp
         SPLIT_BYTE_INTO_QUARTERS_fct.cpp
         SPLIT_DWORD_INTO_BOOLS_fct.cpp
+        SPLIT_DWORD_INTO_BYTES_fct.cpp
         SPLIT_DWORD_INTO_QUARTERS_fct.cpp
         SPLIT_DWORD_INTO_WORDS_fct.cpp
         SPLIT_LWORD_INTO_BOOLS_fct.cpp

--- a/modules/utils/src/eclipse4diac/utils/splitting/SPLIT_DWORD_INTO_BYTES_fct.cpp
+++ b/modules/utils/src/eclipse4diac/utils/splitting/SPLIT_DWORD_INTO_BYTES_fct.cpp
@@ -1,0 +1,171 @@
+/*************************************************************************
+ *** Copyright (c) 2025 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.0.0.202512201229!
+ ***
+ *** Name: SPLIT_DWORD_INTO_BYTES
+ *** Description: this Function extracts the 4 BYTE from a dword
+ *** Version:
+ ***     1.0: 2025-12-21/Franz Höpfinger - HR Agrartechnik - initial Version
+ *************************************************************************/
+
+#include "forte/eclipse4diac/utils/splitting/SPLIT_DWORD_INTO_BYTES_fct.h"
+
+#include "forte/datatypes/forte_byte.h"
+#include "forte/datatypes/forte_dword.h"
+#include "forte/iec61131_functions.h"
+#include "forte/datatypes/forte_array_common.h"
+#include "forte/datatypes/forte_array.h"
+#include "forte/datatypes/forte_array_fixed.h"
+#include "forte/datatypes/forte_array_variable.h"
+
+using namespace std::literals;
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::utils::splitting {
+  namespace {
+    constexpr std::string_view TypeHash =""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
+    const auto cDataInputNames = std::array{"IN"_STRID};
+    const auto cDataOutputNames = std::array{"BYTE_00"_STRID, "BYTE_01"_STRID, "BYTE_02"_STRID, "BYTE_03"_STRID};
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = {},
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = {},
+        .mDINames = cDataInputNames,
+        .mDONames = cDataOutputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+  }
+
+  DEFINE_FIRMWARE_FB(FORTE_SPLIT_DWORD_INTO_BYTES, "eclipse4diac::utils::splitting::SPLIT_DWORD_INTO_BYTES"_STRID, TypeHash)
+
+  FORTE_SPLIT_DWORD_INTO_BYTES::FORTE_SPLIT_DWORD_INTO_BYTES(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CFunctionBlock(paContainer, cFBInterfaceSpec, paInstanceNameId),
+      var_IN(0_DWORD),
+      var_BYTE_00(0_BYTE),
+      var_BYTE_01(0_BYTE),
+      var_BYTE_02(0_BYTE),
+      var_BYTE_03(0_BYTE),
+      conn_CNF(*this, 0),
+      conn_IN(nullptr),
+      conn_BYTE_00(*this, 0, var_BYTE_00),
+      conn_BYTE_01(*this, 1, var_BYTE_01),
+      conn_BYTE_02(*this, 2, var_BYTE_02),
+      conn_BYTE_03(*this, 3, var_BYTE_03) {
+  }
+
+  void FORTE_SPLIT_DWORD_INTO_BYTES::setInitialValues() {
+    CFunctionBlock::setInitialValues();
+    var_IN = 0_DWORD;
+    var_BYTE_00 = 0_BYTE;
+    var_BYTE_01 = 0_BYTE;
+    var_BYTE_02 = 0_BYTE;
+    var_BYTE_03 = 0_BYTE;
+  }
+
+  void FORTE_SPLIT_DWORD_INTO_BYTES::readInputData(const TEventID paEIID) {
+    switch(paEIID) {
+      case scmEventREQID: {
+        readData(0, var_IN, conn_IN);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  void FORTE_SPLIT_DWORD_INTO_BYTES::writeOutputData(const TEventID paEIID) {
+    switch(paEIID) {
+      case scmEventCNFID: {
+        writeData(1, var_BYTE_00, conn_BYTE_00);
+        writeData(2, var_BYTE_01, conn_BYTE_01);
+        writeData(3, var_BYTE_02, conn_BYTE_02);
+        writeData(4, var_BYTE_03, conn_BYTE_03);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  CIEC_ANY *FORTE_SPLIT_DWORD_INTO_BYTES::getDI(const size_t paIndex) {
+    switch(paIndex) {
+      case 0: return &var_IN;
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_SPLIT_DWORD_INTO_BYTES::getDO(const size_t paIndex) {
+    switch(paIndex) {
+      case 0: return &var_BYTE_00;
+      case 1: return &var_BYTE_01;
+      case 2: return &var_BYTE_02;
+      case 3: return &var_BYTE_03;
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_SPLIT_DWORD_INTO_BYTES::getEOConUnchecked(const TPortId paIndex) {
+    switch(paIndex) {
+      case 0: return &conn_CNF;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_SPLIT_DWORD_INTO_BYTES::getDIConUnchecked(const TPortId paIndex) {
+    switch(paIndex) {
+      case 0: return &conn_IN;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_SPLIT_DWORD_INTO_BYTES::getDOConUnchecked(const TPortId paIndex) {
+    switch(paIndex) {
+      case 0: return &conn_BYTE_00;
+      case 1: return &conn_BYTE_01;
+      case 2: return &conn_BYTE_02;
+      case 3: return &conn_BYTE_03;
+    }
+    return nullptr;
+  }
+
+  void FORTE_SPLIT_DWORD_INTO_BYTES::executeEvent(const TEventID, CEventChainExecutionThread *const paECET) {
+    func_SPLIT_DWORD_INTO_BYTES(var_IN, var_BYTE_00, var_BYTE_01, var_BYTE_02, var_BYTE_03);
+    sendOutputEvent(scmEventCNFID, paECET);
+  }
+
+  void func_SPLIT_DWORD_INTO_BYTES(const CIEC_DWORD &st_lv_IN, CAnyBitOutputParameter<CIEC_BYTE> st_lv_BYTE_00, CAnyBitOutputParameter<CIEC_BYTE> st_lv_BYTE_01, CAnyBitOutputParameter<CIEC_BYTE> st_lv_BYTE_02, CAnyBitOutputParameter<CIEC_BYTE> st_lv_BYTE_03) {
+    COutputGuard st_guard_BYTE_00(st_lv_BYTE_00);
+    COutputGuard st_guard_BYTE_01(st_lv_BYTE_01);
+    COutputGuard st_guard_BYTE_02(st_lv_BYTE_02);
+    COutputGuard st_guard_BYTE_03(st_lv_BYTE_03);
+    (*st_lv_BYTE_00) = 0_BYTE;
+    (*st_lv_BYTE_01) = 0_BYTE;
+    (*st_lv_BYTE_02) = 0_BYTE;
+    (*st_lv_BYTE_03) = 0_BYTE;
+
+    #line 15 "SPLIT_DWORD_INTO_BYTES.fct"
+    (*st_lv_BYTE_00) = st_lv_IN.cpartial<CIEC_BYTE>(0);
+    #line 16 "SPLIT_DWORD_INTO_BYTES.fct"
+    (*st_lv_BYTE_01) = st_lv_IN.cpartial<CIEC_BYTE>(1);
+    #line 17 "SPLIT_DWORD_INTO_BYTES.fct"
+    (*st_lv_BYTE_02) = st_lv_IN.cpartial<CIEC_BYTE>(2);
+    #line 18 "SPLIT_DWORD_INTO_BYTES.fct"
+    (*st_lv_BYTE_03) = st_lv_IN.cpartial<CIEC_BYTE>(3);
+
+  }
+
+}


### PR DESCRIPTION
Introduces a new function to split a DWORD into four bytes, enhancing data handling capabilities. Updates internal logic for consistency and optimizes interface declaration.

Fixes incorrect byte count in ASSEMBLE_DWORD_FROM_BYTES description.
