### PR TITLE
Update InOut array bounds from reference value with variable bounds

### DIFF
--- a/core/src/funcbloc.cpp
+++ b/core/src/funcbloc.cpp
@@ -172,7 +172,7 @@ bool CFunctionBlock::configureGenericDIO(TPortId paDIOPortId, const CIEC_ANY &pa
     case CIEC_ANY::e_ARRAY: {
       auto &dioArrayValue = static_cast<CIEC_ARRAY &>(*dio);
       auto &refArrayValue = static_cast<const CIEC_ARRAY &>(paRefValue.unwrap());
-      if (dioArrayValue.hasVariableBounds() && !refArrayValue.hasVariableBounds()) {
+      if (dioArrayValue.hasVariableBounds() && refArrayValue.getLowerBound() <= refArrayValue.getUpperBound()) {
         dioArrayValue.setBounds(refArrayValue);
       }
       break;


### PR DESCRIPTION
This updates the bounds of an array on an InOut from a reference value that also has variable bounds. This may, for example, be the case when the reference value originates from a generic FB. It performs a check if the bounds are valid, in case the reference value is uninitialized.