### PR TITLE
Fix potential deadlock in CEventChainExecutionThread destructor

### DIFF
--- a/core/src/ecet.cpp
+++ b/core/src/ecet.cpp
@@ -30,7 +30,16 @@ namespace forte {
     clear();
   }
 
-  CEventChainExecutionThread::~CEventChainExecutionThread() = default;
+  CEventChainExecutionThread::~CEventChainExecutionThread() {
+    /* Call end() while the vtable is still CEventChainExecutionThread's, so that
+     * onAliveChanged() dispatches to our resumeSelfSuspend() and wakes the thread
+     * from selfSuspend(). Without this, ~CThreadBase() would call end() with the
+     * base-class vtable, onAliveChanged() would be a no-op, and join() would block
+     * forever. This applies to all platforms, not just FreeRTOS.
+     * The subsequent end() call in ~CThreadBase() is a safe no-op because
+     * mThreadHandle is null after the first end() completes. */
+    end();
+  }
 
   void CEventChainExecutionThread::run() {
     while (isAlive()) { // thread is allowed to execute


### PR DESCRIPTION
Call end() explicitly in the destructor while the vtable is still
CEventChainExecutionThread's, ensuring onAliveChanged() dispatches to
resumeSelfSuspend() and wakes the thread from selfSuspend(). Without
this, ~CThreadBase() calls end() with the base-class vtable, making
onAliveChanged() a no-op and causing join() to block forever.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
