### PR TITLE
Initializes thread stack as nullptr

### DIFF
--- a/core/arch/freeRTOS/src/forte_thread.cpp
+++ b/core/arch/freeRTOS/src/forte_thread.cpp
@@ -21,7 +21,6 @@ namespace forte::arch {
   const int CFreeRTOSThread::scmForteTaskPriority = tskIDLE_PRIORITY + 4;
 
   CFreeRTOSThread::CFreeRTOSThread(long paStackSize) : CThreadBase(paStackSize) {
-    mStack = new char[paStackSize];
   }
 
   CFreeRTOSThread::~CFreeRTOSThread() {


### PR DESCRIPTION
in FreeRTOS, xTaskCreate needs just to know the SIZE of the Stack. making a "new" here is wasting Memory, as it is never used.
