### PR TITLE
Restructure Datatypes PR 1 of N

### DIFF
--- a/core/include/forte/datatypes/forte_any.h
+++ b/core/include/forte/datatypes/forte_any.h
@@ -133,8 +133,7 @@ namespace forte {
        *  The data type value is set through the copy assignment
        *
        */
-      virtual void setValue(const CIEC_ANY &) {
-      }
+      virtual void setValue(const CIEC_ANY &) = 0;
 
       /*! \brief Reset the value for to the default initial value
        */

--- a/core/include/forte/datatypes/forte_any.h
+++ b/core/include/forte/datatypes/forte_any.h
@@ -133,8 +133,7 @@ namespace forte {
        *  The data type value is set through the copy assignment
        *
        */
-      virtual void setValue(const CIEC_ANY &paValue) {
-        setValueSimple(paValue);
+      virtual void setValue(const CIEC_ANY &) {
       }
 
       /*! \brief Reset the value for to the default initial value

--- a/core/include/forte/datatypes/forte_any_bit.h
+++ b/core/include/forte/datatypes/forte_any_bit.h
@@ -32,6 +32,10 @@ namespace forte {
         setTUINT64(0);
       }
 
+      TLargestUIntValueType getUnsignedValue() const {
+        return getLargestUInt();
+      }
+
     protected:
       CIEC_ANY_BIT() = default;
   };

--- a/core/include/forte/datatypes/forte_any_bit_partial.h
+++ b/core/include/forte/datatypes/forte_any_bit_partial.h
@@ -57,6 +57,10 @@ namespace forte {
         return *this;
       }
 
+      void setValue(const CIEC_ANY &paValue) override {
+        PartialType::setValue(paValue);
+      }
+
       ~CIEC_ANY_BIT_PARTIAL() override {
         if (mIndex <= scmMaxIndex) {
           constexpr SourceValueType maskTemplate = std::numeric_limits<PartialValueType>::max();

--- a/core/include/forte/datatypes/forte_any_date.h
+++ b/core/include/forte/datatypes/forte_any_date.h
@@ -30,6 +30,10 @@ namespace forte {
         setTUINT64(0);
       }
 
+      TLargestUIntValueType getUnsignedValue() const {
+        return getLargestUInt();
+      }
+
       /*! Retrieve the current timezone
        *
        * Can be sed to adjust mktime()-related values

--- a/core/include/forte/datatypes/forte_any_duration.h
+++ b/core/include/forte/datatypes/forte_any_duration.h
@@ -109,6 +109,10 @@ namespace forte {
         setLargestInt(0);
       }
 
+      TLargestIntValueType getSignedValue() const {
+        return getLargestInt();
+      }
+
       EDataTypeID getDataTypeID() const override {
         return e_ANY;
       }

--- a/core/include/forte/datatypes/forte_any_elementary.h
+++ b/core/include/forte/datatypes/forte_any_elementary.h
@@ -35,6 +35,14 @@ namespace forte {
         return e_ANY;
       }
 
+      TLargestUIntValueType getUnsignedValue() const {
+        return getLargestUInt();
+      }
+
+      TLargestIntValueType getSignedValue() const {
+        return getLargestInt();
+      }
+
       void toString(std::string &paTargetBuf) const override;
       int fromString(const char *paValue) override;
 

--- a/core/include/forte/datatypes/forte_array_dynamic.h
+++ b/core/include/forte/datatypes/forte_array_dynamic.h
@@ -553,6 +553,8 @@ namespace forte {
         return mElementDataTypeEntry != nullptr ? mElementDataTypeEntry->getTypeNameId() : StringId{};
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       [[nodiscard]] int fromString(const char *paValue) override;
 
       // This constructor is only to be used by the create instance method or GenFBs that correctly configure it with

--- a/core/include/forte/datatypes/forte_array_fixed.h
+++ b/core/include/forte/datatypes/forte_array_fixed.h
@@ -290,6 +290,10 @@ namespace forte {
         return data[0].getTypeNameID();
       }
 
+      void setValue(const CIEC_ANY &paValue) override {
+        CIEC_ARRAY::setValue(paValue);
+      }
+
       [[nodiscard]] int fromString(const char *paValue) override {
         int nRetVal = -1;
         const char *pcRunner = paValue;

--- a/core/include/forte/datatypes/forte_array_variable.h
+++ b/core/include/forte/datatypes/forte_array_variable.h
@@ -331,6 +331,10 @@ namespace forte {
         return data[0].getTypeNameID();
       }
 
+      void setValue(const CIEC_ANY &paValue) override {
+        CIEC_ARRAY::setValue(paValue);
+      }
+
       [[nodiscard]] int fromString(const char *) override {
         DEVLOG_ERROR("Parsing variable-size array from string is not supported\n");
         return -1; // not supported

--- a/core/include/forte/datatypes/forte_bool.h
+++ b/core/include/forte/datatypes/forte_bool.h
@@ -67,6 +67,8 @@ namespace forte {
         return (0 != getLargestUInt());
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override final {
         return e_BOOL;
       }

--- a/core/include/forte/datatypes/forte_byte.h
+++ b/core/include/forte/datatypes/forte_byte.h
@@ -84,6 +84,8 @@ namespace forte {
         return getTUINT8();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override final {
         return e_BYTE;
       }

--- a/core/include/forte/datatypes/forte_char.h
+++ b/core/include/forte/datatypes/forte_char.h
@@ -59,6 +59,8 @@ namespace forte {
         return getChar8();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       void toString(std::string &paTargetBuf) const override;
 
       int fromString(const char *paValue) override;

--- a/core/include/forte/datatypes/forte_date.h
+++ b/core/include/forte/datatypes/forte_date.h
@@ -58,6 +58,8 @@ namespace forte {
         return getTUINT64();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_DATE;
       }

--- a/core/include/forte/datatypes/forte_date_and_time.h
+++ b/core/include/forte/datatypes/forte_date_and_time.h
@@ -62,6 +62,8 @@ namespace forte {
         return e_DATE_AND_TIME;
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       /*! \brief Converts string value to data type value
        *
        *   This command implements a conversion function from IEC 61131

--- a/core/include/forte/datatypes/forte_dint.h
+++ b/core/include/forte/datatypes/forte_dint.h
@@ -102,6 +102,8 @@ namespace forte {
         return getTINT32();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_DINT;
       }

--- a/core/include/forte/datatypes/forte_dword.h
+++ b/core/include/forte/datatypes/forte_dword.h
@@ -106,6 +106,8 @@ namespace forte {
         return getTUINT32();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_DWORD;
       }

--- a/core/include/forte/datatypes/forte_int.h
+++ b/core/include/forte/datatypes/forte_int.h
@@ -93,6 +93,8 @@ namespace forte {
         return getTINT16();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_INT;
       }

--- a/core/include/forte/datatypes/forte_ldate.h
+++ b/core/include/forte/datatypes/forte_ldate.h
@@ -72,6 +72,8 @@ namespace forte {
         return e_LDATE;
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       /*! \brief Converts string value to data type value
        *
        *   This command implements a conversion function from IEC 61131

--- a/core/include/forte/datatypes/forte_ldate_and_time.h
+++ b/core/include/forte/datatypes/forte_ldate_and_time.h
@@ -72,6 +72,8 @@ namespace forte {
         return e_LDATE_AND_TIME;
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       /*! \brief Converts string value to data type value
        *
        *   This command implements a conversion function from IEC 61131

--- a/core/include/forte/datatypes/forte_lint.h
+++ b/core/include/forte/datatypes/forte_lint.h
@@ -111,6 +111,8 @@ namespace forte {
         return getTINT64();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_LINT;
       }

--- a/core/include/forte/datatypes/forte_ltime.h
+++ b/core/include/forte/datatypes/forte_ltime.h
@@ -76,6 +76,8 @@ namespace forte {
         return getLargestInt();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_LTIME;
       }

--- a/core/include/forte/datatypes/forte_ltime_of_day.h
+++ b/core/include/forte/datatypes/forte_ltime_of_day.h
@@ -75,6 +75,8 @@ namespace forte {
         return e_LTIME_OF_DAY;
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       /*! \brief Converts string value to data type value
        *
        *   This command implements a conversion function from IEC 61131

--- a/core/include/forte/datatypes/forte_lword.h
+++ b/core/include/forte/datatypes/forte_lword.h
@@ -115,6 +115,8 @@ namespace forte {
         return getTUINT64();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override final {
         return e_LWORD;
       }

--- a/core/include/forte/datatypes/forte_sint.h
+++ b/core/include/forte/datatypes/forte_sint.h
@@ -81,6 +81,8 @@ namespace forte {
         return getTINT8();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_SINT;
       }

--- a/core/include/forte/datatypes/forte_state.h
+++ b/core/include/forte/datatypes/forte_state.h
@@ -62,6 +62,8 @@ namespace forte {
         return getTUINT16();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_UINT;
       }

--- a/core/include/forte/datatypes/forte_string_fixed.h
+++ b/core/include/forte/datatypes/forte_string_fixed.h
@@ -97,6 +97,15 @@ namespace forte {
         return maxLength;
       }
 
+      void setValue(const CIEC_ANY &paValue) override {
+        EDataTypeID eID = paValue.getDataTypeID();
+        if (eID == e_STRING) {
+          *this = static_cast<const CIEC_STRING &>(paValue);
+        } else if (eID == e_CHAR) {
+          *this = static_cast<const CIEC_CHAR &>(paValue);
+        }
+      }
+
       void reserve(const TForteUInt16 paRequestedSize) override {
         if (paRequestedSize > maxLength) {
           DEVLOG_WARNING("Attempt to reserve %zu chars, which is more than the CIEC_STRING_FIXED<%zu> shall support!",

--- a/core/include/forte/datatypes/forte_time.h
+++ b/core/include/forte/datatypes/forte_time.h
@@ -64,6 +64,8 @@ namespace forte {
         return getLargestInt();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_TIME;
       }

--- a/core/include/forte/datatypes/forte_time_of_day.h
+++ b/core/include/forte/datatypes/forte_time_of_day.h
@@ -68,6 +68,8 @@ namespace forte {
         return e_TIME_OF_DAY;
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       /*! \brief Converts string value to data type value
        *
        *   This command implements a conversion function from IEC 61131

--- a/core/include/forte/datatypes/forte_udint.h
+++ b/core/include/forte/datatypes/forte_udint.h
@@ -86,6 +86,8 @@ namespace forte {
         return getTUINT32();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_UDINT;
       }

--- a/core/include/forte/datatypes/forte_uint.h
+++ b/core/include/forte/datatypes/forte_uint.h
@@ -83,6 +83,8 @@ namespace forte {
         return getTUINT16();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_UINT;
       }

--- a/core/include/forte/datatypes/forte_ulint.h
+++ b/core/include/forte/datatypes/forte_ulint.h
@@ -91,6 +91,8 @@ namespace forte {
         return getTUINT64();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_ULINT;
       }

--- a/core/include/forte/datatypes/forte_usint.h
+++ b/core/include/forte/datatypes/forte_usint.h
@@ -75,6 +75,8 @@ namespace forte {
         return getTUINT8();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override {
         return e_USINT;
       }

--- a/core/include/forte/datatypes/forte_wchar.h
+++ b/core/include/forte/datatypes/forte_wchar.h
@@ -60,6 +60,8 @@ namespace forte {
         return getChar16();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       void toString(std::string &paTargetBuf) const override;
 
       int fromString(const char *paValue) override;

--- a/core/include/forte/datatypes/forte_word.h
+++ b/core/include/forte/datatypes/forte_word.h
@@ -95,6 +95,8 @@ namespace forte {
         return getTUINT16();
       }
 
+      void setValue(const CIEC_ANY &paValue) override;
+
       EDataTypeID getDataTypeID() const override final {
         return e_WORD;
       }

--- a/core/include/forte/datatypes/forte_wstring.h
+++ b/core/include/forte/datatypes/forte_wstring.h
@@ -154,12 +154,7 @@ namespace forte {
         return e_WSTRING;
       }
 
-      void setValue(const CIEC_ANY &paValue) override {
-        if (paValue.getDataTypeID() == e_WSTRING) {
-          const CIEC_WSTRING &roSrc(static_cast<const CIEC_WSTRING &>(paValue));
-          this->assign(roSrc.getValue(), roSrc.length());
-        }
-      }
+      void setValue(const CIEC_ANY &paValue) override;
 
       /*! \brief Converts string value to data type value
        *

--- a/core/src/datatypes/forte_array_dynamic.cpp
+++ b/core/src/datatypes/forte_array_dynamic.cpp
@@ -63,6 +63,10 @@ namespace forte {
     }
   }
 
+  void CIEC_ARRAY_DYNAMIC::setValue(const CIEC_ANY &paValue) {
+    CIEC_ARRAY::setValue(paValue);
+  }
+
   int CIEC_ARRAY_DYNAMIC::fromString(const char *paValue) {
     int nRetVal = -1;
     const char *pcRunner = paValue;

--- a/core/src/datatypes/forte_bool.cpp
+++ b/core/src/datatypes/forte_bool.cpp
@@ -15,12 +15,42 @@
  *   Alois Zoitl - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 using namespace std::literals::string_literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(BOOL, "BOOL"_STRID)
+
+  void CIEC_BOOL::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTBOOL8(0 != static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()); break;
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTBOOL8(0 != static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTBOOL8(0 != static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()); break;
+      case e_REAL: setTBOOL8(0.0f != static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))); break;
+      case e_LREAL: setTBOOL8(0.0 != static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_BOOL::fromString(const char *paValue) {
     int nRetVal = 0;

--- a/core/src/datatypes/forte_byte.cpp
+++ b/core/src/datatypes/forte_byte.cpp
@@ -32,17 +32,25 @@ namespace forte {
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_LWORD:
+        setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_REAL:
-      case e_LREAL: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue())); break;
+      case e_LREAL:
+        setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue()));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_byte.cpp
+++ b/core/src/datatypes/forte_byte.cpp
@@ -13,11 +13,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_byte.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(BYTE, "BYTE"_STRID)
+
+  void CIEC_BYTE::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_REAL:
+      case e_LREAL: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue())); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   const StringId CDataTypeTrait<CIEC_BYTE>::scmDataTypeName = "BYTE"_STRID;
 } // namespace forte

--- a/core/src/datatypes/forte_char.cpp
+++ b/core/src/datatypes/forte_char.cpp
@@ -36,7 +36,9 @@ namespace forte {
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setChar(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_LWORD:
+        setChar(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
       case e_SINT:
       case e_INT:
       case e_DINT:
@@ -44,7 +46,9 @@ namespace forte {
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setChar(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setChar(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_char.cpp
+++ b/core/src/datatypes/forte_char.cpp
@@ -15,6 +15,10 @@
  *   Martin Jobst - fix line feed and newline escape sequences
  *******************************************************************************/
 #include "forte/datatypes/forte_char.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include "forte/util/string_utils.h"
 
 using namespace std::literals;
@@ -23,6 +27,29 @@ using namespace forte::literals;
 namespace forte {
 
   DEFINE_FIRMWARE_DATATYPE(CHAR, "CHAR"_STRID)
+
+  void CIEC_CHAR::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_CHAR: setChar(static_cast<TValueType>(static_cast<const CIEC_CHAR &>(paValue))); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setChar(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setChar(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setChar(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   void CIEC_CHAR::toString(std::string &paTargetBuf) const {
     paTargetBuf += "CHAR#'"s;

--- a/core/src/datatypes/forte_date.cpp
+++ b/core/src/datatypes/forte_date.cpp
@@ -18,12 +18,35 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_date.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_date.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include <format>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include <ctype.h>
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(DATE, "DATE"_STRID)
+
+  void CIEC_DATE::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_DATE:
+      case e_TIME_OF_DAY:
+      case e_DATE_AND_TIME:
+      case e_LDATE:
+      case e_LTIME_OF_DAY:
+      case e_LDATE_AND_TIME: setTUINT64(static_cast<const CIEC_ANY_DATE &>(paValue).getUnsignedValue()); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_DATE::fromString(const char *paValue) {
     // 2007-12-21

--- a/core/src/datatypes/forte_date_and_time.cpp
+++ b/core/src/datatypes/forte_date_and_time.cpp
@@ -19,6 +19,10 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_date_and_time.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_date.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include "forte/arch/forte_architecture_time.h"
 #include "forte/util/string_utils.h"
 
@@ -26,6 +30,21 @@ using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(DATE_AND_TIME, "DATE_AND_TIME"_STRID)
+
+  void CIEC_DATE_AND_TIME::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_DATE:
+      case e_TIME_OF_DAY:
+      case e_DATE_AND_TIME:
+      case e_LDATE:
+      case e_LTIME_OF_DAY:
+      case e_LDATE_AND_TIME: setTUINT64(static_cast<const CIEC_ANY_DATE &>(paValue).getUnsignedValue()); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_DATE_AND_TIME::fromString(const char *paValue) {
     // 2007-12-21-15:00:00.000

--- a/core/src/datatypes/forte_dint.cpp
+++ b/core/src/datatypes/forte_dint.cpp
@@ -30,18 +30,28 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_BOOL:
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTINT32(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTINT32(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTINT32(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTINT32(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_dint.cpp
+++ b/core/src/datatypes/forte_dint.cpp
@@ -12,11 +12,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_dint.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(DINT, "DINT"_STRID)
+
+  void CIEC_DINT::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTINT32(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTINT32(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   template CIEC_DINT &CIEC_DINT::operator= <>(const CIEC_SINT &paValue);
 

--- a/core/src/datatypes/forte_dword.cpp
+++ b/core/src/datatypes/forte_dword.cpp
@@ -32,17 +32,25 @@ namespace forte {
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_LWORD:
+        setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_REAL:
-      case e_LREAL: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue())); break;
+      case e_LREAL:
+        setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue()));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_dword.cpp
+++ b/core/src/datatypes/forte_dword.cpp
@@ -13,11 +13,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_dword.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(DWORD, "DWORD"_STRID)
+
+  void CIEC_DWORD::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_REAL:
+      case e_LREAL: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue())); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   const StringId CDataTypeTrait<CIEC_DWORD>::scmDataTypeName = "DWORD"_STRID;
 } // namespace forte

--- a/core/src/datatypes/forte_int.cpp
+++ b/core/src/datatypes/forte_int.cpp
@@ -31,18 +31,28 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_BOOL:
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_int.cpp
+++ b/core/src/datatypes/forte_int.cpp
@@ -13,11 +13,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_int.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(INT, "INT"_STRID)
+
+  void CIEC_INT::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   template CIEC_INT &CIEC_INT::operator= <>(const CIEC_SINT &paValue);
 

--- a/core/src/datatypes/forte_ldate.cpp
+++ b/core/src/datatypes/forte_ldate.cpp
@@ -19,12 +19,31 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_ldate.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_date.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include "forte/arch/forte_architecture_time.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(LDATE, "LDATE"_STRID)
+
+  void CIEC_LDATE::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_DATE:
+      case e_TIME_OF_DAY:
+      case e_DATE_AND_TIME:
+      case e_LDATE:
+      case e_LTIME_OF_DAY:
+      case e_LDATE_AND_TIME: setTUINT64(static_cast<const CIEC_ANY_DATE &>(paValue).getUnsignedValue()); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_LDATE::fromString(const char *paValue) {
     // 2007-12-21

--- a/core/src/datatypes/forte_ldate_and_time.cpp
+++ b/core/src/datatypes/forte_ldate_and_time.cpp
@@ -19,6 +19,10 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_ldate_and_time.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_date.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include "forte/arch/forte_architecture_time.h"
 #include "forte/util/string_utils.h"
 
@@ -26,6 +30,21 @@ using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(LDATE_AND_TIME, "LDATE_AND_TIME"_STRID)
+
+  void CIEC_LDATE_AND_TIME::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_DATE:
+      case e_TIME_OF_DAY:
+      case e_DATE_AND_TIME:
+      case e_LDATE:
+      case e_LTIME_OF_DAY:
+      case e_LDATE_AND_TIME: setTUINT64(static_cast<const CIEC_ANY_DATE &>(paValue).getUnsignedValue()); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_LDATE_AND_TIME::fromString(const char *paValue) {
     // 2007-12-21-15:00:00.000

--- a/core/src/datatypes/forte_lint.cpp
+++ b/core/src/datatypes/forte_lint.cpp
@@ -12,11 +12,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_lint.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(LINT, "LINT"_STRID);
+
+  void CIEC_LINT::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTINT64(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTINT64(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   template CIEC_LINT &CIEC_LINT::operator= <>(const CIEC_SINT &paValue);
 

--- a/core/src/datatypes/forte_lint.cpp
+++ b/core/src/datatypes/forte_lint.cpp
@@ -30,18 +30,28 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_BOOL:
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTINT64(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTINT64(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTINT64(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTINT64(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_lreal.cpp
+++ b/core/src/datatypes/forte_lreal.cpp
@@ -20,6 +20,9 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
 #include "forte/datatypes/forte_real.h"
 #include "forte/datatypes/forte_lint.h"
 #include "forte/datatypes/forte_ulint.h"
@@ -60,26 +63,28 @@ namespace forte {
   void CIEC_LREAL::setValue(const CIEC_ANY &paValue) {
     EDataTypeID eID = paValue.getDataTypeID();
     switch (eID) {
-      case e_LREAL: setValueSimple(paValue); break;
+      case e_LREAL: setTDFLOAT(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))); break;
       case e_REAL: setTDFLOAT(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))); break;
-      case e_STRING: (*this).fromString(reinterpret_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
-      case e_WSTRING: (*this).fromString(reinterpret_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      case e_BOOL: setTDFLOAT(static_cast<const CIEC_BOOL &>(paValue) ? 1.0 : 0.0); break;
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setLargestUInt(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()); break;
       case e_SINT:
       case e_INT:
       case e_DINT:
       case e_LINT:
-        setTDFLOAT(static_cast<TValueType>(static_cast<TForteInt64>(static_cast<const CIEC_LINT &>(paValue))));
+        setTDFLOAT(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
         break;
-      case e_BYTE:
-      case e_WORD:
-      case e_DWORD:
-      case e_LWORD:
-        // bit string will cast to the binary representation of the real value
-        setValueSimple(paValue);
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT:
+        setTDFLOAT(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
         break;
-      default: // UINT types
-        setTDFLOAT(static_cast<TValueType>(static_cast<TForteUInt64>(static_cast<const CIEC_ULINT &>(paValue))));
-        break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
     }
   }
 

--- a/core/src/datatypes/forte_ltime.cpp
+++ b/core/src/datatypes/forte_ltime.cpp
@@ -18,6 +18,11 @@
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte/datatypes/forte_ltime.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_duration.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
+#include <string_view>
 #include "forte/util/forte_constants.h"
 #include "forte/util/string_utils.h"
 
@@ -26,6 +31,17 @@ using namespace std::literals::string_literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(LTIME, "LTIME"_STRID)
+
+  void CIEC_LTIME::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_TIME:
+      case e_LTIME: setLargestInt(static_cast<const CIEC_ANY_DURATION &>(paValue).getSignedValue()); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_LTIME::fromString(const char *paValue) {
     int nRetVal = -1;

--- a/core/src/datatypes/forte_ltime_of_day.cpp
+++ b/core/src/datatypes/forte_ltime_of_day.cpp
@@ -19,12 +19,31 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_ltime_of_day.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_date.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include "forte/util/string_utils.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(LTIME_OF_DAY, "LTIME_OF_DAY"_STRID)
+
+  void CIEC_LTIME_OF_DAY::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_DATE:
+      case e_TIME_OF_DAY:
+      case e_DATE_AND_TIME:
+      case e_LDATE:
+      case e_LTIME_OF_DAY:
+      case e_LDATE_AND_TIME: setTUINT64(static_cast<const CIEC_ANY_DATE &>(paValue).getUnsignedValue()); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_LTIME_OF_DAY::fromString(const char *paValue) {
     // 15:00:00.000

--- a/core/src/datatypes/forte_lword.cpp
+++ b/core/src/datatypes/forte_lword.cpp
@@ -12,11 +12,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_lword.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(LWORD, "LWORD"_STRID)
+
+  void CIEC_LWORD::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_REAL:
+      case e_LREAL: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue())); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   const StringId CDataTypeTrait<CIEC_LWORD>::scmDataTypeName = "LWORD"_STRID;
 } // namespace forte

--- a/core/src/datatypes/forte_lword.cpp
+++ b/core/src/datatypes/forte_lword.cpp
@@ -31,17 +31,25 @@ namespace forte {
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_LWORD:
+        setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_REAL:
-      case e_LREAL: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue())); break;
+      case e_LREAL:
+        setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue()));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_real.cpp
+++ b/core/src/datatypes/forte_real.cpp
@@ -21,6 +21,9 @@
 #include <cstdio>
 #include <format>
 #include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
 #include "forte/datatypes/forte_lreal.h"
 #include "forte/datatypes/forte_lint.h"
 #include "forte/datatypes/forte_ulint.h"
@@ -63,27 +66,30 @@ namespace forte {
   void CIEC_REAL::setValue(const CIEC_ANY &paValue) {
     EDataTypeID eID = paValue.getDataTypeID();
     switch (eID) {
-      case e_REAL: setValueSimple(paValue); break;
+      case e_REAL: setTFLOAT(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))); break;
       case e_LREAL:
-        setTFLOAT(
-            static_cast<TValueType>(static_cast<CIEC_LREAL::TValueType>(static_cast<const CIEC_LREAL &>(paValue))));
+        setTFLOAT(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
         break;
-      case e_STRING: (*this).fromString(((CIEC_STRING &) paValue).getStorage().c_str()); break;
-      case e_WSTRING: (*this).fromString(((CIEC_WSTRING &) paValue).getValue()); break;
+      case e_BOOL: setTFLOAT(static_cast<const CIEC_BOOL &>(paValue) ? 1.0f : 0.0f); break;
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setLargestUInt(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()); break;
       case e_SINT:
       case e_INT:
       case e_DINT:
       case e_LINT:
-        setTFLOAT(static_cast<TValueType>(static_cast<CIEC_LINT::TValueType>(static_cast<const CIEC_LINT &>(paValue))));
+        setTFLOAT(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
         break;
-      case e_BYTE:
-      case e_WORD:
-      case e_DWORD:
-      case e_LWORD: setValueSimple(paValue); break;
-      default: // UINT types
-        setTFLOAT(
-            static_cast<TValueType>(static_cast<CIEC_ULINT::TValueType>(static_cast<const CIEC_ULINT &>(paValue))));
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT:
+        setTFLOAT(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
         break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
     }
   }
 

--- a/core/src/datatypes/forte_sint.cpp
+++ b/core/src/datatypes/forte_sint.cpp
@@ -31,18 +31,28 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_BOOL:
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTINT8(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTINT8(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTINT8(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTINT8(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_sint.cpp
+++ b/core/src/datatypes/forte_sint.cpp
@@ -13,11 +13,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_sint.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(SINT, "SINT"_STRID)
+
+  void CIEC_SINT::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTINT8(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTINT8(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   const StringId CDataTypeTrait<CIEC_SINT>::scmDataTypeName = "SINT"_STRID;
 } // namespace forte

--- a/core/src/datatypes/forte_state.cpp
+++ b/core/src/datatypes/forte_state.cpp
@@ -29,7 +29,9 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
@@ -38,9 +40,15 @@ namespace forte {
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTUINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTUINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTUINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTUINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_state.cpp
+++ b/core/src/datatypes/forte_state.cpp
@@ -11,11 +11,41 @@
  *      - initial implementation and rework communication infrastructure,
  *******************************************************************************/
 #include "forte/datatypes/forte_state.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(STATE, "STATE"_STRID)
+
+  void CIEC_STATE::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT:
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTUINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTUINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   const CIEC_STATE::TValueType CIEC_STATE::scmMaxVal = std::numeric_limits<TValueType>::max();
 } // namespace forte

--- a/core/src/datatypes/forte_time.cpp
+++ b/core/src/datatypes/forte_time.cpp
@@ -17,6 +17,10 @@
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte/datatypes/forte_time.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_duration.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include <string_view>
 #include "forte/timerha.h"
 #include "forte/util/forte_constants.h"
@@ -27,6 +31,17 @@ using namespace std::literals::string_literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(TIME, "TIME"_STRID)
+
+  void CIEC_TIME::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_TIME:
+      case e_LTIME: setLargestInt(static_cast<const CIEC_ANY_DURATION &>(paValue).getSignedValue()); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_TIME::fromString(const char *paValue) {
     int nRetVal = -1;

--- a/core/src/datatypes/forte_time_of_day.cpp
+++ b/core/src/datatypes/forte_time_of_day.cpp
@@ -19,6 +19,10 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_time_of_day.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_date.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include "forte/arch/forte_architecture_time.h"
 #include "forte/util/string_utils.h"
 
@@ -26,6 +30,21 @@ using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(TIME_OF_DAY, "TIME_OF_DAY"_STRID)
+
+  void CIEC_TIME_OF_DAY::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_DATE:
+      case e_TIME_OF_DAY:
+      case e_DATE_AND_TIME:
+      case e_LDATE:
+      case e_LTIME_OF_DAY:
+      case e_LDATE_AND_TIME: setTUINT64(static_cast<const CIEC_ANY_DATE &>(paValue).getUnsignedValue()); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   int CIEC_TIME_OF_DAY::fromString(const char *paValue) {
     // 15:00:00.000

--- a/core/src/datatypes/forte_udint.cpp
+++ b/core/src/datatypes/forte_udint.cpp
@@ -13,11 +13,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_udint.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(UDINT, "UDINT"_STRID)
+
+  void CIEC_UDINT::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTUINT32(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTUINT32(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   template CIEC_UDINT &CIEC_UDINT::operator= <>(const CIEC_USINT &paValue);
 

--- a/core/src/datatypes/forte_udint.cpp
+++ b/core/src/datatypes/forte_udint.cpp
@@ -31,18 +31,28 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_BOOL:
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTUINT32(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTUINT32(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTUINT32(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTUINT32(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTUINT32(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_uint.cpp
+++ b/core/src/datatypes/forte_uint.cpp
@@ -30,18 +30,28 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_BOOL:
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTUINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTUINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTUINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTUINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_uint.cpp
+++ b/core/src/datatypes/forte_uint.cpp
@@ -12,11 +12,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_uint.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(UINT, "UINT"_STRID)
+
+  void CIEC_UINT::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTUINT16(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTUINT16(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   template CIEC_UINT &CIEC_UINT::operator= <>(const CIEC_USINT &paValue);
 

--- a/core/src/datatypes/forte_ulint.cpp
+++ b/core/src/datatypes/forte_ulint.cpp
@@ -30,7 +30,9 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
@@ -39,9 +41,15 @@ namespace forte {
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTUINT64(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTUINT64(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTUINT64(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTUINT64(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_ulint.cpp
+++ b/core/src/datatypes/forte_ulint.cpp
@@ -12,11 +12,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_ulint.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(ULINT, "ULINT"_STRID)
+
+  void CIEC_ULINT::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT:
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT64(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTUINT64(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTUINT64(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   template CIEC_ULINT &CIEC_ULINT::operator= <>(const CIEC_USINT &paValue);
 

--- a/core/src/datatypes/forte_usint.cpp
+++ b/core/src/datatypes/forte_usint.cpp
@@ -12,11 +12,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_usint.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(USINT, "USINT"_STRID)
+
+  void CIEC_USINT::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_REAL: setTUINT8(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
+      case e_LREAL: setTUINT8(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   const StringId CDataTypeTrait<CIEC_USINT>::scmDataTypeName = "USINT"_STRID;
 } // namespace forte

--- a/core/src/datatypes/forte_usint.cpp
+++ b/core/src/datatypes/forte_usint.cpp
@@ -30,18 +30,28 @@ namespace forte {
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_BOOL:
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
-      case e_REAL: setTUINT8(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue)))); break;
-      case e_LREAL: setTUINT8(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue)))); break;
+      case e_LWORD:
+        setTUINT8(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
+      case e_REAL:
+        setTUINT8(static_cast<TValueType>(static_cast<TForteFloat>(static_cast<const CIEC_REAL &>(paValue))));
+        break;
+      case e_LREAL:
+        setTUINT8(static_cast<TValueType>(static_cast<TForteDFloat>(static_cast<const CIEC_LREAL &>(paValue))));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_wchar.cpp
+++ b/core/src/datatypes/forte_wchar.cpp
@@ -37,15 +37,21 @@ namespace forte {
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_LWORD:
+        setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_wchar.cpp
+++ b/core/src/datatypes/forte_wchar.cpp
@@ -15,6 +15,10 @@
  *   Martin Jobst - fix line feed and newline escape sequences
  *******************************************************************************/
 #include "forte/datatypes/forte_wchar.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 #include <cstdint>
 #include <format>
 #include "forte/util/string_utils.h"
@@ -24,6 +28,29 @@ using namespace std::literals::string_literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(WCHAR, "WCHAR"_STRID)
+
+  void CIEC_WCHAR::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_WCHAR: setChar16(static_cast<TValueType>(static_cast<const CIEC_WCHAR &>(paValue))); break;
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setChar16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   void CIEC_WCHAR::toString(std::string &paTargetBuf) const {
     const TForteWChar symbol = this->operator TForteWChar();

--- a/core/src/datatypes/forte_word.cpp
+++ b/core/src/datatypes/forte_word.cpp
@@ -12,11 +12,41 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_word.h"
+#include "forte/datatypes/forte_any_bit.h"
+#include "forte/datatypes/forte_any_int.h"
+#include "forte/datatypes/forte_real.h"
+#include "forte/datatypes/forte_lreal.h"
+#include "forte/datatypes/forte_string.h"
+#include "forte/datatypes/forte_wstring.h"
 
 using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(WORD, "WORD"_STRID)
+
+  void CIEC_WORD::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    switch (eID) {
+      case e_BOOL:
+      case e_BYTE:
+      case e_WORD:
+      case e_DWORD:
+      case e_LWORD: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_SINT:
+      case e_INT:
+      case e_DINT:
+      case e_LINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_USINT:
+      case e_UINT:
+      case e_UDINT:
+      case e_ULINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_REAL:
+      case e_LREAL: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue())); break;
+      case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
+      case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
+      default: break;
+    }
+  }
 
   const StringId CDataTypeTrait<CIEC_WORD>::scmDataTypeName = "WORD"_STRID;
 } // namespace forte

--- a/core/src/datatypes/forte_word.cpp
+++ b/core/src/datatypes/forte_word.cpp
@@ -31,17 +31,25 @@ namespace forte {
       case e_BYTE:
       case e_WORD:
       case e_DWORD:
-      case e_LWORD: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue())); break;
+      case e_LWORD:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_BIT &>(paValue).getUnsignedValue()));
+        break;
       case e_SINT:
       case e_INT:
       case e_DINT:
-      case e_LINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue())); break;
+      case e_LINT:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getSignedValue()));
+        break;
       case e_USINT:
       case e_UINT:
       case e_UDINT:
-      case e_ULINT: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue())); break;
+      case e_ULINT:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_INT &>(paValue).getUnsignedValue()));
+        break;
       case e_REAL:
-      case e_LREAL: setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue())); break;
+      case e_LREAL:
+        setTUINT16(static_cast<TValueType>(static_cast<const CIEC_ANY_ELEMENTARY &>(paValue).getUnsignedValue()));
+        break;
       case e_STRING: (*this).fromString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str()); break;
       case e_WSTRING: (*this).fromString(static_cast<const CIEC_WSTRING &>(paValue).getValue()); break;
       default: break;

--- a/core/src/datatypes/forte_wstring.cpp
+++ b/core/src/datatypes/forte_wstring.cpp
@@ -15,6 +15,7 @@
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte/datatypes/forte_wstring.h"
+#include "forte/datatypes/forte_string.h"
 
 #include "forte/util/devlog.h"
 
@@ -24,6 +25,18 @@ using namespace forte::literals;
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(WSTRING, "WSTRING"_STRID)
+
+  void CIEC_WSTRING::setValue(const CIEC_ANY &paValue) {
+    EDataTypeID eID = paValue.getDataTypeID();
+    if (eID == e_WSTRING) {
+      const CIEC_WSTRING &roSrc(static_cast<const CIEC_WSTRING &>(paValue));
+      this->assign(roSrc.getValue(), roSrc.length());
+    } else if (eID == e_STRING) {
+      this->fromCharString(static_cast<const CIEC_STRING &>(paValue).getStorage().c_str());
+    } else if (eID == e_WCHAR) {
+      *this = CIEC_WSTRING(static_cast<const CIEC_WCHAR &>(paValue));
+    }
+  }
 
   bool CIEC_WSTRING::fromUTF16(const TForteWChar *paBuffer, unsigned int paBufferLen) {
     return fromUTF16(reinterpret_cast<const TForteByte *>(paBuffer), 2 * paBufferLen);


### PR DESCRIPTION
This PR is the Start of a Series of small PRs, restructuring the Datatypes.
#786 was a fail.
so this is a 2nd try, refactoring small amounts of code one-by-one.

this PR now does introduce the "setValue" to all Types, and avoid the "setValueSimple". 

related to #794