### PR TITLE
RT_E_SINGLE: Fix output event monitoring and simplify event dispatch

### DIFF
--- a/modules/rt_events/include/forte/eclipse4diac/rtevents/rtesingle.h
+++ b/modules/rt_events/include/forte/eclipse4diac/rtevents/rtesingle.h
@@ -41,11 +41,8 @@ namespace forte::eclipse4diac::rtevents {
       void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override {
         if (paEIID) { // it is not the init event
           if (mInitialized && checkActivation(paEIID)) {
-            CEventConnection *eoCon = getEOConUnchecked(1);
-            if (eoCon->isConnected()) {
-              eoCon->triggerEvent(&mECEO);
-              mECEO.resumeSelfSuspend();
-            }
+            sendOutputEvent(1, &mECEO);
+            mECEO.resumeSelfSuspend();
           }
         } else { // we got init
           if (var_QI == true) {


### PR DESCRIPTION
Replace direct triggerEvent() call with sendOutputEvent() in CRTEventSingle::executeEvent so the monitoring event counter is incremented correctly. This makes output events visible in the 4diac monitoring view without changing the RT dispatch behavior.
