### PR TITLE
add ATAN2 as it is defined so in IEC 61131-3

### DIFF
--- a/modules/IEC61131-3/include/forte/iec61131/numerical/CMakeLists.txt
+++ b/modules/IEC61131-3/include/forte/iec61131/numerical/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(forte-iec61131-3 PUBLIC
         F_ABS_fbt.h
         F_ACOS_fbt.h
         F_ASIN_fbt.h
+        F_ATAN2_fbt.h
         F_ATAN_fbt.h
         F_COS_fbt.h
         F_EXP_fbt.h

--- a/modules/IEC61131-3/include/forte/iec61131/numerical/F_ATAN2_fbt.h
+++ b/modules/IEC61131-3/include/forte/iec61131/numerical/F_ATAN2_fbt.h
@@ -1,0 +1,83 @@
+/*************************************************************************
+ *** Copyright (c) 2013 ACIN, fortiss GmbH, Martin Erich Jobst, HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: F_ATAN2
+ *** Description: principal arc tan of Y/X
+ *** Version:
+ ***     1.0: 2026-02-01/Franz Höpfinger - HR Agrartechnik GmbH - copy from F_ATAN an make initial Version
+ *************************************************************************/
+
+#pragma once
+
+#include "forte/simplefb.h"
+#include "forte/datatypes/forte_any_real_variant.h"
+#include "forte/forte_st_util.h"
+
+namespace forte::iec61131::numerical {
+  class FORTE_F_ATAN2 final : public CSimpleFB {
+      DECLARE_FIRMWARE_FB(FORTE_F_ATAN2)
+
+    private:
+      static const TEventID scmEventCNFID = 0;
+      static const TEventID scmEventREQID = 0;
+
+      CIEC_ANY *getVarInternal(size_t) override;
+
+      void alg_REQ(void);
+
+      void enterStateREQ(CEventChainExecutionThread *const paECET);
+
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    public:
+      FORTE_F_ATAN2(StringId paInstanceNameId, CFBContainer &paContainer);
+
+      CIEC_ANY_REAL_VARIANT var_Y;
+      CIEC_ANY_REAL_VARIANT var_X;
+
+      CIEC_ANY_REAL_VARIANT var_OUT;
+
+      CEventConnection conn_CNF;
+
+      CDataConnection *conn_Y;
+      CDataConnection *conn_X;
+
+      COutDataConnection<CIEC_ANY_REAL_VARIANT> conn_OUT;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+
+      void evt_REQ(const CIEC_ANY_REAL_VARIANT &paY,
+                   const CIEC_ANY_REAL_VARIANT &paX,
+                   COutputParameter<CIEC_ANY_REAL_VARIANT> paOUT) {
+        COutputGuard guard_OUT(paOUT);
+        var_Y = paY;
+        var_X = paX;
+        executeEvent(scmEventREQID, nullptr);
+        paOUT->setValue(var_OUT.unwrap());
+      }
+
+      void operator()(const CIEC_ANY_REAL_VARIANT &paY,
+                      const CIEC_ANY_REAL_VARIANT &paX,
+                      COutputParameter<CIEC_ANY_REAL_VARIANT> paOUT) {
+        evt_REQ(std::forward<const CIEC_ANY_REAL_VARIANT &>(paY), std::forward<const CIEC_ANY_REAL_VARIANT &>(paX),
+                std::forward<COutputParameter<CIEC_ANY_REAL_VARIANT>>(paOUT));
+      }
+  };
+} // namespace forte::iec61131::numerical

--- a/modules/IEC61131-3/src/iec61131/numerical/CMakeLists.txt
+++ b/modules/IEC61131-3/src/iec61131/numerical/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(forte-iec61131-3 PRIVATE
         F_ABS_fbt.cpp
         F_ACOS_fbt.cpp
         F_ASIN_fbt.cpp
+        F_ATAN2_fbt.cpp
         F_ATAN_fbt.cpp
         F_COS_fbt.cpp
         F_EXP_fbt.cpp

--- a/modules/IEC61131-3/src/iec61131/numerical/F_ATAN2_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/numerical/F_ATAN2_fbt.cpp
@@ -1,0 +1,150 @@
+/*************************************************************************
+ *** Copyright (c) 2013 ACIN, fortiss GmbH, Martin Erich Jobst, HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: F_ATAN2
+ *** Description: principal arc tan of Y/X
+ *** Version:
+ ***     1.0: 2026-02-01/Franz Höpfinger - HR Agrartechnik GmbH - copy from F_ATAN an make initial Version
+ *************************************************************************/
+
+#include "forte/iec61131/numerical/F_ATAN2_fbt.h"
+
+#include "forte/datatypes/forte_any_real_variant.h"
+#include "forte/forte_st_util.h"
+#include "forte/iec61131_functions/func_ATAN2.h"
+
+using namespace std::literals;
+using namespace forte::literals;
+
+namespace forte::iec61131::numerical {
+  namespace {
+
+    const auto cEventInputNames = std::array{"REQ"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
+    const auto cDataInputNames = std::array{"Y"_STRID, "X"_STRID};
+    const auto cDataOutputNames = std::array{"OUT"_STRID};
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = {},
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = {},
+        .mDINames = cDataInputNames,
+        .mDONames = cDataOutputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+  } // namespace
+
+  DEFINE_FIRMWARE_FB(FORTE_F_ATAN2, "iec61131::numerical::F_ATAN2"_STRID)
+
+  FORTE_F_ATAN2::FORTE_F_ATAN2(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CSimpleFB(paContainer, cFBInterfaceSpec, paInstanceNameId, {}),
+      var_Y(CIEC_ANY_REAL_VARIANT()),
+      var_X(CIEC_ANY_REAL_VARIANT()),
+      var_OUT(CIEC_ANY_REAL_VARIANT()),
+      conn_CNF(*this, 0),
+      conn_Y(nullptr),
+      conn_X(nullptr),
+      conn_OUT(*this, 0, var_OUT) {
+  }
+
+  void FORTE_F_ATAN2::setInitialValues() {
+    CSimpleFB::setInitialValues();
+    var_Y = CIEC_ANY_REAL_VARIANT();
+    var_X = CIEC_ANY_REAL_VARIANT();
+    var_OUT = CIEC_ANY_REAL_VARIANT();
+  }
+
+  void FORTE_F_ATAN2::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    switch (paEIID) {
+      case scmEventREQID: enterStateREQ(paECET); break;
+      default: break;
+    }
+  }
+
+  void FORTE_F_ATAN2::enterStateREQ(CEventChainExecutionThread *const paECET) {
+    alg_REQ();
+    sendOutputEvent(scmEventCNFID, paECET);
+  }
+
+  void FORTE_F_ATAN2::readInputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventREQID: {
+        readData(0, var_Y, conn_Y);
+        readData(1, var_X, conn_X);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  void FORTE_F_ATAN2::writeOutputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventCNFID: {
+        writeData(2, var_OUT, conn_OUT);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_F_ATAN2::getDI(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_Y;
+      case 1: return &var_X;
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_F_ATAN2::getDO(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_OUT;
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_F_ATAN2::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_CNF;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_F_ATAN2::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_Y;
+      case 1: return &conn_X;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_F_ATAN2::getDOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_OUT;
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_F_ATAN2::getVarInternal(size_t) {
+    return nullptr;
+  }
+
+  void FORTE_F_ATAN2::alg_REQ(void) {
+
+#line 2 "F_ATAN2.fbt"
+    var_OUT = std::visit(
+        [](auto &&x, auto &&y) -> CIEC_ANY_REAL_VARIANT { return CIEC_ANY_REAL_VARIANT(func_ATAN2(y, x)); },
+        static_cast<CIEC_ANY_REAL_VARIANT::variant &>(var_X), static_cast<CIEC_ANY_REAL_VARIANT::variant &>(var_Y));
+  }
+
+} // namespace forte::iec61131::numerical


### PR DESCRIPTION
https://github.com/eclipse-4diac/4diac-ide/pull/2080

Correct F_ATAN2 input type handling and argument order

Implement std::visit to properly handle CIEC_ANY_REAL_VARIANT types for inputs X and Y, allowing the function block to work with various real number types.
Additionally, correct the argument order for func_ATAN2 to match the standard atan2(y, x) signature, where y is the first argument and x is the second.
