### PR TITLE
Initialize internal state for RT_E_* function blocks

### DIFF
--- a/modules/rt_events/include/forte/eclipse4diac/rtevents/rtesingle.h
+++ b/modules/rt_events/include/forte/eclipse4diac/rtevents/rtesingle.h
@@ -67,7 +67,8 @@ namespace forte::eclipse4diac::rtevents {
       CRTEventSingle(CFBContainer &paContainer,
                      const SFBInterfaceSpec &paInterfaceSpec,
                      const StringId paInstanceNameId) :
-          CFunctionBlock(paContainer, paInterfaceSpec, paInstanceNameId) {};
+          CFunctionBlock(paContainer, paInterfaceSpec, paInstanceNameId),
+          mInitialized(false) {};
 
       CIEC_BOOL var_QI;
       CIEC_TIME var_Deadline;

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_CYCLE_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_CYCLE_fbt.cpp
@@ -43,7 +43,8 @@ namespace forte::eclipse4diac::rtevents {
       conn_DT(nullptr),
       conn_Deadline(nullptr),
       conn_WCET(nullptr),
-      conn_QO(*this, 0, var_QO) {
+      conn_QO(*this, 0, var_QO),
+      mActive(false) {
     setEventChainExecutor(&mECEO);
   };
 

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_DELAY_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_DELAY_fbt.cpp
@@ -46,7 +46,9 @@ namespace forte::eclipse4diac::rtevents {
       conn_Tmin(nullptr),
       conn_Deadline(nullptr),
       conn_WCET(nullptr),
-      conn_QO(*this, 0, var_QO) {
+      conn_QO(*this, 0, var_QO),
+      mActive(false),
+      mInitialized(false) {
     setEventChainExecutor(&mECEO);
   };
 

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_DEMUX_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_DEMUX_fbt.cpp
@@ -58,7 +58,8 @@ namespace forte::eclipse4diac::rtevents {
       conn_WCET2(nullptr),
       conn_Deadline3(nullptr),
       conn_WCET3(nullptr),
-      conn_QO(*this, 0, var_QO) {};
+      conn_QO(*this, 0, var_QO),
+      mInitialized(false) {};
 
   void FORTE_RT_E_DEMUX::setInitialValues() {
     var_QI = 0_BOOL;

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_F_TRIG_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_F_TRIG_fbt.cpp
@@ -45,7 +45,8 @@ namespace forte::eclipse4diac::rtevents {
       conn_Tmin(nullptr),
       conn_Deadline(nullptr),
       conn_WCET(nullptr),
-      conn_QO(*this, 0, var_QO) {};
+      conn_QO(*this, 0, var_QO),
+      mWasHigh(false) {};
 
   void FORTE_RT_E_F_TRIG::setInitialValues() {
     var_QI = 0_BOOL;

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_REND_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_REND_fbt.cpp
@@ -53,18 +53,21 @@ namespace forte::eclipse4diac::rtevents {
     var_Deadline = 0_TIME;
     var_WCET = 0_TIME;
     var_QO = 0_BOOL;
+    mState = 0;
   }
 
   bool FORTE_RT_E_REND::checkActivation(TEventID paEIID) {
     switch (paEIID) {
       case scmEventEI1ID:
         if (mState == 2) {
+          mState = 0;
           return true;
         }
         mState = 1;
         break;
       case scmEventEI2ID:
         if (mState == 1) {
+          mState = 0;
           return true;
         }
         mState = 2;

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_R_TRIG_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_R_TRIG_fbt.cpp
@@ -45,7 +45,8 @@ namespace forte::eclipse4diac::rtevents {
       conn_Tmin(nullptr),
       conn_Deadline(nullptr),
       conn_WCET(nullptr),
-      conn_QO(*this, 0, var_QO) {};
+      conn_QO(*this, 0, var_QO),
+      mWasHigh(false) {};
 
   void FORTE_RT_E_R_TRIG::setInitialValues() {
     var_QI = 0_BOOL;

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_SPLIT_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_SPLIT_fbt.cpp
@@ -49,7 +49,8 @@ namespace forte::eclipse4diac::rtevents {
       conn_WCET_EO1(nullptr),
       conn_Deadline_EO2(nullptr),
       conn_WCET_EO2(nullptr),
-      conn_QO(*this, 0, var_QO) {};
+      conn_QO(*this, 0, var_QO),
+      mInitialized(false) {};
 
   void FORTE_RT_E_SPLIT::setInitialValues() {
     var_QI = 0_BOOL;

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_SWITCH_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_SWITCH_fbt.cpp
@@ -51,7 +51,8 @@ namespace forte::eclipse4diac::rtevents {
       conn_WCET_EO1(nullptr),
       conn_Deadline_EO2(nullptr),
       conn_WCET_EO2(nullptr),
-      conn_QO(*this, 0, var_QO) {};
+      conn_QO(*this, 0, var_QO),
+      mInitialized(false) {};
 
   void FORTE_RT_E_SWITCH::setInitialValues() {
     var_QI = 0_BOOL;


### PR DESCRIPTION
Ensures a defined initial state for member variables, preventing potential undefined behavior from uninitialized flags and state variables.
