### PR TITLE
Runtime now accepts inline vector literals for ANY_VARIANT

### DIFF
--- a/core/src/datatypes/forte_any_variant.cpp
+++ b/core/src/datatypes/forte_any_variant.cpp
@@ -13,8 +13,109 @@
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
 #include "forte/datatypes/forte_any_variant.h"
+#include "forte/datatypes/forte_array_dynamic.h"
+
+#include <charconv>
+#include <cctype>
+#include <cstring>
+#include <memory>
+#include <string_view>
 
 using namespace forte::literals;
+
+namespace {
+  const char *skipWhitespace(const char *paPos, const char *paEnd) {
+    while (paPos < paEnd && std::isspace(static_cast<unsigned char>(*paPos))) {
+      ++paPos;
+    }
+    return paPos;
+  }
+
+  bool parseKeyword(const char *&paPos, const char *paEnd, std::string_view paKeyword) {
+    paPos = skipWhitespace(paPos, paEnd);
+    for (char keywordChar : paKeyword) {
+      if (paPos == paEnd || std::toupper(static_cast<unsigned char>(*paPos)) != keywordChar) {
+        return false;
+      }
+      ++paPos;
+    }
+    return true;
+  }
+
+  bool parseSignedInteger(const char *&paPos, const char *paEnd, intmax_t &paValue) {
+    paPos = skipWhitespace(paPos, paEnd);
+    const char *begin = paPos;
+    if (paPos < paEnd && ('+' == *paPos || '-' == *paPos)) {
+      ++paPos;
+    }
+    if (paPos == paEnd || !std::isdigit(static_cast<unsigned char>(*paPos))) {
+      return false;
+    }
+    while (paPos < paEnd && std::isdigit(static_cast<unsigned char>(*paPos))) {
+      ++paPos;
+    }
+    auto [parsedUntil, error] = std::from_chars(begin, paPos, paValue);
+    return error == std::errc{} && parsedUntil == paPos;
+  }
+
+  bool parseInlineArrayType(const char *paBegin,
+                            const char *paEnd,
+                            intmax_t &paLowerBound,
+                            intmax_t &paUpperBound,
+                            forte::StringId &paElementTypeNameId) {
+    const char *runner = paBegin;
+    if (!parseKeyword(runner, paEnd, "ARRAY")) {
+      return false;
+    }
+    runner = skipWhitespace(runner, paEnd);
+    if (runner == paEnd || '[' != *runner) {
+      return false;
+    }
+    ++runner;
+
+    if (!parseSignedInteger(runner, paEnd, paLowerBound)) {
+      return false;
+    }
+
+    runner = skipWhitespace(runner, paEnd);
+    if ((paEnd - runner) < 2 || runner[0] != '.' || runner[1] != '.') {
+      return false;
+    }
+    runner += 2;
+
+    if (!parseSignedInteger(runner, paEnd, paUpperBound)) {
+      return false;
+    }
+
+    runner = skipWhitespace(runner, paEnd);
+    if (runner == paEnd || ']' != *runner) {
+      return false;
+    }
+    ++runner;
+
+    if (!parseKeyword(runner, paEnd, "OF")) {
+      return false;
+    }
+
+    runner = skipWhitespace(runner, paEnd);
+    if (runner == paEnd || paLowerBound > paUpperBound) {
+      return false;
+    }
+
+    const char *elementTypeBegin = runner;
+    const char *elementTypeEnd = paEnd;
+    while (elementTypeEnd > elementTypeBegin && std::isspace(static_cast<unsigned char>(*(elementTypeEnd - 1)))) {
+      --elementTypeEnd;
+    }
+    if (elementTypeBegin == elementTypeEnd) {
+      return false;
+    }
+
+    paElementTypeNameId =
+        forte::StringId::lookup({elementTypeBegin, static_cast<size_t>(elementTypeEnd - elementTypeBegin)});
+    return true;
+  }
+} // namespace
 
 namespace forte {
   DEFINE_FIRMWARE_DATATYPE(ANY_VARIANT, "ANY"_STRID)
@@ -148,6 +249,23 @@ namespace forte {
             case e_ARRAY: operator=(CIEC_ANY_UNIQUE_PTR<CIEC_ARRAY>(static_cast<CIEC_ARRAY *>(value))); break;
             case e_STRUCT: operator=(CIEC_ANY_UNIQUE_PTR<CIEC_STRUCT>(static_cast<CIEC_STRUCT *>(value))); break;
             default: setValue(*value); delete value;
+          }
+        } else {
+          intmax_t lowerBound;
+          intmax_t upperBound;
+          StringId elementTypeNameId;
+          if (parseInlineArrayType(paValue, hashPos, lowerBound, upperBound, elementTypeNameId)) {
+            auto arrayValue = std::make_unique<CIEC_ARRAY_DYNAMIC>();
+            arrayValue->setup(lowerBound, upperBound, elementTypeNameId);
+            if (arrayValue->getElementDataTypeID() == e_ANY) {
+              return -1;
+            }
+            retVal = arrayValue->fromString(hashPos + 1); // start after '#'
+            if (retVal < 0) {
+              return retVal;
+            }
+            retVal += static_cast<int>(hashPos - paValue + 1); // add count for type including '#'
+            operator=(CIEC_ANY_UNIQUE_PTR<CIEC_ARRAY>(arrayValue.release()));
           }
         }
       }

--- a/tests/core/datatypes/CIEC_ANY_VARIANT_test.cpp
+++ b/tests/core/datatypes/CIEC_ANY_VARIANT_test.cpp
@@ -13,6 +13,7 @@
  *******************************************************************************/
 #include <boost/test/unit_test.hpp>
 #include "forte_boost_output_support.h"
+#include "forte/datatypes/forte_array.h"
 #include "forte/datatypes/forte_any_variant.h"
 
 using namespace forte::literals;
@@ -155,6 +156,33 @@ namespace forte::test {
     checkStringConversion(test, "ULINT#123123123123123", CIEC_ANY::e_ULINT);
     checkStringConversion(test, "LWORD#123123123123123", CIEC_ANY::e_LWORD);
     checkStringConversion(test, "AnyTestStruct#(Var1:='test',Var2:=TRUE,Var3:=17)", CIEC_ANY::e_STRUCT);
+  }
+
+  BOOST_AUTO_TEST_CASE(Inline_Array_String_Conversion_test) {
+    CIEC_ANY_VARIANT test;
+
+    const char *realArrayString = "ARRAY[0..0] OF REAL#[0.35]";
+    BOOST_CHECK_EQUAL(test.fromString(realArrayString), strlen(realArrayString));
+    BOOST_CHECK_EQUAL(test.getDataTypeID(), CIEC_ANY::e_ANY);
+    BOOST_CHECK_EQUAL(test.unwrap().getDataTypeID(), CIEC_ANY::e_ARRAY);
+    const CIEC_ARRAY &realArray = static_cast<const CIEC_ARRAY &>(test.unwrap());
+    BOOST_CHECK_EQUAL(realArray.getLowerBound(), 0);
+    BOOST_CHECK_EQUAL(realArray.getUpperBound(), 0);
+    BOOST_CHECK_EQUAL(realArray.getElementDataTypeID(), CIEC_ANY::e_REAL);
+    BOOST_CHECK_CLOSE(static_cast<CIEC_REAL::TValueType>(static_cast<const CIEC_REAL &>(realArray[0])), 0.35f, 0.1f);
+
+    const char *byteArrayString = "ARRAY[0..3] OF BYTE#[1,2,3,4]";
+    BOOST_CHECK_EQUAL(test.fromString(byteArrayString), strlen(byteArrayString));
+    BOOST_CHECK_EQUAL(test.getDataTypeID(), CIEC_ANY::e_ANY);
+    BOOST_CHECK_EQUAL(test.unwrap().getDataTypeID(), CIEC_ANY::e_ARRAY);
+    const CIEC_ARRAY &byteArray = static_cast<const CIEC_ARRAY &>(test.unwrap());
+    BOOST_CHECK_EQUAL(byteArray.getLowerBound(), 0);
+    BOOST_CHECK_EQUAL(byteArray.getUpperBound(), 3);
+    BOOST_CHECK_EQUAL(byteArray.getElementDataTypeID(), CIEC_ANY::e_BYTE);
+    BOOST_CHECK_EQUAL(static_cast<CIEC_BYTE::TValueType>(static_cast<const CIEC_BYTE &>(byteArray[0])), 1);
+    BOOST_CHECK_EQUAL(static_cast<CIEC_BYTE::TValueType>(static_cast<const CIEC_BYTE &>(byteArray[1])), 2);
+    BOOST_CHECK_EQUAL(static_cast<CIEC_BYTE::TValueType>(static_cast<const CIEC_BYTE &>(byteArray[2])), 3);
+    BOOST_CHECK_EQUAL(static_cast<CIEC_BYTE::TValueType>(static_cast<const CIEC_BYTE &>(byteArray[3])), 4);
   }
 
   BOOST_AUTO_TEST_CASE(Equality_test) {


### PR DESCRIPTION
Runtime now accepts inline vector literals for ANY_VARIANT, so real-vector feeding is user-friendly for M_Inference/ML_Inference