### PR TITLE
fix: CGatheringDataConnection::disconnect does not null destination DI slot

### DIFF
--- a/core/src/gatherdataconn.cpp
+++ b/core/src/gatherdataconn.cpp
@@ -49,6 +49,8 @@ namespace forte::internal {
     }
     mGatheringData.clear();
 
+    paDstFB.connectDI(dstPortId, nullptr);
+
     return EMGMResponse::Ready;
   }
 


### PR DESCRIPTION
When a DeleteConnection command targets a gathering connection using a
port-only path, CGatheringDataConnection::disconnect returned without
clearing the destination FB data input slot. The caller in
CResource::deleteConnection then freed the object, leaving the slot
with a stale pointer.

Fix: Call connectDI(dstPortId, nullptr) before returning, consistent
with how CDataConnection::disconnect handles cleanup.