### PR TITLE
Replace magic numbers with named constants in test files

### DIFF
--- a/tests/modules/IEC61131-3/F_DIV_tester.cpp
+++ b/tests/modules/IEC61131-3/F_DIV_tester.cpp
@@ -18,6 +18,9 @@ using namespace forte::literals;
 namespace forte::iec61131::arithmetic {
   struct F_DIV_TestFixture : public test::CFBTestFixtureBase {
 
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID CNF = 0;
+
       F_DIV_TestFixture() : CFBTestFixtureBase("iec61131::arithmetic::F_DIV"_STRID) {
         setInputData({&mIn1_DIV, &mIn2_DIV});
         setOutputData({&mOut_DIV});
@@ -36,8 +39,8 @@ namespace forte::iec61131::arithmetic {
     mIn1_DIV = 30_INT;
     mIn2_DIV = 5_INT;
     /* trigger the inputevent */
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_CHECK_EQUAL(6, static_cast<CIEC_INT::TValueType>(mOut_DIV));
   }
 
@@ -45,8 +48,8 @@ namespace forte::iec61131::arithmetic {
     mIn1_DIV = 30_INT;
     mIn2_DIV = 0_INT;
     /* trigger the inputevent */
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
   }
 
   BOOST_AUTO_TEST_SUITE_END()

--- a/tests/modules/IEC61131-3/F_DIV_tester.cpp
+++ b/tests/modules/IEC61131-3/F_DIV_tester.cpp
@@ -33,8 +33,8 @@ namespace forte::iec61131::arithmetic {
   BOOST_FIXTURE_TEST_SUITE(F_DIV_Tests, F_DIV_TestFixture)
 
   BOOST_AUTO_TEST_CASE(validDivision) {
-    mIn1_DIV = CIEC_INT(30);
-    mIn2_DIV = CIEC_INT(5);
+    mIn1_DIV = 30_INT;
+    mIn2_DIV = 5_INT;
     /* trigger the inputevent */
     triggerEvent(0);
     BOOST_CHECK(checkForSingleOutputEventOccurence(0));
@@ -42,8 +42,8 @@ namespace forte::iec61131::arithmetic {
   }
 
   BOOST_AUTO_TEST_CASE(divisionByZero) {
-    mIn1_DIV = CIEC_INT(30);
-    mIn2_DIV = CIEC_INT(0);
+    mIn1_DIV = 30_INT;
+    mIn2_DIV = 0_INT;
     /* trigger the inputevent */
     triggerEvent(0);
     BOOST_CHECK(checkForSingleOutputEventOccurence(0));

--- a/tests/modules/convert/GEN_STRUCT_DEMUX_tester.cpp
+++ b/tests/modules/convert/GEN_STRUCT_DEMUX_tester.cpp
@@ -19,6 +19,8 @@ using namespace forte::literals;
 
 namespace forte::eclipse4diac::convert::test {
   struct STRUCT_DEMUX_TestFixture_1 : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID CNF = 0;
 
       STRUCT_DEMUX_TestFixture_1() :
           CFBTestFixtureBase("eclipse4diac::convert::STRUCT_DEMUX_1Struct_Muxer_Test_Struct_1"_STRID) {
@@ -43,46 +45,46 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_FIXTURE_TEST_SUITE(STRUCT_DEMUX_MainTests, STRUCT_DEMUX_TestFixture_1)
 
   BOOST_AUTO_TEST_CASE(initalValueCheck) {
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(changeValueCheck) {
-    mIn.Var1 = CIEC_INT(-256);
-    mIn.Var2 = CIEC_INT(23145);
+    mIn.Var1 = -256_INT;
+    mIn.Var2 = 23145_INT;
     mIn.Var3 = "My Test String!"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(updateValueCheck) {
-    mIn.Var1 = CIEC_INT(12);
-    mIn.Var2 = CIEC_INT(11111);
+    mIn.Var1 = 12_INT;
+    mIn.Var2 = 11111_INT;
     mIn.Var3 = "string!"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
 
     // change values to check consecutive updates
 
-    mIn.Var1 = CIEC_INT(32255);
-    mIn.Var2 = CIEC_INT(12345);
+    mIn.Var1 = 32255_INT;
+    mIn.Var2 = 12345_INT;
     mIn.Var3 = "new string!"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(steadyStateValueCheck) {
-    mIn.Var1 = CIEC_INT(13);
-    mIn.Var2 = CIEC_INT(234);
+    mIn.Var1 = 13_INT;
+    mIn.Var2 = 234_INT;
     mIn.Var3 = "stable value"_STRING;
 
     for (size_t i = 0; i < 45; i++) {
-      triggerEvent(0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+      triggerEvent(REQ);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
       checkStructValues();
     }
   }
@@ -90,6 +92,8 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_AUTO_TEST_SUITE_END()
 
   struct STRUCT_DEMUX_TestFixture_2 : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID CNF = 0;
 
       STRUCT_DEMUX_TestFixture_2() :
           CFBTestFixtureBase("eclipse4diac::convert::STRUCT_DEMUX_1Struct_Muxer_Test_Struct_2"_STRID) {
@@ -114,17 +118,17 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_FIXTURE_TEST_SUITE(STRUCT_DEMUX_SecondStructTest, STRUCT_DEMUX_TestFixture_2)
 
   BOOST_AUTO_TEST_CASE(initalValueCheck) {
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(changeValueCheck) {
-    mIn.Var1 = CIEC_INT(1234);
+    mIn.Var1 = 1234_INT;
     mIn.Var2 = "this is the second struct!"_STRING;
-    mIn.Var3 = CIEC_INT(-2345);
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    mIn.Var3 = -2345_INT;
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
@@ -166,6 +170,8 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_AUTO_TEST_SUITE_END()
 
   struct STRUCT_DEMUX_TestFixture_5 : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID CNF = 0;
 
       STRUCT_DEMUX_TestFixture_5() :
           CFBTestFixtureBase("eclipse4diac::convert::STRUCT_DEMUX_1Struct_Muxer_Test_Struct_5"_STRID) {
@@ -197,19 +203,19 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_FIXTURE_TEST_SUITE(STRUCT_DEMUX_ArrayStructTest, STRUCT_DEMUX_TestFixture_5)
 
   BOOST_AUTO_TEST_CASE(initalValueCheck) {
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(changeValueCheck) {
-    mIn.Var1 = CIEC_INT(1234);
-    mIn.Var2 = CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{CIEC_INT(17), CIEC_INT(4), CIEC_INT(21), CIEC_INT(42)};
+    mIn.Var1 = 1234_INT;
+    mIn.Var2 = CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{17_INT, 4_INT, 21_INT, 42_INT};
     mIn.Var3 = CIEC_ARRAY_FIXED<CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>, 0, 1>{
-        CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{CIEC_INT(17), CIEC_INT(4), CIEC_INT(21), CIEC_INT(42)},
-        CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{CIEC_INT(1), CIEC_INT(2), CIEC_INT(3), CIEC_INT(4)}};
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+        CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{17_INT, 4_INT, 21_INT, 42_INT},
+        CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{1_INT, 2_INT, 3_INT, 4_INT}};
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 

--- a/tests/modules/convert/GEN_STRUCT_MUX_tester.cpp
+++ b/tests/modules/convert/GEN_STRUCT_MUX_tester.cpp
@@ -19,6 +19,8 @@ using namespace forte::literals;
 
 namespace forte::eclipse4diac::convert::test {
   struct STRUCT_MUX_TestFixture_1 : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID CNF = 0;
 
       STRUCT_MUX_TestFixture_1() :
           CFBTestFixtureBase("eclipse4diac::convert::STRUCT_MUX_1Struct_Muxer_Test_Struct_1"_STRID) {
@@ -43,46 +45,46 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_FIXTURE_TEST_SUITE(STRUCT_MUX_MainTests, STRUCT_MUX_TestFixture_1)
 
   BOOST_AUTO_TEST_CASE(initalValueCheck) {
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(changeValueCheck) {
-    mVar1 = CIEC_INT(-256);
-    mVar2 = CIEC_INT(23145);
+    mVar1 = -256_INT;
+    mVar2 = 23145_INT;
     mVar3 = "My Test String!"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(updateValueCheck) {
-    mVar1 = CIEC_INT(12);
-    mVar2 = CIEC_INT(-11111);
+    mVar1 = 12_INT;
+    mVar2 = -11111_INT;
     mVar3 = "string!"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
 
     // change values to check consecutive updates
 
-    mVar1 = CIEC_INT(32255);
-    mVar2 = CIEC_INT(12345);
+    mVar1 = 32255_INT;
+    mVar2 = 12345_INT;
     mVar3 = "new string!"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(steadyStateValueCheck) {
-    mVar1 = CIEC_INT(13);
-    mVar2 = CIEC_INT(234);
+    mVar1 = 13_INT;
+    mVar2 = 234_INT;
     mVar3 = "stable value"_STRING;
 
     for (size_t i = 0; i < 45; i++) {
-      triggerEvent(0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+      triggerEvent(REQ);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
       checkStructValues();
     }
   }
@@ -90,6 +92,8 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_AUTO_TEST_SUITE_END()
 
   struct STRUCT_MUX_TestFixture_2 : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID CNF = 0;
 
       STRUCT_MUX_TestFixture_2() :
           CFBTestFixtureBase("eclipse4diac::convert::STRUCT_MUX_1Struct_Muxer_Test_Struct_2"_STRID) {
@@ -114,17 +118,17 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_FIXTURE_TEST_SUITE(STRUCT_MUX_SecondStructTest, STRUCT_MUX_TestFixture_2)
 
   BOOST_AUTO_TEST_CASE(initalValueCheck) {
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(changeValueCheck) {
-    mVar1 = CIEC_INT(1234);
+    mVar1 = 1234_INT;
     mVar2 = "this is the second struct!"_STRING;
-    mVar3 = CIEC_INT(-2345);
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    mVar3 = -2345_INT;
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
@@ -166,6 +170,8 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_AUTO_TEST_SUITE_END()
 
   struct STRUCT_MUX_TestFixture_5 : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID CNF = 0;
 
       STRUCT_MUX_TestFixture_5() :
           CFBTestFixtureBase("eclipse4diac::convert::STRUCT_MUX_1Struct_Muxer_Test_Struct_5"_STRID) {
@@ -197,19 +203,19 @@ namespace forte::eclipse4diac::convert::test {
   BOOST_FIXTURE_TEST_SUITE(STRUCT_MUX_ArrayStructTest, STRUCT_MUX_TestFixture_5)
 
   BOOST_AUTO_TEST_CASE(initalValueCheck) {
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 
   BOOST_AUTO_TEST_CASE(changeValueCheck) {
-    mVar1 = CIEC_INT(1234);
-    mVar2 = CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{CIEC_INT(17), CIEC_INT(4), CIEC_INT(21), CIEC_INT(42)};
+    mVar1 = 1234_INT;
+    mVar2 = CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{17_INT, 4_INT, 21_INT, 42_INT};
     mVar3 = CIEC_ARRAY_FIXED<CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>, 0, 1>{
-        CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{CIEC_INT(17), CIEC_INT(4), CIEC_INT(21), CIEC_INT(42)},
-        CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{CIEC_INT(1), CIEC_INT(2), CIEC_INT(3), CIEC_INT(4)}};
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+        CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{17_INT, 4_INT, 21_INT, 42_INT},
+        CIEC_ARRAY_FIXED<CIEC_INT, 0, 3>{1_INT, 2_INT, 3_INT, 4_INT}};
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     checkStructValues();
   }
 

--- a/tests/modules/utils/GEN_CSV_WRITER_tester.cpp
+++ b/tests/modules/utils/GEN_CSV_WRITER_tester.cpp
@@ -108,7 +108,7 @@ namespace forte::eclipse4diac::utils::test {
 
   BOOST_FIXTURE_TEST_CASE(validWrite, GEN_CSV_WRITER_TestFixtureIntString) {
     mQI = true_BOOL;
-    mSD_1 = CIEC_INT(1);
+    mSD_1 = 1_INT;
     mSD_2 = "Test"_STRING;
 
     triggerEvent(InputEventREQ);
@@ -117,7 +117,7 @@ namespace forte::eclipse4diac::utils::test {
     BOOST_CHECK(mQO);
 
     mQI = true_BOOL;
-    mSD_1 = CIEC_INT(20);
+    mSD_1 = 20_INT;
     mSD_2 = "Test2"_STRING;
 
     triggerEvent(InputEventREQ);
@@ -131,9 +131,9 @@ namespace forte::eclipse4diac::utils::test {
 
   BOOST_FIXTURE_TEST_CASE(arrayWrite, GEN_CSV_WRITER_TestFixtureArrayArray) {
     mQI = true_BOOL;
-    mSD_1[0].setValue(CIEC_INT(1));
-    mSD_1[1].setValue(CIEC_INT(2));
-    mSD_1[2].setValue(CIEC_INT(3));
+    mSD_1[0].setValue(1_INT);
+    mSD_1[1].setValue(2_INT);
+    mSD_1[2].setValue(3_INT);
     mSD_2[0].setValue(CIEC_STRING("A"s));
     mSD_2[1].setValue(CIEC_STRING("B"s));
     mSD_2[2].setValue(CIEC_STRING("C"s));

--- a/tests/modules/utils/GET_STRUCT_VALUE_tester.cpp
+++ b/tests/modules/utils/GET_STRUCT_VALUE_tester.cpp
@@ -123,6 +123,9 @@ namespace forte::eclipse4diac::utils::test {
   DEFINE_FIRMWARE_DATATYPE(GET_STRUCT_VALUE_Struct_test2, "GET_STRUCT_VALUE_Struct_test2"_STRID)
 
   struct GET_STRUCT_VALUE_GenericTestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID INVALID_EI = 1;
+      static constexpr TEventID CNF = 0;
 
       GET_STRUCT_VALUE_GenericTestFixture(CIEC_ANY *paIN_STRUCT, CIEC_ANY *paOUT) :
           CFBTestFixtureBase("eclipse4diac::convert::GET_STRUCT_VALUE"_STRID) {
@@ -149,51 +152,51 @@ namespace forte::eclipse4diac::utils::test {
 
   BOOST_AUTO_TEST_CASE(firstLevel) {
     mMember = "Val1"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_CHECK_EQUAL(true, mQO);
     BOOST_CHECK_EQUAL(1, static_cast<CIEC_INT::TValueType>(mOut));
   }
 
   BOOST_AUTO_TEST_CASE(secondLevel) {
     mMember = "Val2.Val2"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_CHECK_EQUAL(true, mQO);
     BOOST_CHECK_EQUAL(2, static_cast<CIEC_INT::TValueType>(mOut));
   }
 
   BOOST_AUTO_TEST_CASE(firstLevelWrongName) {
     mMember = "xVal1"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_CHECK_EQUAL(false, mQO);
   }
 
   BOOST_AUTO_TEST_CASE(firstLevelWrongNameWithSecondLevel) {
     mMember = "xVal1.Val2"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_CHECK_EQUAL(false, mQO);
   }
 
   BOOST_AUTO_TEST_CASE(secondLevelWrongName) {
     mMember = "Val2.xVal2"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_CHECK_EQUAL(false, mQO);
   }
 
   BOOST_AUTO_TEST_CASE(accessNonStruct) {
     mMember = "Val1.Val1"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_CHECK_EQUAL(false, mQO);
   }
 
   BOOST_AUTO_TEST_CASE(WrongEventInput) {
     mMember = "Val2.Val1"_STRING;
-    triggerEvent(1);
+    triggerEvent(INVALID_EI);
     BOOST_CHECK(eventChainEmpty());
   }
 
@@ -202,7 +205,7 @@ namespace forte::eclipse4diac::utils::test {
   struct GET_STRUCT_VALUE_WRONG_OUTPUT_TYPE_TestFixture : public GET_STRUCT_VALUE_GenericTestFixture {
 
       GET_STRUCT_VALUE_WRONG_OUTPUT_TYPE_TestFixture() : GET_STRUCT_VALUE_GenericTestFixture(&mIn_struct, &mOut) {
-        mIn_struct = CIEC_INT(1);
+        mIn_struct = 1_INT;
         setup();
       }
 
@@ -214,8 +217,8 @@ namespace forte::eclipse4diac::utils::test {
 
   BOOST_AUTO_TEST_CASE(wrongInputType) {
     mMember = "Val1"_STRING;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_CHECK_EQUAL(false, mQO);
   }
 

--- a/tests/stdfblib/CFB_DELEGATING_TEST_tester.cpp
+++ b/tests/stdfblib/CFB_DELEGATING_TEST_tester.cpp
@@ -23,6 +23,8 @@ using namespace forte::literals;
 
 namespace forte::test {
   struct CFB_DELEGATING_TEST_TestFixture : CFBTestFixtureBase {
+      static constexpr TEventID REQ = 0;
+      static constexpr TEventID CNF = 0;
 
       CFB_DELEGATING_TEST_TestFixture() : CFBTestFixtureBase("test::CFB_DELEGATING_TEST"_STRID) {
         setInputData({&var_QI, &var_DI1});
@@ -39,8 +41,8 @@ namespace forte::test {
   BOOST_FIXTURE_TEST_SUITE(DelegatingTests, CFB_DELEGATING_TEST_TestFixture)
 
   BOOST_AUTO_TEST_CASE(initTest) {
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_TEST(var_QO == true);
     BOOST_TEST(var_DO1.var_VAR1 == false);
     BOOST_TEST(var_DO1.var_VAR2 == false);
@@ -50,8 +52,8 @@ namespace forte::test {
   BOOST_AUTO_TEST_CASE(dataTest) {
     var_QI = true_BOOL;
     var_DI1.var_VAR1 = true_BOOL;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(REQ);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
     BOOST_TEST(var_QO == false);
     BOOST_TEST(var_DO1.var_VAR1 == true);
     BOOST_TEST(var_DO1.var_VAR2 == false);

--- a/tests/stdfblib/CFB_TEST_tester.cpp
+++ b/tests/stdfblib/CFB_TEST_tester.cpp
@@ -18,6 +18,10 @@ using namespace forte::literals;
 
 namespace forte::test {
   struct CFB_TEST_TestFixture : public CFBTestFixtureBase {
+      static constexpr TEventID SET = 0;
+      static constexpr TEventID RESET = 1;
+      static constexpr TEventID CNF = 0;
+      static constexpr TEventID CHANGED = 1;
 
       CFB_TEST_TestFixture() : CFBTestFixtureBase("CFB_TEST"_STRID) {
         setInputData({&mInQI});
@@ -30,10 +34,10 @@ namespace forte::test {
 
       bool checkBothOutputEvents() {
         bool bResult = true;
-        if (0 != pullFirstChainEventID()) {
+        if (CNF != pullFirstChainEventID()) {
           bResult = false;
         }
-        if (1 != pullFirstChainEventID()) {
+        if (CHANGED != pullFirstChainEventID()) {
           bResult = false;
         }
         if (!eventChainEmpty()) {
@@ -48,10 +52,10 @@ namespace forte::test {
   BOOST_AUTO_TEST_CASE(inhibitTest) {
     mInQI = false_BOOL;
     for (unsigned int i = 0; i < 100; ++i) {
-      triggerEvent(0);
+      triggerEvent(SET);
       BOOST_CHECK(eventChainEmpty());
       BOOST_CHECK_EQUAL(false, mOutSR);
-      triggerEvent(1);
+      triggerEvent(RESET);
       BOOST_CHECK(eventChainEmpty());
       BOOST_CHECK_EQUAL(false, mOutSR);
     }
@@ -59,26 +63,26 @@ namespace forte::test {
 
   BOOST_AUTO_TEST_CASE(setTest) {
     mInQI = true_BOOL;
-    triggerEvent(0);
+    triggerEvent(SET);
     BOOST_CHECK(checkBothOutputEvents());
     BOOST_CHECK_EQUAL(true, mOutSR);
     for (unsigned int i = 0; i < 100; ++i) {
-      triggerEvent(0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+      triggerEvent(SET);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
       BOOST_CHECK_EQUAL(true, mOutSR);
     }
   }
 
   BOOST_AUTO_TEST_CASE(resetTest) {
     mInQI = true_BOOL;
-    triggerEvent(0);
+    triggerEvent(SET);
     clearEventChain();
-    triggerEvent(1);
+    triggerEvent(RESET);
     BOOST_CHECK(checkBothOutputEvents());
     BOOST_CHECK_EQUAL(false, mOutSR);
     for (unsigned int i = 0; i < 100; ++i) {
-      triggerEvent(1);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+      triggerEvent(RESET);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(CNF));
       BOOST_CHECK_EQUAL(false, mOutSR);
     }
   }
@@ -86,10 +90,10 @@ namespace forte::test {
   BOOST_AUTO_TEST_CASE(toggleTest) {
     mInQI = true_BOOL;
     for (int i = 0; i < 1000; ++i) {
-      triggerEvent(0);
+      triggerEvent(SET);
       BOOST_CHECK(checkBothOutputEvents());
       BOOST_CHECK_EQUAL(true, mOutSR);
-      triggerEvent(1);
+      triggerEvent(RESET);
       BOOST_CHECK(checkBothOutputEvents());
       BOOST_CHECK_EQUAL(false, mOutSR);
     }

--- a/tests/stdfblib/events/E_CTD_tester.cpp
+++ b/tests/stdfblib/events/E_CTD_tester.cpp
@@ -22,6 +22,10 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_CTD_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID CD = 0;
+      static constexpr TEventID LD = 1;
+      static constexpr TEventID CDO = 0;
+      static constexpr TEventID LDO = 1;
 
       E_CTD_TestFixture() : CFBTestFixtureBase("iec61499::events::E_CTD"_STRID) {
         setInputData({&mInPV});
@@ -43,9 +47,9 @@ namespace forte::iec61499::events::test {
         } else {
           if (func_NE(CIEC_UINT(pa_prevCV - 1), mOutCV)) {
             return false;
-          } else if (func_NE(mOutQ, func_LT(mOutCV, CIEC_UINT(1)))) {
+          } else if (func_NE(mOutQ, func_LT(mOutCV, 1_UINT))) {
             return false;
-          } else if (!checkForSingleOutputEventOccurence(0)) {
+          } else if (!checkForSingleOutputEventOccurence(CDO)) {
             return false;
           }
         }
@@ -57,7 +61,7 @@ namespace forte::iec61499::events::test {
                     func_OR(func_NE(mInPV, mOutCV), func_NE(CIEC_BOOL(pa_usedPV < 1), mOutQ)))) {
           return false;
         }
-        if (!checkForSingleOutputEventOccurence(1)) {
+        if (!checkForSingleOutputEventOccurence(LDO)) {
           return false;
         }
         return true;
@@ -73,10 +77,10 @@ namespace forte::iec61499::events::test {
     for (unsigned int i = 0; i < numberOfValues; i++) {
       for (unsigned int j = 0; j < numberOfTries; j++) {
         mInPV = CIEC_UINT(valuesToTest[i]);
-        triggerEvent(1);
-        checkForSingleOutputEventOccurence(1);
+        triggerEvent(LD);
+        checkForSingleOutputEventOccurence(LDO);
         // Send event
-        triggerEvent(0);
+        triggerEvent(CD);
         BOOST_CHECK(checkCD(valuesToTest[i]));
       }
     }
@@ -89,7 +93,7 @@ namespace forte::iec61499::events::test {
     for (unsigned int i = 0; i < numberOftest; ++i) {
       for (unsigned int j = 0; j < numberOfTries; j++) {
         mInPV = CIEC_UINT(PVToTest[i]);
-        triggerEvent(1);
+        triggerEvent(LD);
         BOOST_CHECK(checkLD(PVToTest[i]));
       }
     }
@@ -98,48 +102,48 @@ namespace forte::iec61499::events::test {
   BOOST_AUTO_TEST_CASE(Mix) {
     unsigned int numberOfTries = 100;
     for (unsigned int i = 0; i < numberOfTries; i++) {
-      mInPV = CIEC_UINT(0);
-      triggerEvent(1);
+      mInPV = 0_UINT;
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(0));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(0));
 
-      mInPV = CIEC_UINT(1);
-      triggerEvent(0);
+      mInPV = 1_UINT;
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(0));
-      triggerEvent(1);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(1));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(1));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(0));
-      triggerEvent(1);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(1));
-      triggerEvent(1);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(1));
-      triggerEvent(1);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(1));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(1));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(0));
 
-      mInPV = CIEC_UINT(65535);
-      triggerEvent(1);
+      mInPV = 65535_UINT;
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(65535));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(65535));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(65534));
-      triggerEvent(1);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(65535));
-      triggerEvent(1);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(65535));
-      triggerEvent(1);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(65535));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(65535));
-      triggerEvent(0);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(65534));
     }
   }

--- a/tests/stdfblib/events/E_CTUD_tester.cpp
+++ b/tests/stdfblib/events/E_CTUD_tester.cpp
@@ -23,6 +23,13 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_CTUD_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID CU = 0;
+      static constexpr TEventID CD = 1;
+      static constexpr TEventID R = 2;
+      static constexpr TEventID LD = 3;
+      static constexpr TEventID CO = 0;
+      static constexpr TEventID RO = 1;
+      static constexpr TEventID LDO = 2;
 
       E_CTUD_TestFixture() : CFBTestFixtureBase("iec61499::events::E_CTUD"_STRID) {
         setInputData({&mInPV});
@@ -39,7 +46,7 @@ namespace forte::iec61499::events::test {
         if (paPrevCV < 65535) {
           if (((paPrevCV + 1) != static_cast<CIEC_UINT::TValueType>(mOutCV))) {
             return false;
-          } else if (!checkForSingleOutputEventOccurence(0)) {
+          } else if (!checkForSingleOutputEventOccurence(CO)) {
             return false;
           }
         } else {
@@ -64,7 +71,7 @@ namespace forte::iec61499::events::test {
             return false;
           } else if (mOutQD != (static_cast<CIEC_UINT::TValueType>(mOutCV) < 1)) {
             return false;
-          } else if (!checkForSingleOutputEventOccurence(0)) {
+          } else if (!checkForSingleOutputEventOccurence(CO)) {
             return false;
           }
         }
@@ -78,7 +85,7 @@ namespace forte::iec61499::events::test {
         if (0 != static_cast<CIEC_UINT::TValueType>(mOutCV)) {
           return false;
         }
-        if (!checkForSingleOutputEventOccurence(1)) {
+        if (!checkForSingleOutputEventOccurence(RO)) {
           return false;
         }
         if (!checkBooleans()) {
@@ -93,7 +100,7 @@ namespace forte::iec61499::events::test {
             ((paUsedPV < 1) != (true == static_cast<CIEC_BOOL::TValueType>(mOutQD)))) {
           return false;
         }
-        if (!checkForSingleOutputEventOccurence(2)) {
+        if (!checkForSingleOutputEventOccurence(LDO)) {
           return false;
         }
         if (!checkBooleans()) {
@@ -103,8 +110,7 @@ namespace forte::iec61499::events::test {
       }
 
       bool checkBooleans() {
-        return func_NOT(
-            func_OR(func_NE(mOutQU, func_GE(mOutCV, mInPV)), func_NE(mOutQD, func_LT(mOutCV, CIEC_UINT(1)))));
+        return func_NOT(func_OR(func_NE(mOutQU, func_GE(mOutCV, mInPV)), func_NE(mOutQD, func_LT(mOutCV, 1_UINT))));
       }
   };
 
@@ -115,13 +121,13 @@ namespace forte::iec61499::events::test {
     TForteUInt16 valuesToTest[] = {10, 1, 0, 65534, 65535};
     unsigned int numberOfValues = static_cast<unsigned int>(sizeof(valuesToTest) / sizeof(TForteUInt16));
     for (unsigned int j = 0; j < numberOfValues; j++) {
-      triggerEvent(2);
+      triggerEvent(R);
       BOOST_CHECK(checkR());
       mInPV = CIEC_UINT(valuesToTest[j]);
       for (unsigned int k = 0U; k < static_cast<CIEC_UINT::TValueType>(mInPV) + 3U; k++) {
         prevCV = static_cast<CIEC_UINT::TValueType>(mOutCV);
         // Send event
-        triggerEvent(0);
+        triggerEvent(CU);
         BOOST_CHECK(checkCU(prevCV));
       }
     }
@@ -134,10 +140,10 @@ namespace forte::iec61499::events::test {
     for (unsigned int i = 0; i < numberOfTries; i++) {
       for (unsigned int j = 0; j < numberOfValues; j++) {
         mInPV = CIEC_UINT(valuesToTest[j]);
-        triggerEvent(3);
-        checkForSingleOutputEventOccurence(1);
+        triggerEvent(LD);
+        checkForSingleOutputEventOccurence(RO);
         // Send event
-        triggerEvent(1);
+        triggerEvent(CD);
         BOOST_CHECK(checkCD(valuesToTest[j]));
       }
     }
@@ -150,9 +156,9 @@ namespace forte::iec61499::events::test {
     for (unsigned int i = 0; i < numberOfTries; i++) {
       for (unsigned int j = 0; j < numberOfValues; j++) {
         mInPV = CIEC_UINT(valuesToTest[j]);
-        triggerEvent(3); // loads the value to input of the FB, because the Rese event doesn't scan the PV input.
-        checkForSingleOutputEventOccurence(1);
-        triggerEvent(2);
+        triggerEvent(LD); // loads the value to input of the FB, because the Rese event doesn't scan the PV input.
+        checkForSingleOutputEventOccurence(RO);
+        triggerEvent(R);
         BOOST_CHECK(checkR());
       }
     }
@@ -165,7 +171,7 @@ namespace forte::iec61499::events::test {
     for (unsigned int i = 0; i < numberOfTries; i++) {
       for (unsigned int j = 0; j < numberOftest; j++) {
         mInPV = CIEC_UINT(PVToTest[j]);
-        triggerEvent(3);
+        triggerEvent(LD);
         BOOST_CHECK(checkLD(PVToTest[j]));
       }
     }
@@ -174,67 +180,67 @@ namespace forte::iec61499::events::test {
   BOOST_AUTO_TEST_CASE(Mix) {
     unsigned int numberOfTries = 10;
     for (unsigned int i = 0; i < numberOfTries; i++) {
-      mInPV = CIEC_UINT(0);
-      triggerEvent(3);
+      mInPV = 0_UINT;
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(0));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(0));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(1));
-      triggerEvent(1);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(2));
-      triggerEvent(3);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(0));
-      triggerEvent(2);
+      triggerEvent(R);
       BOOST_CHECK(checkR());
 
-      mInPV = CIEC_UINT(1);
-      triggerEvent(0);
+      mInPV = 1_UINT;
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(0));
-      triggerEvent(3);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(1));
-      triggerEvent(3);
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(1));
 
-      mInPV = CIEC_UINT(65533);
-      triggerEvent(3);
+      mInPV = 65533_UINT;
+      triggerEvent(LD);
       BOOST_CHECK(checkLD(65533));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65533));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65534));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65535));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65535));
-      triggerEvent(1);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(65535));
-      triggerEvent(1);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(65534));
-      triggerEvent(2);
+      triggerEvent(R);
       BOOST_CHECK(checkR());
 
-      mInPV = CIEC_UINT(65533);
+      mInPV = 65533_UINT;
       for (unsigned int j = 0; j < 65533; j++) {
         // Send event
-        triggerEvent(0);
+        triggerEvent(CU);
         BOOST_CHECK(checkCU(j));
       }
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65533));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65534));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65535));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65535));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65535));
-      triggerEvent(1);
+      triggerEvent(CD);
       BOOST_CHECK(checkCD(65535));
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(65534));
-      triggerEvent(2);
+      triggerEvent(R);
       BOOST_CHECK(checkR());
     }
   }

--- a/tests/stdfblib/events/E_CTU_tester.cpp
+++ b/tests/stdfblib/events/E_CTU_tester.cpp
@@ -24,6 +24,10 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_CTU_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID CU = 0;
+      static constexpr TEventID R = 1;
+      static constexpr TEventID CUO = 0;
+      static constexpr TEventID RO = 1;
 
       E_CTU_TestFixture() : CFBTestFixtureBase("iec61499::events::E_CTU"_STRID) {
         setInputData({&mInPV});
@@ -39,7 +43,7 @@ namespace forte::iec61499::events::test {
         if (paPrevCV < std::numeric_limits<CIEC_UINT::TValueType>::max()) {
           if (func_NE(CIEC_UINT(paPrevCV + 1), mOutCV)) {
             return false;
-          } else if (!checkForSingleOutputEventOccurence(0)) {
+          } else if (!checkForSingleOutputEventOccurence(CUO)) {
             return false;
           }
         } else {
@@ -55,10 +59,10 @@ namespace forte::iec61499::events::test {
       }
 
       bool checkR() {
-        if (func_OR(func_NE(CIEC_UINT(0), mOutCV), mOutQ)) {
+        if (func_OR(func_NE(0_UINT, mOutCV), mOutQ)) {
           return false;
         }
-        if (!checkForSingleOutputEventOccurence(1)) {
+        if (!checkForSingleOutputEventOccurence(RO)) {
           return false;
         }
         return true;
@@ -72,13 +76,13 @@ namespace forte::iec61499::events::test {
     TForteUInt16 valuesToTest[] = {10, 1, 0, 65534, 65535};
     size_t numberOfValues = static_cast<size_t>(sizeof(valuesToTest) / sizeof(TForteUInt16));
     for (size_t j = 0; j < numberOfValues; j++) {
-      triggerEvent(1);
+      triggerEvent(R);
       BOOST_CHECK(checkR());
       mInPV = CIEC_UINT(valuesToTest[j]);
       for (unsigned int k = 0U; k < static_cast<CIEC_UINT::TValueType>(mInPV) + 3U; k++) {
         prevCV = static_cast<CIEC_UINT::TValueType>(mOutCV);
         // Send event
-        triggerEvent(0);
+        triggerEvent(CU);
         BOOST_CHECK(checkCU(prevCV));
       }
     }
@@ -91,55 +95,55 @@ namespace forte::iec61499::events::test {
     for (size_t i = 0; i < numberOfTries; i++) {
       for (size_t j = 0; j < numberOfValues; j++) {
         mInPV = CIEC_UINT(valuesToTest[j]);
-        triggerEvent(1);
+        triggerEvent(R);
         BOOST_CHECK(checkR());
       }
     }
   }
 
   BOOST_AUTO_TEST_CASE(Mix) {
-    mInPV = CIEC_UINT(0);
-    triggerEvent(1);
+    mInPV = 0_UINT;
+    triggerEvent(R);
     BOOST_CHECK(checkR());
 
-    triggerEvent(0);
+    triggerEvent(CU);
     BOOST_CHECK(checkCU(0));
 
-    mInPV = CIEC_UINT(1);
-    triggerEvent(0);
+    mInPV = 1_UINT;
+    triggerEvent(CU);
     BOOST_CHECK(checkCU(1));
 
-    triggerEvent(1);
+    triggerEvent(R);
     BOOST_CHECK(checkR());
 
-    triggerEvent(0);
+    triggerEvent(CU);
     BOOST_CHECK(checkCU(0));
-    triggerEvent(0);
+    triggerEvent(CU);
     BOOST_CHECK(checkCU(1));
 
-    triggerEvent(0);
+    triggerEvent(CU);
     BOOST_CHECK(checkCU(2));
 
-    triggerEvent(1);
+    triggerEvent(R);
     BOOST_CHECK(checkR());
 
-    mInPV = CIEC_UINT(65533);
+    mInPV = 65533_UINT;
     for (TForteUInt16 i = 0; i < std::numeric_limits<CIEC_UINT::TValueType>::max(); i++) {
       // Send event
-      triggerEvent(0);
+      triggerEvent(CU);
       BOOST_CHECK(checkCU(i));
     }
 
-    triggerEvent(0);
+    triggerEvent(CU);
     BOOST_CHECK(checkCU(std::numeric_limits<CIEC_UINT::TValueType>::max()));
 
-    triggerEvent(0);
+    triggerEvent(CU);
     BOOST_CHECK(checkCU(std::numeric_limits<CIEC_UINT::TValueType>::max()));
 
-    triggerEvent(0);
+    triggerEvent(CU);
     BOOST_CHECK(checkCU(std::numeric_limits<CIEC_UINT::TValueType>::max()));
 
-    triggerEvent(1);
+    triggerEvent(R);
     BOOST_CHECK(checkR());
   }
 

--- a/tests/stdfblib/events/E_DELAY_tester.cpp
+++ b/tests/stdfblib/events/E_DELAY_tester.cpp
@@ -31,6 +31,10 @@ namespace forte::iec61499::events::test {
       DECLARE_FB_TESTER(E_DELAY_tester);
 
     public:
+      static constexpr TEventID START = 0;
+      static constexpr TEventID STOP = 1;
+      static constexpr TEventID EO = 0;
+
       E_DELAY_tester(CResource *mTestResource) : CFBTester(mTestResource) {
         setInputData({&mDT});
       }
@@ -47,18 +51,18 @@ namespace forte::iec61499::events::test {
 
       bool testCase_NormalDelay() {
         mDT.setFromMilliSeconds(500);
-        triggerEvent(0);
+        triggerEvent(START);
         usleep(500000);
-        return checkForSingleOutputEventOccurence(0);
+        return checkForSingleOutputEventOccurence(EO);
       }
       bool testCase_AbortedDelay() {
         bool retVal = true;
         mDT.setFromMilliSeconds(1000);
-        triggerEvent(0);
+        triggerEvent(START);
         if (!eventChainEmpty()) {
           retVal = false_BOOL;
         }
-        triggerEvent(1);
+        triggerEvent(STOP);
         if (!eventChainEmpty()) {
           retVal = false_BOOL;
         }
@@ -71,14 +75,14 @@ namespace forte::iec61499::events::test {
       bool testCase_MultipleStarts() {
         bool retVal = true;
         mDT.setFromMilliSeconds(200);
-        triggerEvent(0);
+        triggerEvent(START);
         usleep(50000);
         if (!eventChainEmpty()) {
           retVal = false_BOOL;
         }
-        triggerEvent(0);
+        triggerEvent(START);
         usleep(150000);
-        if (!checkForSingleOutputEventOccurence(0)) {
+        if (!checkForSingleOutputEventOccurence(EO)) {
           retVal = false_BOOL;
         }
         usleep(50000);

--- a/tests/stdfblib/events/E_DEMUX_tester.cpp
+++ b/tests/stdfblib/events/E_DEMUX_tester.cpp
@@ -22,6 +22,12 @@ namespace forte::iec61499::events::test {
       DECLARE_FB_TESTER(E_DEMUX_tester);
 
     public:
+      static constexpr TEventID EI = 0;
+      static constexpr TEventID EO0 = 0;
+      static constexpr TEventID EO1 = 1;
+      static constexpr TEventID EO2 = 2;
+      static constexpr TEventID EO3 = 3;
+
     private:
       E_DEMUX_tester(CResource *mTestResource) : CFBTester(mTestResource) {
         setInputData({&mIn_K});
@@ -42,35 +48,35 @@ namespace forte::iec61499::events::test {
         /* prepare inputparameters */
         mIn_K = 0;
         /* trigger the inputevent */
-        triggerEvent(0);
-        return checkForSingleOutputEventOccurence(0);
+        triggerEvent(EI);
+        return checkForSingleOutputEventOccurence(EO0);
       }
       bool testCase_K1() {
         /* prepare inputparameters */
         mIn_K = 1;
         /* trigger the inputevent */
-        triggerEvent(0);
-        return checkForSingleOutputEventOccurence(1);
+        triggerEvent(EI);
+        return checkForSingleOutputEventOccurence(EO1);
       }
       bool testCase_K2() {
         /* prepare inputparameters */
         mIn_K = 2;
         /* trigger the inputevent */
-        triggerEvent(0);
-        return checkForSingleOutputEventOccurence(2);
+        triggerEvent(EI);
+        return checkForSingleOutputEventOccurence(EO2);
       }
       bool testCase_K3() {
         /* prepare inputparameters */
         mIn_K = 3;
         /* trigger the inputevent */
-        triggerEvent(0);
-        return checkForSingleOutputEventOccurence(3);
+        triggerEvent(EI);
+        return checkForSingleOutputEventOccurence(EO3);
       }
       bool testCase_K_GT_3() {
         /* prepare inputparameters */
         mIn_K = 4;
         /* trigger the inputevent */
-        triggerEvent(0);
+        triggerEvent(EI);
         return eventChainEmpty();
       }
 

--- a/tests/stdfblib/events/E_F_TRIG_tester.cpp
+++ b/tests/stdfblib/events/E_F_TRIG_tester.cpp
@@ -18,6 +18,8 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_F_TRIG_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID EI = 0;
+      static constexpr TEventID EO = 0;
 
       E_F_TRIG_TestFixture() : CFBTestFixtureBase("iec61499::events::E_F_TRIG"_STRID) {
         setInputData({&mInQI});
@@ -31,33 +33,33 @@ namespace forte::iec61499::events::test {
 
   BOOST_AUTO_TEST_CASE(RaisingEdge) {
     mInQI = true_BOOL;
-    triggerEvent(0);
+    triggerEvent(EI);
     BOOST_CHECK(eventChainEmpty());
   }
 
   BOOST_AUTO_TEST_CASE(FallingEdge) {
     mInQI = true_BOOL;
-    triggerEvent(0);
+    triggerEvent(EI);
     mInQI = false_BOOL;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(EI);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
   }
 
   BOOST_AUTO_TEST_CASE(StableHigh) {
     mInQI = true_BOOL;
-    triggerEvent(0);
+    triggerEvent(EI);
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent(0);
+      triggerEvent(EI);
       BOOST_CHECK(eventChainEmpty());
     }
   }
 
   BOOST_AUTO_TEST_CASE(StableLow) {
     mInQI = false_BOOL;
-    triggerEvent(0); // Just in case that the QI has been true first handle a potential falling edge
+    triggerEvent(EI); // Just in case that the QI has been true first handle a potential falling edge
     clearEventChain();
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent(0);
+      triggerEvent(EI);
       BOOST_CHECK(eventChainEmpty());
     }
   }

--- a/tests/stdfblib/events/E_PERMIT_tester.cpp
+++ b/tests/stdfblib/events/E_PERMIT_tester.cpp
@@ -18,6 +18,8 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_PERMIT_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID EI = 0;
+      static constexpr TEventID EO = 0;
 
       E_PERMIT_TestFixture() : CFBTestFixtureBase("iec61499::events::E_PERMIT"_STRID) {
         setInputData({&mInPERMIT});
@@ -31,13 +33,13 @@ namespace forte::iec61499::events::test {
 
   BOOST_AUTO_TEST_CASE(permit) {
     mInPERMIT = true_BOOL;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(EI);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
   }
 
   BOOST_AUTO_TEST_CASE(dontPermit) {
     mInPERMIT = false_BOOL;
-    triggerEvent(0);
+    triggerEvent(EI);
     BOOST_CHECK(eventChainEmpty());
   }
 

--- a/tests/stdfblib/events/E_R_TRIG_tester.cpp
+++ b/tests/stdfblib/events/E_R_TRIG_tester.cpp
@@ -18,6 +18,8 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_R_TRIG_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID EI = 0;
+      static constexpr TEventID EO = 0;
 
       E_R_TRIG_TestFixture() : CFBTestFixtureBase("iec61499::events::E_R_TRIG"_STRID) {
         setInputData({&mInQI});
@@ -31,25 +33,25 @@ namespace forte::iec61499::events::test {
 
   BOOST_AUTO_TEST_CASE(RaisingEdge) {
     mInQI = true_BOOL;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(EI);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
   }
 
   BOOST_AUTO_TEST_CASE(FallingEdge) {
     mInQI = true_BOOL;
-    triggerEvent(0);
+    triggerEvent(EI);
     clearEventChain();
     mInQI = false_BOOL;
-    triggerEvent(0);
+    triggerEvent(EI);
     BOOST_CHECK(eventChainEmpty());
   }
 
   BOOST_AUTO_TEST_CASE(StableHigh) {
     mInQI = true_BOOL;
-    triggerEvent(0);
+    triggerEvent(EI);
     pullFirstChainEventID();
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent(0);
+      triggerEvent(EI);
       BOOST_CHECK(eventChainEmpty());
     }
   }
@@ -57,7 +59,7 @@ namespace forte::iec61499::events::test {
   BOOST_AUTO_TEST_CASE(StableLow) {
     mInQI = false_BOOL;
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent(0);
+      triggerEvent(EI);
       BOOST_CHECK(eventChainEmpty());
     }
   }

--- a/tests/stdfblib/events/E_SELECT_tester.cpp
+++ b/tests/stdfblib/events/E_SELECT_tester.cpp
@@ -19,6 +19,9 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_SELECT_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID EI0 = 0;
+      static constexpr TEventID EI1 = 1;
+      static constexpr TEventID EO = 0;
 
       E_SELECT_TestFixture() : CFBTestFixtureBase("iec61499::events::E_SELECT"_STRID) {
         setInputData({&mInG});
@@ -32,30 +35,30 @@ namespace forte::iec61499::events::test {
 
   BOOST_AUTO_TEST_CASE(SelectEI0) {
     mInG = false_BOOL;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
-    triggerEvent(1);
+    triggerEvent(EI0);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    triggerEvent(EI1);
     BOOST_CHECK(eventChainEmpty());
   }
 
   BOOST_AUTO_TEST_CASE(SelectEI1) {
     mInG = true_BOOL;
-    triggerEvent(1);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
-    triggerEvent(0);
+    triggerEvent(EI1);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    triggerEvent(EI0);
     BOOST_CHECK(eventChainEmpty());
   }
 
   BOOST_AUTO_TEST_CASE(MultipleSelectEI0) {
     mInG = false_BOOL;
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent(0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+      triggerEvent(EI0);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
     }
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent(0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
-      triggerEvent(1);
+      triggerEvent(EI0);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+      triggerEvent(EI1);
       BOOST_CHECK(eventChainEmpty());
     }
   }
@@ -63,13 +66,13 @@ namespace forte::iec61499::events::test {
   BOOST_AUTO_TEST_CASE(MultipleSelectEI1) {
     mInG = true_BOOL;
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent(1);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+      triggerEvent(EI1);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
     }
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent(1);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
-      triggerEvent(0);
+      triggerEvent(EI1);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+      triggerEvent(EI0);
       BOOST_CHECK(eventChainEmpty());
     }
   }
@@ -77,13 +80,13 @@ namespace forte::iec61499::events::test {
   BOOST_AUTO_TEST_CASE(Alternate) {
     for (unsigned int i = 0; i < 1000; ++i) {
       mInG = func_NOT(mInG);
-      triggerEvent((mInG) ? 1 : 0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+      triggerEvent((mInG) ? EI1 : EI0);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
     }
     for (unsigned int i = 0; i < 1000; i++) {
-      triggerEvent((mInG) ? 1 : 0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
-      triggerEvent((mInG) ? 0 : 1);
+      triggerEvent((mInG) ? EI1 : EI0);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+      triggerEvent((mInG) ? EI0 : EI1);
       BOOST_CHECK(eventChainEmpty());
     }
   }

--- a/tests/stdfblib/events/E_SR_tester.cpp
+++ b/tests/stdfblib/events/E_SR_tester.cpp
@@ -18,6 +18,9 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_SR_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID S = 0;
+      static constexpr TEventID R = 1;
+      static constexpr TEventID EO = 0;
 
       E_SR_TestFixture() : CFBTestFixtureBase("iec61499::events::E_SR"_STRID) {
         setOutputData({&mOutQ});
@@ -29,7 +32,7 @@ namespace forte::iec61499::events::test {
       /*\brief Check if the E_SR changed to the given target state
        */
       bool checkStateChange(bool paTargetState) {
-        return checkForSingleOutputEventOccurence(0) && (paTargetState == mOutQ);
+        return checkForSingleOutputEventOccurence(EO) && (paTargetState == mOutQ);
       }
   };
 
@@ -37,25 +40,25 @@ namespace forte::iec61499::events::test {
 
   BOOST_AUTO_TEST_CASE(EventS) {
     // Send event
-    triggerEvent(0);
+    triggerEvent(S);
     BOOST_CHECK(checkStateChange(true));
 
     for (unsigned int i = 0; i < 100; ++i) {
-      triggerEvent(0);
+      triggerEvent(S);
       BOOST_CHECK(eventChainEmpty());
       BOOST_CHECK(mOutQ);
     }
   }
 
   BOOST_AUTO_TEST_CASE(EventR) {
-    triggerEvent(0); // initially SR is reset, requires a set before reset
+    triggerEvent(S); // initially SR is reset, requires a set before reset
     BOOST_CHECK(checkStateChange(true));
-    triggerEvent(1);
+    triggerEvent(R);
     // Test correct order of outgoing events
     BOOST_CHECK(checkStateChange(false));
 
     for (unsigned int i = 0; i < 100; ++i) {
-      triggerEvent(1);
+      triggerEvent(R);
       BOOST_CHECK(eventChainEmpty());
       BOOST_CHECK_EQUAL(false, mOutQ);
     }
@@ -63,9 +66,9 @@ namespace forte::iec61499::events::test {
 
   BOOST_AUTO_TEST_CASE(Toggle) {
     for (unsigned int i = 0; i < 100; ++i) {
-      triggerEvent(0);
+      triggerEvent(S);
       BOOST_CHECK(checkStateChange(true));
-      triggerEvent(1);
+      triggerEvent(R);
       BOOST_CHECK(checkStateChange(false));
     }
   }

--- a/tests/stdfblib/events/E_SWITCH_tester.cpp
+++ b/tests/stdfblib/events/E_SWITCH_tester.cpp
@@ -19,6 +19,9 @@ using namespace forte::literals;
 
 namespace forte::iec61499::events::test {
   struct E_SWITCH_TestFixture : public forte::test::CFBTestFixtureBase {
+      static constexpr TEventID EI = 0;
+      static constexpr TEventID EO0 = 0;
+      static constexpr TEventID EO1 = 1;
 
       E_SWITCH_TestFixture() : CFBTestFixtureBase("iec61499::events::E_SWITCH"_STRID) {
         setInputData({&mInG});
@@ -32,37 +35,37 @@ namespace forte::iec61499::events::test {
 
   BOOST_AUTO_TEST_CASE(singleE0) {
     mInG = false_BOOL;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+    triggerEvent(EI);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO0));
   }
 
   BOOST_AUTO_TEST_CASE(SingleE1) {
     mInG = true_BOOL;
-    triggerEvent(0);
-    BOOST_CHECK(checkForSingleOutputEventOccurence(1));
+    triggerEvent(EI);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO1));
   }
 
   BOOST_AUTO_TEST_CASE(MultipleE0) {
     mInG = false_BOOL;
     for (unsigned int i = 0; i < 1000; ++i) {
-      triggerEvent(0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(0));
+      triggerEvent(EI);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(EO0));
     }
   }
 
   BOOST_AUTO_TEST_CASE(MultipleE1) {
     mInG = true_BOOL;
     for (unsigned int i = 0; i < 1000; ++i) {
-      triggerEvent(0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence(1));
+      triggerEvent(EI);
+      BOOST_CHECK(checkForSingleOutputEventOccurence(EO1));
     }
   }
 
   BOOST_AUTO_TEST_CASE(Alternate) {
     for (unsigned int i = 0; i < 1000; ++i) {
       mInG = func_NOT(mInG);
-      triggerEvent(0);
-      BOOST_CHECK(checkForSingleOutputEventOccurence((mInG) ? 1 : 0));
+      triggerEvent(EI);
+      BOOST_CHECK(checkForSingleOutputEventOccurence((mInG) ? EO1 : EO0));
     }
   }
 


### PR DESCRIPTION
Refactored 16 test files to replace direct integer literals (magic
numbers) in triggerEvent() and checkForSingleOutputEventOccurence()
calls with descriptive static constexpr constants:

- Event tests: E_SWITCH, E_SELECT, E_SR, E_R_TRIG, E_PERMIT,
  E_F_TRIG, E_CTU, E_CTD, E_CTUD, E_DELAY, E_DEMUX
- CFB tests: CFB_TEST, CFB_DELEGATING_TEST
- Module tests: GET_STRUCT_VALUE, GEN_STRUCT_MUX, GEN_STRUCT_DEMUX

This follows the pattern established in GEN_E_REND_4_tester.cpp
and improves code readability and maintainability.
