### PR TITLE
Add help message for common problems when unable to create device

### DIFF
--- a/core/arch/common/src/main.cpp
+++ b/core/arch/common/src/main.cpp
@@ -58,7 +58,12 @@ int main(int argc, char *arg[]) {
   }
 
   if (!g4diacForteInstance.startupNewDevice(ipPort)) {
-    DEVLOG_INFO("Could not start a new device\n");
+    DEVLOG_ERROR("Could not start a new device\n");
+    if constexpr (forte::cgBuildSharedLibs) {
+      DEVLOG_ERROR("Did you load the required shared libraries using '-l'?\n");
+    } else {
+      DEVLOG_ERROR("Did you link the static libraries into the final executable using '--whole-archive'?\n");
+    }
     return -1;
   }
 

--- a/core/include/forte/config/forte_config.h.in
+++ b/core/include/forte/config/forte_config.h.in
@@ -37,6 +37,10 @@ namespace forte {
 
   //! Maximum supported absolute port index for forcing data pins.
   constexpr std::size_t cgMaxSupportedForceIndex = ${FORTE_MGM_MAX_SUPPORTED_FORCE_INDEX};
+
+#cmakedefine01 BUILD_SHARED_LIBS
+  constexpr bool cgBuildSharedLibs = BUILD_SHARED_LIBS;
+#undef BUILD_SHARED_LIBS
 }
 
 //! Support custom serializable data types


### PR DESCRIPTION
This adds a help message for common problems with loading shared libraries or building with required linker flags when unable to create the device during startup.