### PR TITLE
Fix missing includes for embrick module

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: cpp-linter/cpp-linter-action@v2.16.6
+      - uses: cpp-linter/cpp-linter-action@v2.16.7
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/modules/embrick/handler/pin.cpp
+++ b/modules/embrick/handler/pin.cpp
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string>
+#include <cstring>
 
 namespace forte::eclipse4diac::io::embrick {
 


### PR DESCRIPTION
Adding `#include <cstring>` to the `modules/embrick/handler/pin.cpp`, so that the embrick module compiles without an error.
