### PR TITLE
Enhances CIEC_ARRAY assignment with bounds check

### DIFF
--- a/core/include/forte/datatypes/forte_array.h
+++ b/core/include/forte/datatypes/forte_array.h
@@ -86,6 +86,9 @@ namespace forte {
       }
 
       CIEC_ARRAY &operator=(const CIEC_ARRAY &paSource) {
+        if (hasVariableBounds()) {
+          setBounds(paSource.getLowerBound(), paSource.getUpperBound());
+        }
         assignDynamic(paSource, paSource.getLowerBound(), paSource.getUpperBound());
         return *this;
       }


### PR DESCRIPTION
Adds a condition to set new bounds during assignment when
the array has variable bounds, ensuring boundary integrity
is maintained during dynamic array assignments.
