### PR TITLE
add forte::arch::format

### DIFF
--- a/core/arch/CMakeLists.txt
+++ b/core/arch/CMakeLists.txt
@@ -26,6 +26,13 @@ target_compile_options(forte-core PUBLIC
         $<$<COMPILE_LANGUAGE:CXX>:$<$<BOOL:${HAVE_EXCEPTIONS_FLAG}>:$<IF:$<BOOL:${FORTE_RTTI_AND_EXCEPTIONS}>,-fexceptions,-fno-exceptions>>>
 )
 
+option(FORTE_CUSTOM_FORMAT "Use custom format implementation" FALSE)
+#mark_as_advanced(FORTE_CUSTOM_FORMAT)
+if(FORTE_CUSTOM_FORMAT)
+  target_compile_definitions(forte-core PUBLIC "FORTE_CUSTOM_FORMAT")
+endif(FORTE_CUSTOM_FORMAT)
+
+
 ###############################################################################
 # Architectures
 

--- a/core/arch/common/include/forte/arch/CMakeLists.txt
+++ b/core/arch/common/include/forte/arch/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(forte-core PUBLIC
         forte_architecture.h
         forte_architecture_time.h
         forte_fileio.h
+        forte_format.h
         forte_printer.h
         forte_specific_architecture.h
         threadbase.h

--- a/core/arch/common/include/forte/arch/forte_format.h
+++ b/core/arch/common/include/forte/arch/forte_format.h
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Insolsoft
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Anton Gusev  - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#pragma once
+
+#ifdef FORTE_CUSTOM_FORMAT
+#include "forte/arch/forte_architecture_format.h"
+#else
+
+#include <format>
+
+namespace forte::arch {
+  template<typename... Args>
+  std::string format(const std::format_string<Args...> fmt, Args &&...args) {
+    return std::format(fmt, std::forward<Args>(args)...);
+  }
+
+  template<typename It, typename... Args>
+  void format_to(It it, const std::format_string<Args...> fmt, Args &&...args) {
+    std::format_to(it, fmt, std::forward<Args>(args)...);
+  }
+} // namespace forte::arch
+
+#endif

--- a/core/include/forte/datatypes/forte_any_date.h
+++ b/core/include/forte/datatypes/forte_any_date.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "forte/datatypes/forte_any_elementary.h"
+#include "forte/arch/forte_architecture_time.h"
 
 namespace forte {
   /*!\ingroup COREDTS IIEC_ANY_DATE represents any date data types according to IEC 61131.

--- a/core/src/datatypes/forte_any_date.cpp
+++ b/core/src/datatypes/forte_any_date.cpp
@@ -14,8 +14,6 @@
 #include <stdlib.h>
 #include "forte/datatypes/forte_any_date.h"
 
-#include "forte/arch/forte_architecture_time.h"
-
 namespace forte {
   TForteInt32 CIEC_ANY_DATE::smTimeZoneOffset = -1;
 

--- a/core/src/datatypes/forte_any_duration.cpp
+++ b/core/src/datatypes/forte_any_duration.cpp
@@ -12,7 +12,7 @@
  *      - initial implementation and rework communication infrastructure
  *******************************************************************************/
 #include "forte/datatypes/forte_any_duration.h"
-#include <format>
+#include "forte/arch/forte_format.h"
 
 namespace forte {
   // change time elements to string
@@ -21,7 +21,7 @@ namespace forte {
                                                int64_t paTimeElement,
                                                const std::string &paUnit) const {
     if (paTimeElement != 0) {
-      std::format_to(std::back_inserter(paTargetBuf), "{}", paTimeElement);
+      forte::arch::format_to(std::back_inserter(paTargetBuf), "{}", paTimeElement);
       paTargetBuf += paUnit;
     }
   }

--- a/core/src/datatypes/forte_date.cpp
+++ b/core/src/datatypes/forte_date.cpp
@@ -18,7 +18,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_date.h"
-#include <format>
+#include "forte/arch/forte_format.h"
 
 using namespace forte::literals;
 
@@ -72,8 +72,8 @@ namespace forte {
   void CIEC_DATE::toString(std::string &paTargetBuf) const {
     tm ptm;
     if (nullptr != getTimeStruct(&ptm)) {
-      std::format_to(std::back_inserter(paTargetBuf), "D#{:04}-{:02}-{:02}", 1900 + ptm.tm_year, ptm.tm_mon + 1,
-                     ptm.tm_mday);
+      forte::arch::format_to(std::back_inserter(paTargetBuf), "D#{:04}-{:02}-{:02}", 1900 + ptm.tm_year, ptm.tm_mon + 1,
+                             ptm.tm_mday);
     }
   }
 

--- a/core/src/datatypes/forte_date_and_time.cpp
+++ b/core/src/datatypes/forte_date_and_time.cpp
@@ -13,14 +13,13 @@
  *               - initial implementation and rework communication infrastructure
  *   Alois Zoitl - migrated data type toString to std::string
  *******************************************************************************/
-#include <format>
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_date_and_time.h"
-#include "forte/arch/forte_architecture_time.h"
 #include "forte/util/string_utils.h"
+#include "forte/arch/forte_format.h"
 
 using namespace forte::literals;
 
@@ -110,9 +109,9 @@ namespace forte {
   void CIEC_DATE_AND_TIME::toString(std::string &paTargetBuf) const {
     tm ptm;
     if (nullptr != getTimeStruct(&ptm)) {
-      std::format_to(std::back_inserter(paTargetBuf), "DT#{:04}-{:02}-{:02}-{:02}:{:02}:{:02}.{:03}",
-                     1900 + ptm.tm_year, ptm.tm_mon + 1, ptm.tm_mday, ptm.tm_hour, ptm.tm_min, ptm.tm_sec,
-                     getMilliSeconds());
+      forte::arch::format_to(std::back_inserter(paTargetBuf), "DT#{:04}-{:02}-{:02}-{:02}:{:02}:{:02}.{:03}",
+                             1900 + ptm.tm_year, ptm.tm_mon + 1, ptm.tm_mday, ptm.tm_hour, ptm.tm_min, ptm.tm_sec,
+                             getMilliSeconds());
     }
   }
 

--- a/core/src/datatypes/forte_ldate.cpp
+++ b/core/src/datatypes/forte_ldate.cpp
@@ -13,13 +13,12 @@
  *                - initial implementation and rework communication infrastructure
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
-#include <format>
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_ldate.h"
-#include "forte/arch/forte_architecture_time.h"
+#include "forte/arch/forte_format.h"
 
 using namespace forte::literals;
 
@@ -73,8 +72,8 @@ namespace forte {
   void CIEC_LDATE::toString(std::string &paTargetBuf) const {
     tm ptm;
     if (nullptr != getTimeStruct(&ptm)) {
-      std::format_to(std::back_inserter(paTargetBuf), "LD#{:04}-{:02}-{:02}", 1900 + ptm.tm_year, ptm.tm_mon + 1,
-                     ptm.tm_mday);
+      forte::arch::format_to(std::back_inserter(paTargetBuf), "LD#{:04}-{:02}-{:02}", 1900 + ptm.tm_year,
+                             ptm.tm_mon + 1, ptm.tm_mday);
     }
   }
 

--- a/core/src/datatypes/forte_ldate_and_time.cpp
+++ b/core/src/datatypes/forte_ldate_and_time.cpp
@@ -13,14 +13,13 @@
  *                - initial implementation and rework communication infrastructure
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
-#include <format>
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_ldate_and_time.h"
-#include "forte/arch/forte_architecture_time.h"
 #include "forte/util/string_utils.h"
+#include "forte/arch/forte_format.h"
 
 using namespace forte::literals;
 
@@ -110,9 +109,9 @@ namespace forte {
   void CIEC_LDATE_AND_TIME::toString(std::string &paTargetBuf) const {
     tm ptm;
     if (nullptr != getTimeStruct(&ptm)) {
-      std::format_to(std::back_inserter(paTargetBuf), "LDT#{:04}-{:02}-{:02}-{:02}:{:02}:{:02}.{:03}",
-                     1900 + ptm.tm_year, ptm.tm_mon + 1, ptm.tm_mday, ptm.tm_hour, ptm.tm_min, ptm.tm_sec,
-                     getMilliSeconds());
+      forte::arch::format_to(std::back_inserter(paTargetBuf), "LDT#{:04}-{:02}-{:02}-{:02}:{:02}:{:02}.{:03}",
+                             1900 + ptm.tm_year, ptm.tm_mon + 1, ptm.tm_mday, ptm.tm_hour, ptm.tm_min, ptm.tm_sec,
+                             getMilliSeconds());
     }
   }
 

--- a/core/src/datatypes/forte_lreal.cpp
+++ b/core/src/datatypes/forte_lreal.cpp
@@ -15,7 +15,6 @@
  *   Alois Zoitl - migrated data type toString to std::string
  *******************************************************************************/
 #include <cmath>
-#include <format>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -25,6 +24,7 @@
 #include "forte/datatypes/forte_ulint.h"
 #include "forte/datatypes/forte_string.h"
 #include "forte/datatypes/forte_wstring.h"
+#include "forte/arch/forte_format.h"
 
 using namespace forte::literals;
 
@@ -52,8 +52,8 @@ namespace forte {
 
   void CIEC_LREAL::toString(std::string &paTargetBuf) const {
     auto startPos = paTargetBuf.size();
-    std::format_to(std::back_inserter(paTargetBuf), "{:.{}g}", getTDFLOAT(),
-                   std::numeric_limits<TValueType>::max_digits10);
+    forte::arch::format_to(std::back_inserter(paTargetBuf), "{:.{}g}", getTDFLOAT(),
+                           std::numeric_limits<TValueType>::max_digits10);
     normalizeToStringRepresentation(paTargetBuf, startPos);
   }
 

--- a/core/src/datatypes/forte_ltime_of_day.cpp
+++ b/core/src/datatypes/forte_ltime_of_day.cpp
@@ -13,13 +13,13 @@
  *                - initial implementation and rework communication infrastructure
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
-#include <format>
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_ltime_of_day.h"
 #include "forte/util/string_utils.h"
+#include "forte/arch/forte_format.h"
 
 using namespace forte::literals;
 
@@ -96,9 +96,9 @@ namespace forte {
     TForteUInt64 ntoStingBuffer = getTUINT64();
     time_t t = static_cast<time_t>(ntoStingBuffer / (1000ULL * 1000000ULL));
 
-    std::format_to(std::back_inserter(paTargetBuf), "LTOD#{:02}:{:02}:{:02}.{:03}", static_cast<int>(t / 3600),
-                   static_cast<int>((t % 3600) / 60), static_cast<int>(t % 60),
-                   (int) ((ntoStingBuffer / 1000000) % 1000));
+    forte::arch::format_to(std::back_inserter(paTargetBuf), "LTOD#{:02}:{:02}:{:02}.{:03}", static_cast<int>(t / 3600),
+                           static_cast<int>((t % 3600) / 60), static_cast<int>(t % 60),
+                           (int) ((ntoStingBuffer / 1000000) % 1000));
   }
 
   const StringId CDataTypeTrait<CIEC_LTIME_OF_DAY>::scmDataTypeName = "LTIME_OF_DAY"_STRID;

--- a/core/src/datatypes/forte_real.cpp
+++ b/core/src/datatypes/forte_real.cpp
@@ -19,13 +19,13 @@
 #include <cstring>
 #include <cstdlib>
 #include <cstdio>
-#include <format>
 #include "forte/datatypes/forte_real.h"
 #include "forte/datatypes/forte_lreal.h"
 #include "forte/datatypes/forte_lint.h"
 #include "forte/datatypes/forte_ulint.h"
 #include "forte/datatypes/forte_string.h"
 #include "forte/datatypes/forte_wstring.h"
+#include "forte/arch/forte_format.h"
 
 using namespace forte::literals;
 
@@ -54,8 +54,8 @@ namespace forte {
 
   void CIEC_REAL::toString(std::string &paTargetBuf) const {
     auto startPos = paTargetBuf.size();
-    std::format_to(std::back_inserter(paTargetBuf), "{:.{}g}", getTFLOAT(),
-                   std::numeric_limits<TValueType>::max_digits10);
+    forte::arch::format_to(std::back_inserter(paTargetBuf), "{:.{}g}", getTFLOAT(),
+                           std::numeric_limits<TValueType>::max_digits10);
 
     normalizeToStringRepresentation(paTargetBuf, startPos);
   }

--- a/core/src/datatypes/forte_time_of_day.cpp
+++ b/core/src/datatypes/forte_time_of_day.cpp
@@ -13,14 +13,13 @@
  *      - initial implementation and rework communication infrastructure
  *   Alois Zoitl  - migrated data type toString to std::string
  *******************************************************************************/
-#include <format>
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #include <ctype.h>
 #include "forte/datatypes/forte_time_of_day.h"
-#include "forte/arch/forte_architecture_time.h"
 #include "forte/util/string_utils.h"
+#include "forte/arch/forte_format.h"
 
 using namespace forte::literals;
 
@@ -97,9 +96,9 @@ namespace forte {
     TForteUInt64 ntoStingBuffer = getTUINT64();
     time_t t = static_cast<time_t>(ntoStingBuffer / 1000000000);
 
-    std::format_to(std::back_inserter(paTargetBuf), "TOD#{:02}:{:02}:{:02}.{:03}", (int) (t / 3600),
-                   static_cast<int>((t % 3600) / 60), static_cast<int>(t % 60),
-                   static_cast<int>((ntoStingBuffer / 1000000) % 1000));
+    forte::arch::format_to(std::back_inserter(paTargetBuf), "TOD#{:02}:{:02}:{:02}.{:03}", (int) (t / 3600),
+                           static_cast<int>((t % 3600) / 60), static_cast<int>(t % 60),
+                           static_cast<int>((ntoStingBuffer / 1000000) % 1000));
   }
 
   const StringId CDataTypeTrait<CIEC_TIME_OF_DAY>::scmDataTypeName = "TIME_OF_DAY"_STRID;

--- a/core/src/monitoring.cpp
+++ b/core/src/monitoring.cpp
@@ -22,7 +22,7 @@
 #include "resource_internal.h"
 #include "forte/ecet.h"
 #include "forte/util/string_utils.h"
-#include <format>
+#include "forte/arch/forte_format.h"
 
 using namespace std::string_literals;
 
@@ -126,7 +126,7 @@ namespace forte {
         appendPortTag(paResponse, paEventWatchEntry.getPortId());
 
         paResponse += "<Data value=\""s;
-        std::format_to(std::back_inserter(paResponse), "{}", paEventWatchEntry.mEventDataBuf);
+        forte::arch::format_to(std::back_inserter(paResponse), "{}", paEventWatchEntry.mEventDataBuf);
         paResponse += "\"/>\n</Port>"s;
       }
 


### PR DESCRIPTION
replace all `std::format_to` calls to `forte::arch::format_to`

depending on FORTE_CUSTOM_FORMAT flag redirect these calls to std::format or to custom format implementation provided by arch.