### PR TITLE
Fix missing includes for embrick module

### DIFF
--- a/modules/embrick/handler/pin.cpp
+++ b/modules/embrick/handler/pin.cpp
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string>
+#include <cstring>
 
 namespace forte::eclipse4diac::io::embrick {
 


### PR DESCRIPTION
Adding` #include <cstring>` to the `modules/embrick/handler/pin.cpp`, so that the embrick module compiles without an error.