### PR TITLE
Allow multiple IOObservers for inputs in the I/O system #752

### DIFF
--- a/core/include/forte/io/mapper/io_handle.h
+++ b/core/include/forte/io/mapper/io_handle.h
@@ -33,11 +33,11 @@ namespace forte::io {
       virtual ~IOHandle();
 
       bool hasObserver() const {
-        return !!mObserver;
+        return !mObservers.empty();
       }
 
       IOObserver *getObserver() {
-        return mObserver;
+        return mObservers.empty() ? nullptr : mObservers.front();
       }
 
       std::vector<IOObserver *> &getObservers() {
@@ -77,7 +77,6 @@ namespace forte::io {
 
     private:
       std::vector<IOObserver *> mObservers; // We now support multiple observers on inputs.
-      IOObserver *mObserver; // The first or only observer for faster checking.
   };
 
 } // namespace forte::io

--- a/core/include/forte/io/mapper/io_handle.h
+++ b/core/include/forte/io/mapper/io_handle.h
@@ -40,7 +40,7 @@ namespace forte::io {
         return mObserver;
       }
 
-      std::vector<IOObserver*>& getObservers() {
+      std::vector<IOObserver *> &getObservers() {
         return mObservers;
       }
 
@@ -73,11 +73,11 @@ namespace forte::io {
 
       virtual void onObserver(IOObserver *paObserver);
       virtual void dropObserver();
-      virtual void dropObserver(IOObserver* paObserver);
+      virtual void dropObserver(IOObserver *paObserver);
 
     private:
-      std::vector<IOObserver*>mObservers; // We now support multiple observers on inputs.
-      IOObserver *mObserver;  // The first or only observer for faster checking.
+      std::vector<IOObserver *> mObservers; // We now support multiple observers on inputs.
+      IOObserver *mObserver; // The first or only observer for faster checking.
   };
 
 } // namespace forte::io

--- a/core/include/forte/io/mapper/io_handle.h
+++ b/core/include/forte/io/mapper/io_handle.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016 - 2018 Johannes Messmer (admin@jomess.com), fortiss GmbH
+ * Copyright (c) 2016 - 2026 Johannes Messmer (admin@jomess.com), fortiss GmbH,
+ *                           AVL List GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +10,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
+ *   Thomas Oellinger - Add support for multiple observers per input.
  *******************************************************************************/
 
 #ifndef SRC_CORE_IO_MAPPER_HANDLE_H_
@@ -36,6 +38,10 @@ namespace forte::io {
 
       IOObserver *getObserver() {
         return mObserver;
+      }
+
+      std::vector<IOObserver*>& getObservers() {
+        return mObservers;
       }
 
       CIEC_ANY::EDataTypeID getIOHandleDataType() const {
@@ -67,9 +73,11 @@ namespace forte::io {
 
       virtual void onObserver(IOObserver *paObserver);
       virtual void dropObserver();
+      virtual void dropObserver(IOObserver* paObserver);
 
     private:
-      IOObserver *mObserver;
+      std::vector<IOObserver*>mObservers; // We now support multiple observers on inputs.
+      IOObserver *mObserver;  // The first or only observer for faster checking.
   };
 
 } // namespace forte::io

--- a/core/src/io/mapper/io_handle.cpp
+++ b/core/src/io/mapper/io_handle.cpp
@@ -22,8 +22,7 @@ namespace forte::io {
   IOHandle::IOHandle(IODeviceController *paController, IOMapper::Direction paDirection, CIEC_ANY::EDataTypeID paType) :
       mController(paController),
       mType(paType),
-      mDirection(paDirection),
-      mObserver(nullptr) {
+      mDirection(paDirection) {
   }
 
   IOHandle::~IOHandle() {
@@ -31,18 +30,13 @@ namespace forte::io {
   }
 
   void IOHandle::onObserver(IOObserver *paObserver) {
-    if (IOMapper::In == mDirection) {
-      if (paObserver) {
-        this->mObservers.push_back(paObserver);
-        this->mObserver = paObserver;
-      }
-    } else {
-      this->mObserver = paObserver;
+    if (paObserver) {
+      this->mObservers.push_back(paObserver);
     }
   }
 
   void IOHandle::dropObserver() {
-    this->mObserver = nullptr;
+    this->mObservers.clear();
   }
 
   void IOHandle::dropObserver(IOObserver *paObserver) {
@@ -50,31 +44,17 @@ namespace forte::io {
       auto iter = std::find(this->mObservers.begin(), this->mObservers.end(), paObserver);
       if (iter != this->mObservers.end()) {
         this->mObservers.erase(iter);
-        if (this->mObservers.empty()) {
-          this->mObserver = nullptr;
-        } else {
-          this->mObserver = this->mObservers.at(0);
-        }
       }
     } else {
-      this->mObserver = nullptr;
       this->mObservers.clear();
     }
   }
 
   void IOHandle::onChange() {
-    if (mObserver != nullptr) {
-      if (mObservers.empty()) { // Single observer for outputs:
-        if (mObserver->onChange()) {
-          mController->fireIndicationEvent(mObserver);
-        }
-      } else { // Multiple observers for inputs:
-        auto itEnd(mObservers.end());
-        for (auto itObserver = mObservers.begin(); itObserver != itEnd;) {
-          if ((*itObserver)->onChange()) {
-            mController->fireIndicationEvent((*itObserver));
-          }
-        }
+    auto itEnd(mObservers.end());
+    for (auto itObserver = mObservers.begin(); itObserver != itEnd;) {
+      if ((*itObserver)->onChange()) {
+        mController->fireIndicationEvent((*itObserver));
       }
     }
   }

--- a/core/src/io/mapper/io_handle.cpp
+++ b/core/src/io/mapper/io_handle.cpp
@@ -36,8 +36,7 @@ namespace forte::io {
         this->mObservers.push_back(paObserver);
         this->mObserver = paObserver;
       }
-    }
-    else {
+    } else {
       this->mObserver = paObserver;
     }
   }
@@ -46,20 +45,18 @@ namespace forte::io {
     this->mObserver = nullptr;
   }
 
-  void IOHandle::dropObserver(IOObserver* paObserver) {
+  void IOHandle::dropObserver(IOObserver *paObserver) {
     if (paObserver) {
       auto iter = std::find(this->mObservers.begin(), this->mObservers.end(), paObserver);
       if (iter != this->mObservers.end()) {
         this->mObservers.erase(iter);
         if (this->mObservers.empty()) {
           this->mObserver = nullptr;
-        }
-        else {
+        } else {
           this->mObserver = this->mObservers.at(0);
         }
       }
-    }
-    else {
+    } else {
       this->mObserver = nullptr;
       this->mObservers.clear();
     }
@@ -71,8 +68,7 @@ namespace forte::io {
         if (mObserver->onChange()) {
           mController->fireIndicationEvent(mObserver);
         }
-      }
-      else {  // Multiple observers for inputs:
+      } else { // Multiple observers for inputs:
         auto itEnd(mObservers.end());
         for (auto itObserver = mObservers.begin(); itObserver != itEnd;) {
           if ((*itObserver)->onChange()) {

--- a/core/src/io/mapper/io_handle.cpp
+++ b/core/src/io/mapper/io_handle.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016 - 2018 Johannes Messmer (admin@jomess.com), fortiss GmbH
+ * Copyright (c) 2016 - 2026 Johannes Messmer (admin@jomess.com), fortiss GmbH,
+ *                           AVL List GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +10,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
+ *   Thomas Oellinger - Add support for multiple observers per input.
  *******************************************************************************/
 
 #include "forte/io/mapper/io_handle.h"
@@ -29,16 +31,55 @@ namespace forte::io {
   }
 
   void IOHandle::onObserver(IOObserver *paObserver) {
-    this->mObserver = paObserver;
+    if (IOMapper::In == mDirection) {
+      if (paObserver) {
+        this->mObservers.push_back(paObserver);
+        this->mObserver = paObserver;
+      }
+    }
+    else {
+      this->mObserver = paObserver;
+    }
   }
 
   void IOHandle::dropObserver() {
     this->mObserver = nullptr;
   }
 
+  void IOHandle::dropObserver(IOObserver* paObserver) {
+    if (paObserver) {
+      auto iter = std::find(this->mObservers.begin(), this->mObservers.end(), paObserver);
+      if (iter != this->mObservers.end()) {
+        this->mObservers.erase(iter);
+        if (this->mObservers.empty()) {
+          this->mObserver = nullptr;
+        }
+        else {
+          this->mObserver = this->mObservers.at(0);
+        }
+      }
+    }
+    else {
+      this->mObserver = nullptr;
+      this->mObservers.clear();
+    }
+  }
+
   void IOHandle::onChange() {
-    if (mObserver != nullptr && mObserver->onChange()) {
-      mController->fireIndicationEvent(mObserver);
+    if (mObserver != nullptr) {
+      if (mObservers.empty()) { // Single observer for outputs:
+        if (mObserver->onChange()) {
+          mController->fireIndicationEvent(mObserver);
+        }
+      }
+      else {  // Multiple observers for inputs:
+        auto itEnd(mObservers.end());
+        for (auto itObserver = mObservers.begin(); itObserver != itEnd;) {
+          if ((*itObserver)->onChange()) {
+            mController->fireIndicationEvent((*itObserver));
+          }
+        }
+      }
     }
   }
 } // namespace forte::io

--- a/core/src/io/mapper/io_mapper.cpp
+++ b/core/src/io/mapper/io_mapper.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2022 Johannes Messmer (admin@jomess.com), fortiss GmbH,
- *                          Jonathan Lainer
+ *                          Jonathan Lainer,
+ *                          AVL List GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -11,6 +12,7 @@
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
  *   Jonathan Lainer - Add method for deregistering Handles by ID.
+ *   Thomas Oellinger - Add support for multiple observers per input.
  *******************************************************************************/
 
 #include "forte/io/mapper/io_mapper.h"
@@ -99,10 +101,17 @@ namespace forte::io {
   bool IOMapper::registerObserver(std::string const &paId, IOObserver *paObserver) {
     util::CCriticalRegion criticalRegion(mSyncMutex);
 
-    // Check for duplicates
-    if (mObservers.find(paId) != mObservers.end()) {
-      DEVLOG_WARNING("[IOMapper]  Duplicated observer entry '%s'\n", paId.c_str());
-      return false;
+    auto handleIt = mHandles.find(paId);
+    if (handleIt != mHandles.end()) {
+      auto handle = handleIt->second;
+      // We now allow multiple observer per input channel:
+      if (handle->getDirection() != IOMapper::Direction::In) {
+        // If not input then do not allow duplicates
+        if (mObservers.find(paId) != mObservers.end()) {
+          DEVLOG_WARNING("[IOMapper]  Duplicated observer entry '%s'\n", paId.c_str());
+          return false;
+        }
+      }
     }
 
     // Insert into observer list
@@ -111,7 +120,7 @@ namespace forte::io {
     DEVLOG_DEBUG("[IOMapper] Register observer %s\n", paId.c_str());
 
     // Check for existing handle
-    if (auto handleIt = mHandles.find(paId); handleIt != mHandles.end()) {
+    if (handleIt != mHandles.end()) {
       auto handle = handleIt->second;
       handle->onObserver(paObserver);
       paObserver->onHandle(handle);


### PR DESCRIPTION
  - Enable multiple reader function blocks to consume the same physical input from an IOHandle
  - Multiple observers are only allowed for inputs, not outputs (outputs still restricted to single observer)                                                                                               
  - Added `dropObserver(IOObserver*)` method to remove specific observers