### PR TITLE
Add getter for the defining value of an InOut connection

### DIFF
--- a/core/include/forte/inoutdataconn.h
+++ b/core/include/forte/inoutdataconn.h
@@ -68,12 +68,16 @@ namespace forte {
   template<typename T>
   class COutInOutDataConnection final : public CInOutDataConnection {
     public:
-      COutInOutDataConnection(CFunctionBlock &paSrcFB, TPortId paSrcPortId, const T &paValue) :
-          CInOutDataConnection(paSrcFB, paSrcPortId, &mValue),
-          mValue(paValue) {
+      COutInOutDataConnection(CFunctionBlock &paSrcFB, const TPortId paSrcPortId, const T &paValue) :
+          CInOutDataConnection(paSrcFB, paSrcPortId, &mDefiningValue),
+          mDefiningValue(paValue) {
+      }
+
+      T &getDefiningValue() {
+        return mDefiningValue;
       }
 
     private:
-      T mValue;
+      T mDefiningValue;
   };
 } // namespace forte


### PR DESCRIPTION
Add getter for the defining value of an InOut connection and also rename `mValue` to `mDefiningValue` to avoid name clash.