### PR TITLE
Simplify event output triggering logic

### DIFF
--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_DEMUX_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_DEMUX_fbt.cpp
@@ -79,36 +79,11 @@ namespace forte::eclipse4diac::rtevents {
     switch (paEIID) {
       case scmEventEIID:
         if (mInitialized) {
-          CEventConnection *eoCon;
           switch (static_cast<CIEC_UINT::TValueType>(var_K)) {
-            case 0:
-              eoCon = getEOConUnchecked(scmEventEO0ID);
-              if (eoCon->isConnected()) {
-                eoCon->triggerEvent(&mECEO0);
-                mECEO0.resumeSelfSuspend();
-              }
-              break;
-            case 1:
-              eoCon = getEOConUnchecked(scmEventEO1ID);
-              if (eoCon->isConnected()) {
-                eoCon->triggerEvent(&mECEO1);
-                mECEO1.resumeSelfSuspend();
-              }
-              break;
-            case 2:
-              eoCon = getEOConUnchecked(scmEventEO2ID);
-              if (eoCon->isConnected()) {
-                eoCon->triggerEvent(&mECEO2);
-                mECEO2.resumeSelfSuspend();
-              }
-              break;
-            case 3:
-              eoCon = getEOConUnchecked(scmEventEO3ID);
-              if (eoCon->isConnected()) {
-                eoCon->triggerEvent(&mECEO3);
-                mECEO3.resumeSelfSuspend();
-              }
-              break;
+            case 0: sendOutputEvent(scmEventEO0ID, &mECEO0); mECEO0.resumeSelfSuspend(); break;
+            case 1: sendOutputEvent(scmEventEO1ID, &mECEO1); mECEO1.resumeSelfSuspend(); break;
+            case 2: sendOutputEvent(scmEventEO2ID, &mECEO2); mECEO2.resumeSelfSuspend(); break;
+            case 3: sendOutputEvent(scmEventEO3ID, &mECEO3); mECEO3.resumeSelfSuspend(); break;
             default: break;
           }
         }

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_SPLIT_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_SPLIT_fbt.cpp
@@ -65,17 +65,10 @@ namespace forte::eclipse4diac::rtevents {
     switch (paEIID) {
       case scmEventEIID:
         if (mInitialized) {
-          CEventConnection *eoCon;
-          eoCon = getEOConUnchecked(scmEventEO1ID);
-          if (eoCon->isConnected()) {
-            eoCon->triggerEvent(&mECEO1);
-            mECEO1.resumeSelfSuspend();
-          }
-          eoCon = getEOConUnchecked(scmEventEO2ID);
-          if (eoCon->isConnected()) {
-            eoCon->triggerEvent(&mECEO2);
-            mECEO2.resumeSelfSuspend();
-          }
+          sendOutputEvent(scmEventEO1ID, &mECEO1);
+          mECEO1.resumeSelfSuspend();
+          sendOutputEvent(scmEventEO2ID, &mECEO2);
+          mECEO2.resumeSelfSuspend();
         }
         break;
       case scmEventINITID:

--- a/modules/rt_events/src/eclipse4diac/rtevents/RT_E_SWITCH_fbt.cpp
+++ b/modules/rt_events/src/eclipse4diac/rtevents/RT_E_SWITCH_fbt.cpp
@@ -68,19 +68,12 @@ namespace forte::eclipse4diac::rtevents {
     switch (paEIID) {
       case scmEventEIID:
         if (mInitialized) {
-          CEventConnection *eoCon;
           if (!var_G) {
-            eoCon = getEOConUnchecked(scmEventEO1ID);
-            if (eoCon->isConnected()) {
-              eoCon->triggerEvent(&mECEO1);
-              mECEO1.resumeSelfSuspend();
-            }
+            sendOutputEvent(scmEventEO1ID, &mECEO1);
+            mECEO1.resumeSelfSuspend();
           } else {
-            eoCon = getEOConUnchecked(scmEventEO2ID);
-            if (eoCon->isConnected()) {
-              eoCon->triggerEvent(&mECEO2);
-              mECEO2.resumeSelfSuspend();
-            }
+            sendOutputEvent(scmEventEO2ID, &mECEO2);
+            mECEO2.resumeSelfSuspend();
           }
         }
         break;


### PR DESCRIPTION
Replace direct triggerEvent() call with sendOutputEvent() so the monitoring event counter is incremented correctly. This makes output events visible in the 4diac monitoring view without changing the RT dispatch behavior.
