### PR TITLE
fix: CGatheringDataConnection::disconnect does not null destination DI slot

### DIFF
--- a/core/src/gatherdataconn.cpp
+++ b/core/src/gatherdataconn.cpp
@@ -48,6 +48,7 @@ namespace forte::internal {
       }
     }
     mGatheringData.clear();
+    paDstFB.connectDI(dstPortId, nullptr); // clear stale DI slot
 
     return EMGMResponse::Ready;
   }


### PR DESCRIPTION
When a DeleteConnection command targets a gathering connection using a port-only path, CGatheringDataConnection::disconnect returns without clearing the destination FB data input slot. 
The caller in CResource::deleteConnection then frees the object, leaving the slot with a stale pointer.


Root cause: 
connectDI(port, nullptr) was never called in CGatheringDataConnection::disconnect, unlike CDataConnection::disconnect which upholds this correctly.


Fix: 
Call connectDI(dstPortId, nullptr) before returning, consistent with how other connection types handle cleanup.

```
EMGMResponse CGatheringDataConnection::disconnect(CFunctionBlock &paDstFB,
                                                   std::span<const StringId> paDstPortNameId) {
  for (const auto [member, connection, memberName] : mGatheringData) {
    connection->disconnect(paDstFB, memberName);
    if (connection->isDelegating()) {
      delete connection;
    }
  }
  mGatheringData.clear();

  const TPortId dstPortId =
      paDstFB.getFBInterfaceSpec().getDIID(paDstPortNameId.front());
  paDstFB.connectDI(dstPortId, nullptr);

  return EMGMResponse::Ready;
}
```