### PR TITLE
fix: FQN of FBs is now correct for the io layer

### DIFF
--- a/core/src/io/IB_fbt.cpp
+++ b/core/src/io/IB_fbt.cpp
@@ -18,7 +18,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_IB, "IB"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_IB, "eclipse4diac::io::IB"_STRID)
 
   FORTE_IB::FORTE_IB(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CInputFB<CIEC_BYTE>(paContainer, paInstanceNameId) {

--- a/core/src/io/ID_fbt.cpp
+++ b/core/src/io/ID_fbt.cpp
@@ -19,7 +19,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_ID, "ID"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_ID, "eclipse4diac::io::ID"_STRID)
 
   FORTE_ID::FORTE_ID(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CInputFB<CIEC_DWORD>(paContainer, paInstanceNameId) {};

--- a/core/src/io/IE_fbt.cpp
+++ b/core/src/io/IE_fbt.cpp
@@ -42,7 +42,7 @@ namespace forte::io {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_IE, "IE"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_IE, "eclipse4diac::io::IE"_STRID)
 
   FORTE_IE::FORTE_IE(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CProcessInterfaceFB(paContainer, cFBInterfaceSpec, paInstanceNameId),

--- a/core/src/io/IL_fbt.cpp
+++ b/core/src/io/IL_fbt.cpp
@@ -18,7 +18,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_IL, "IL"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_IL, "eclipse4diac::io::IL"_STRID)
 
   FORTE_IL::FORTE_IL(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CInputFB<CIEC_LWORD>(paContainer, paInstanceNameId) {

--- a/core/src/io/IW_fbt.cpp
+++ b/core/src/io/IW_fbt.cpp
@@ -18,7 +18,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_IW, "IW"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_IW, "eclipse4diac::io::IW"_STRID)
 
   FORTE_IW::FORTE_IW(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CInputFB<CIEC_WORD>(paContainer, paInstanceNameId) {

--- a/core/src/io/IX_fbt.cpp
+++ b/core/src/io/IX_fbt.cpp
@@ -18,7 +18,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_IX, "IX"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_IX, "eclipse4diac::io::IX"_STRID)
 
   FORTE_IX::FORTE_IX(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CInputFB<CIEC_BOOL>(paContainer, paInstanceNameId) {

--- a/core/src/io/QB_fbt.cpp
+++ b/core/src/io/QB_fbt.cpp
@@ -18,7 +18,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_QB, "QB"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_QB, "eclipse4diac::io::QB"_STRID)
 
   FORTE_QB::FORTE_QB(const StringId paInstanceNameId, CFBContainer &paContainer) :
       COutputFB<CIEC_BYTE>(paContainer, paInstanceNameId) {

--- a/core/src/io/QD_fbt.cpp
+++ b/core/src/io/QD_fbt.cpp
@@ -19,7 +19,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_QD, "QD"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_QD, "eclipse4diac::io::QD"_STRID)
 
   FORTE_QD::FORTE_QD(const StringId paInstanceNameId, CFBContainer &paContainer) :
       COutputFB<CIEC_DWORD>(paContainer, paInstanceNameId) {

--- a/core/src/io/QL_fbt.cpp
+++ b/core/src/io/QL_fbt.cpp
@@ -17,7 +17,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_QL, "QL"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_QL, "eclipse4diac::io::QL"_STRID)
 
   FORTE_QL::FORTE_QL(const StringId paInstanceNameId, CFBContainer &paContainer) :
       COutputFB<CIEC_LWORD>(paContainer, paInstanceNameId) {};

--- a/core/src/io/QW_fbt.cpp
+++ b/core/src/io/QW_fbt.cpp
@@ -18,7 +18,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_QW, "QW"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_QW, "eclipse4diac::io::QW"_STRID)
 
   FORTE_QW::FORTE_QW(const StringId paInstanceNameId, CFBContainer &paContainer) :
       COutputFB<CIEC_WORD>(paContainer, paInstanceNameId) {

--- a/core/src/io/QX_fbt.cpp
+++ b/core/src/io/QX_fbt.cpp
@@ -18,7 +18,7 @@
 using namespace forte::literals;
 
 namespace forte::io {
-  DEFINE_FIRMWARE_FB(FORTE_QX, "QX"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_QX, "eclipse4diac::io::QX"_STRID)
 
   FORTE_QX::FORTE_QX(const StringId paInstanceNameId, CFBContainer &paContainer) :
       COutputFB<CIEC_BOOL>(paContainer, paInstanceNameId) {


### PR DESCRIPTION
Before that change the IO layer FBs were not found and this resulted in a 
`<Response ID="1" Reason="UNSUPPORTED_TYPE"/>` response.