### PR TITLE
Use `std::string_view` for MGM command response texts

### DIFF
--- a/core/include/forte/datatypes/forte_string.h
+++ b/core/include/forte/datatypes/forte_string.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2025 Profactor GmbH, ACIN, nxtControl GmbH, TU Wien/ACIN,
+ * Copyright (c) 2005       Profactor GmbH, ACIN, nxtControl GmbH, TU Wien/ACIN,
  *                          Primetals Technologies Austria GmbH,
- *                          Martin Erich Jobst
+ *                          Martin Erich Jobst, HR Agrartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@
  *   Martin Jobst - add compare operators
  *                - add equals function
  *   Alois Zoitl  - migrated data type toString to std::string
+ *    Franz Höpfinger - string_view for getResponseText
  *******************************************************************************/
 
 #pragma once
@@ -198,7 +199,7 @@ namespace forte {
 
       virtual void append(const CIEC_STRING &paValue);
 
-      virtual void append(const std::string &paValue);
+      virtual void append(const std::string_view paValue);
 
       int compare(const CIEC_STRING &paValue) const;
 

--- a/core/include/forte/datatypes/forte_string_fixed.h
+++ b/core/include/forte/datatypes/forte_string_fixed.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Primetals Technologies Austria GmbH
+ * Copyright (c) 2023 Primetals Technologies Austria GmbH, HR Agrartechnik GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +9,7 @@
  * Contributors:
  *    Martin Melik Merkumians
  *      - initial implementation
+ *    Franz Höpfinger - string_view for getResponseText
  *******************************************************************************/
 
 #pragma once
@@ -121,7 +122,7 @@ namespace forte {
         }
       }
 
-      void append(const std::string &paValue) override {
+      void append(const std::string_view paValue) override {
         const size_t currentLength = length();
         if (currentLength < maxLength) {
           const size_t remainingSpace = maxLength - currentLength;

--- a/core/include/forte/mgmcmd.h
+++ b/core/include/forte/mgmcmd.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005 - 2015 ACIN, Profactor GmbH, fortiss GmbH
+ * Copyright (c) 2005 ACIN, Profactor GmbH, fortiss GmbH, HR Agrartechnik GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,6 +10,7 @@
  *    Alois Zoitl, Gunnar Grabmaier, Thomas Strasser, Gerhard Ebenhofer,
  *    Martin Melik Merkumians, Ingo Hegny,
  *      - initial implementation and rework communication infrastructure
+ *    Franz Höpfinger - string_view for getResponseText
  *******************************************************************************/
 
 #pragma once
@@ -287,7 +288,7 @@ namespace forte {
 
   namespace mgm_cmd {
 
-    const std::string &getResponseText(EMGMResponse paResp);
+    const std::string_view getResponseText(EMGMResponse paResp);
 
   } // namespace mgm_cmd
 

--- a/core/src/datatypes/forte_string.cpp
+++ b/core/src/datatypes/forte_string.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2025 Profactor GmbH, TU Wien/ACIN, nxtControl GmbH,
+ * Copyright (c) 2005       Profactor GmbH, TU Wien/ACIN, nxtControl GmbH,
  *                          fortiss GmbH, Primetals Technologies Austria GmbH
- *                          Martin Erich Jobst
+ *                          Martin Erich Jobst, HR Agrartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@
  *                           - changes storage to std::string
  *   Alois Zoitl - migrated data type toString to std::string
  *   Martin Jobst - fix line feed and newline escape sequences
+ *    Franz Höpfinger - string_view for getResponseText
  *******************************************************************************/
 
 #include "forte/datatypes/forte_string.h"
@@ -139,7 +140,7 @@ namespace forte {
     this->append(paValue.getStorage());
   }
 
-  void CIEC_STRING::append(const std::string &paValue) {
+  void CIEC_STRING::append(const std::string_view paValue) {
     mValue.append(paValue);
   }
 

--- a/core/src/mgmcmd.cpp
+++ b/core/src/mgmcmd.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Jose Cabral
+ * Copyright (c) 2024 Jose Cabral, HR Agrartechnik GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,11 +9,14 @@
  * Contributors:
  *    Jose Cabral:
  *      - initial implementation and rework communication infrastructure
+ *    Franz Höpfinger - string_view for getResponseText
  *******************************************************************************/
 
 #include "forte/mgmcmd.h"
 
 #include <type_traits>
+
+using namespace std::literals;
 
 namespace forte::mgm_cmd {
 
@@ -21,21 +24,21 @@ namespace forte::mgm_cmd {
    *
    * TODO fully define all responses as defined in IEC 61499 inc. numbers.
    */
-  const std::string scmMGMResponseTexts[] = {"RDY",
-                                             "BAD_PARAMS",
-                                             "LOCAL_TERMINATION",
-                                             "SYSTEM_TERMINATION",
-                                             "NOT_READY",
-                                             "UNSUPPORTED_CMD",
-                                             "UNSUPPORTED_TYPE",
-                                             "NO_SUCH_OBJECT",
-                                             "INVALID_OBJECT",
-                                             "INVALID_OPERATION",
-                                             "INVALID_STATE",
-                                             "OVERFLOW",
-                                             "INVALID_DST"};
+  constexpr std::string_view scmMGMResponseTexts[] = {"RDY"sv,
+                                                      "BAD_PARAMS"sv,
+                                                      "LOCAL_TERMINATION"sv,
+                                                      "SYSTEM_TERMINATION"sv,
+                                                      "NOT_READY"sv,
+                                                      "UNSUPPORTED_CMD"sv,
+                                                      "UNSUPPORTED_TYPE"sv,
+                                                      "NO_SUCH_OBJECT"sv,
+                                                      "INVALID_OBJECT"sv,
+                                                      "INVALID_OPERATION"sv,
+                                                      "INVALID_STATE"sv,
+                                                      "OVERFLOW"sv,
+                                                      "INVALID_DST"sv};
 
-  const std::string &getResponseText(EMGMResponse paResp) {
+  const std::string_view getResponseText(EMGMResponse paResp) {
     return scmMGMResponseTexts[static_cast<std::underlying_type_t<EMGMResponse>>(paResp)];
   }
 

--- a/stdfblib/system/src/DEV_MGR.cpp
+++ b/stdfblib/system/src/DEV_MGR.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2005 - 2015 ACIN, Profactor GmbH, fortiss GmbH
- *                      2018 Johannes Kepler University
+ * Copyright (c) 2005   ACIN, Profactor GmbH, fortiss GmbH
+ *                      Johannes Kepler University
+ *                      HR Agrartechnik GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -16,6 +17,7 @@
  *   Jens Reimann
  *    - Enhance bootfile loading behavior
  *    Alois Zoitl - introduced new CGenFB class for better handling generic FBs
+ *    Franz Höpfinger - string_view for getResponseText
  *******************************************************************************/
 
 #include "DEV_MGR.h"
@@ -107,7 +109,7 @@ namespace forte::iec61499::system {
   bool DEV_MGR::executeCommand(const char *const paDest, char *paCommand) {
     EMGMResponse eResp = mCommandParser.parseAndExecuteMGMCommand(paDest, paCommand);
     if (eResp != EMGMResponse::Ready) {
-      DEVLOG_ERROR("Boot file error. DEV_MGR says error is %s\n", forte::mgm_cmd::getResponseText(eResp).c_str());
+      DEVLOG_ERROR("Boot file error. DEV_MGR says error is %s\n", forte::mgm_cmd::getResponseText(eResp).data());
     }
     return (eResp == EMGMResponse::Ready);
   }


### PR DESCRIPTION
Optimize memory usage and avoid unnecessary string copies by employing `std::string_view` for the static response text array and its accessor function.
