### PR TITLE
Display the actual port being used in BSD and Win32 Socket Interface

### DIFF
--- a/core/arch/common/include/forte/arch/bsdsocketinterf.h
+++ b/core/arch/common/include/forte/arch/bsdsocketinterf.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 ACIN, fortiss GmbH, OFFIS e.V.
+ * Copyright (c) 2010 ACIN, fortiss GmbH, OFFIS e.V.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/core/arch/common/src/bsdsocketinterf.cpp
+++ b/core/arch/common/src/bsdsocketinterf.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2026 ACIN, Profactor GmbH, AIT, fortiss GmbH, OFFIS e.V.
+ * Copyright (c) 2010 ACIN, Profactor GmbH, AIT, fortiss GmbH, OFFIS e.V.
  *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
@@ -50,34 +50,35 @@ namespace forte::arch {
     (void) paIPAddr; // Needed to avoid compiler warning at log levels where DEVLOG_INFO is empty
     DEVLOG_INFO("CBSDSocketInterface: Opening TCP-Server connection at: %s:%d\n", paIPAddr, paPort);
 
-    if (TSocketDescriptor nSocket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP); nSocket != -1) {
-      struct sockaddr_in stSockAddr = {0};
-      stSockAddr.sin_family = AF_INET;
-#if VXWORKS
-      stSockAddr.sin_port = static_cast<unsigned short>(htons(paPort));
-#else
-      stSockAddr.sin_port = htons(paPort);
-#endif
-      stSockAddr.sin_addr.s_addr = htonl(INADDR_ANY);
-
-      if (bind(nSocket, (struct sockaddr *) &stSockAddr, sizeof(struct sockaddr)) == 0) {
-        if (listen(nSocket, 1) == -1) { // for the classic IEC 61499 server only one connection at the same time is
-          // accepted TODO mayb make this adjustable for future extensions
-          DEVLOG_ERROR("CBSDSocketInterface: listen() failed: %s\n", strerror(errno));
-        } else {
-          nRetVal = nSocket;
-        }
-        if (paPort == 0) {
-          displayActualPort(nSocket);
-        }
-      } else {
-        DEVLOG_ERROR("CBSDSocketInterface: bind() failed: %s\n", strerror(errno));
-      }
-      if (nRetVal == -1) {
-        close(nSocket);
-      }
-    } else {
+    TSocketDescriptor nSocket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (nSocket == -1) {
       DEVLOG_ERROR("CBSDSocketInterface: Couldn't create socket: %s\n", strerror(errno));
+      return nRetVal;
+    }
+    struct sockaddr_in stSockAddr = {0};
+    stSockAddr.sin_family = AF_INET;
+#if VXWORKS
+    stSockAddr.sin_port = static_cast<unsigned short>(htons(paPort));
+#else
+    stSockAddr.sin_port = htons(paPort);
+#endif
+    stSockAddr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    if (bind(nSocket, (struct sockaddr *) &stSockAddr, sizeof(struct sockaddr)) != 0) {
+      DEVLOG_ERROR("CBSDSocketInterface: bind() failed: %s\n", strerror(errno));
+      close(nSocket);
+      return nRetVal;
+    }
+    if (listen(nSocket, 1) == -1) { // for the classic IEC 61499 server only one connection at the same time is
+      // accepted TODO mayb make this adjustable for future extensions
+      DEVLOG_ERROR("CBSDSocketInterface: listen() failed: %s\n", strerror(errno));
+      close(nSocket);
+      return nRetVal;
+    }
+
+    nRetVal = nSocket;
+    if (paPort == 0) {
+      displayActualPort(nSocket);
     }
     return nRetVal;
   }

--- a/core/arch/common/src/bsdsocketinterf.cpp
+++ b/core/arch/common/src/bsdsocketinterf.cpp
@@ -47,11 +47,8 @@ namespace forte::arch {
                                                                                       unsigned short paPort) {
     TSocketDescriptor nRetVal = -1;
 
-#ifndef FORTE_LOGINFO
-    (void) paIPAddr;
-#else
+    (void) paIPAddr; // Needed to avoid compiler warning at log levels where DEVLOG_INFO is empty
     DEVLOG_INFO("CBSDSocketInterface: Opening TCP-Server connection at: %s:%d\n", paIPAddr, paPort);
-#endif
 
     if (TSocketDescriptor nSocket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP); nSocket != -1) {
       struct sockaddr_in stSockAddr = {0};

--- a/core/arch/common/src/bsdsocketinterf.cpp
+++ b/core/arch/common/src/bsdsocketinterf.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2010 ACIN, Profactor GmbH, AIT, fortiss GmbH, OFFIS e.V.
+ * Copyright (c) 2010, 2026 ACIN, Profactor GmbH, AIT, fortiss GmbH, OFFIS e.V.
+ *                          Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +13,8 @@
  *     - initial API and implementation and/or initial documentation
  *   Jörg Walter
  *     - improve multicast support
+ *   Markus Meingast
+ *     - add logging of actual tcp port being used
  *******************************************************************************/
 #include "forte/arch/sockhand.h" //needs to be first pulls in the platform specific includes
 #include "forte/arch/bsdsocketinterf.h"
@@ -19,6 +22,19 @@
 #include <string.h>
 
 namespace forte::arch {
+  namespace {
+    void displayActualPort(CBSDSocketInterface::TSocketDescriptor paSocket) {
+      struct sockaddr_in stSockAddr = {0};
+      socklen_t addressLen = sizeof(stSockAddr);
+      if (getsockname(paSocket, (struct sockaddr *) &stSockAddr, &addressLen) == 0) {
+        unsigned short assignedPort = ntohs(stSockAddr.sin_port);
+        DEVLOG_INFO("CBSDSocketInterface: Socket is listening on port: %d\n", assignedPort);
+      } else {
+        DEVLOG_ERROR("CBSDSocketInterface: getsockname() failed: %s\n", strerror(errno));
+      }
+    }
+  } // namespace
+
   void CBSDSocketInterface::closeSocket(TSocketDescriptor paSockD) {
 #if defined(NET_OS)
     closesocket(paSockD);
@@ -37,9 +53,8 @@ namespace forte::arch {
     DEVLOG_INFO("CBSDSocketInterface: Opening TCP-Server connection at: %s:%d\n", paIPAddr, paPort);
 #endif
 
-    if (TSocketDescriptor nSocket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP); -1 != nSocket) {
-      struct sockaddr_in stSockAddr;
-      memset(&(stSockAddr), '\0', sizeof(sockaddr_in));
+    if (TSocketDescriptor nSocket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP); nSocket != -1) {
+      struct sockaddr_in stSockAddr = {0};
       stSockAddr.sin_family = AF_INET;
 #if VXWORKS
       stSockAddr.sin_port = static_cast<unsigned short>(htons(paPort));
@@ -48,17 +63,20 @@ namespace forte::arch {
 #endif
       stSockAddr.sin_addr.s_addr = htonl(INADDR_ANY);
 
-      if (0 == bind(nSocket, (struct sockaddr *) &stSockAddr, sizeof(struct sockaddr))) {
-        if (-1 == listen(nSocket, 1)) { // for the classic IEC 61499 server only one connection at the same time is
+      if (bind(nSocket, (struct sockaddr *) &stSockAddr, sizeof(struct sockaddr)) == 0) {
+        if (listen(nSocket, 1) == -1) { // for the classic IEC 61499 server only one connection at the same time is
           // accepted TODO mayb make this adjustable for future extensions
           DEVLOG_ERROR("CBSDSocketInterface: listen() failed: %s\n", strerror(errno));
         } else {
           nRetVal = nSocket;
         }
+        if (paPort == 0) {
+          displayActualPort(nSocket);
+        }
       } else {
         DEVLOG_ERROR("CBSDSocketInterface: bind() failed: %s\n", strerror(errno));
       }
-      if (-1 == nRetVal) {
+      if (nRetVal == -1) {
         close(nSocket);
       }
     } else {

--- a/core/arch/win32/include/forte/arch/win32socketinterf.h
+++ b/core/arch/win32/include/forte/arch/win32socketinterf.h
@@ -38,7 +38,5 @@ namespace forte::arch {
 
     private:
       CWin32SocketInterface(); // this function is not implemented as we don't want instances of this class
-
-      static LPSTR getErrorMessage(int paErrorNumber);
   };
 } // namespace forte::arch

--- a/core/arch/win32/include/forte/arch/win32socketinterf.h
+++ b/core/arch/win32/include/forte/arch/win32socketinterf.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 ACIN, fortiss GmbH, OFFIS e.V.
+ * Copyright (c) 2010 ACIN, fortiss GmbH, OFFIS e.V.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/core/arch/win32/src/win32socketinterf.cpp
+++ b/core/arch/win32/src/win32socketinterf.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2026 ACIN, Profactor GmbH, AIT, fortiss GmbH, OFFIS e.V., HIT robot group
+ * Copyright (c) 2010 ACIN, Profactor GmbH, AIT, fortiss GmbH, OFFIS e.V., HIT robot group
  *               Samator Indo Gas, Primetals Technologies Austria GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,45 +58,46 @@ namespace forte::arch {
     DEVLOG_INFO("CWin32SocketInterface: Opening TCP-Server connection at: %s:%d\n", paIPAddr, paPort);
 
     TSocketDescriptor nSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-
-    if (INVALID_SOCKET != nSocket) {
-      struct sockaddr_in stSockAddr = {0};
-      stSockAddr.sin_family = AF_INET;
-      stSockAddr.sin_port = htons(paPort);
-      stSockAddr.sin_addr.s_addr = htonl(INADDR_ANY);
-
-      int nOptVal = 1;
-      if (SOCKET_ERROR == setsockopt(nSocket, SOL_SOCKET, SO_REUSEADDR, (char *) &nOptVal, sizeof(nOptVal))) {
-        LPSTR pacErrorMessage = getErrorMessage(WSAGetLastError());
-        DEVLOG_ERROR("CWin32SocketInterface: could not set socket option SO_REUSEADDR:  %s\n", pacErrorMessage);
-        LocalFree(pacErrorMessage);
-      }
-
-      if (0 == bind(nSocket, (struct sockaddr *) &stSockAddr, sizeof(struct sockaddr))) {
-        if (SOCKET_ERROR ==
-            listen(nSocket, 1)) { // for the classic IEC 61499 server only one connection at the same time
-                                  // is accepted TODO mayb make this adjustable for future extensions
-          int nLastError = WSAGetLastError();
-          LPSTR pacErrorMessage = getErrorMessage(nLastError);
-          DEVLOG_ERROR("CWin32SocketInterface: listen() failed: %d - %s\n", nLastError, pacErrorMessage);
-          LocalFree(pacErrorMessage);
-        } else {
-          nRetVal = nSocket;
-        }
-        if (paPort == 0) {
-          displayActualPort(nSocket);
-        }
-      } else {
-        int nLastError = WSAGetLastError();
-        LPSTR pacErrorMessage = getErrorMessage(nLastError);
-        DEVLOG_ERROR("CWin32SocketInterface: bind() failed: %d - %s\n", nLastError, pacErrorMessage);
-        LocalFree(pacErrorMessage);
-      }
-    } else {
+    if (nSocket == INVALID_SOCKET) {
       int nLastError = WSAGetLastError();
       LPSTR pacErrorMessage = getErrorMessage(nLastError);
       DEVLOG_ERROR("CWin32SocketInterface: Couldn't create socket: %d - %s\n", nLastError, pacErrorMessage);
       LocalFree(pacErrorMessage);
+      return nRetVal;
+    }
+    struct sockaddr_in stSockAddr = {0};
+    stSockAddr.sin_family = AF_INET;
+    stSockAddr.sin_port = htons(paPort);
+    stSockAddr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    int nOptVal = 1;
+    if (setsockopt(nSocket, SOL_SOCKET, SO_REUSEADDR, (char *) &nOptVal, sizeof(nOptVal)) == SOCKET_ERROR) {
+      LPSTR pacErrorMessage = getErrorMessage(WSAGetLastError());
+      DEVLOG_ERROR("CWin32SocketInterface: could not set socket option SO_REUSEADDR:  %s\n", pacErrorMessage);
+      LocalFree(pacErrorMessage);
+      return nRetVal;
+    }
+
+    if (bind(nSocket, (struct sockaddr *) &stSockAddr, sizeof(struct sockaddr)) != 0) {
+      int nLastError = WSAGetLastError();
+      LPSTR pacErrorMessage = getErrorMessage(nLastError);
+      DEVLOG_ERROR("CWin32SocketInterface: bind() failed: %d - %s\n", nLastError, pacErrorMessage);
+      LocalFree(pacErrorMessage);
+      return nRetVal;
+    }
+
+    if (listen(nSocket, 1) == SOCKET_ERROR) { // for the classic IEC 61499 server only one connection at the same time
+      // is accepted TODO mayb make this adjustable for future extensions
+      int nLastError = WSAGetLastError();
+      LPSTR pacErrorMessage = getErrorMessage(nLastError);
+      DEVLOG_ERROR("CWin32SocketInterface: listen() failed: %d - %s\n", nLastError, pacErrorMessage);
+      LocalFree(pacErrorMessage);
+      return nRetVal;
+    }
+
+    nRetVal = nSocket;
+    if (paPort == 0) {
+      displayActualPort(nSocket);
     }
     return nRetVal;
   }

--- a/core/arch/win32/src/win32socketinterf.cpp
+++ b/core/arch/win32/src/win32socketinterf.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2023 ACIN, Profactor GmbH, AIT, fortiss GmbH, OFFIS e.V., HIT robot group
- *               2024 Samator Indo Gas
+ * Copyright (c) 2010, 2026 ACIN, Profactor GmbH, AIT, fortiss GmbH, OFFIS e.V., HIT robot group
+ *               Samator Indo Gas, Primetals Technologies Austria GmbH
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,6 +13,7 @@
  *  Jörg Walter - Windows XP compatibility, improve UDP multicast support
  *  Zhao Xin - fix socket resource leakage
  *  Ketut Kumajaya - switch to the Unicode version of WSAStringToAddress
+ *  Markus Meingast - add logging of actual tcp port being used
  *******************************************************************************/
 
 #include "forte/arch/sockhand.h" //needs to be first pulls in the platform specific includes
@@ -21,6 +22,29 @@
 #include "../../common/src/forte_stringFunctions.h"
 
 namespace forte::arch {
+  namespace {
+    LPSTR getErrorMessage(int paErrorNumber) {
+      LPSTR pacErrorMessage = nullptr;
+      FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                    nullptr, paErrorNumber, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), pacErrorMessage, 0, nullptr);
+      return pacErrorMessage;
+    }
+
+    void displayActualPort(CWin32SocketInterface::TSocketDescriptor paSocket) {
+      sockaddr_in stSockAddr = {0};
+      socklen_t addressLen = sizeof(stSockAddr);
+      if (getsockname(paSocket, (struct sockaddr *) &stSockAddr, &addressLen) == 0) {
+        unsigned short assignedPort = ntohs(stSockAddr.sin_port);
+        DEVLOG_INFO("CWin32SocketInterface: Socket is listening on port: %d\n", assignedPort);
+      } else {
+        int nLastError = WSAGetLastError();
+        LPSTR pacErrorMessage = getErrorMessage(nLastError);
+        DEVLOG_ERROR("CWin32SocketInterface: getsockname() failed: %d - %s\n", nLastError, pacErrorMessage);
+        LocalFree(pacErrorMessage);
+      }
+    }
+  } // namespace
+
 #define S2WS(x) forte_stringToWstring(x)
 
   void CWin32SocketInterface::closeSocket(TSocketDescriptor paSockD) {
@@ -36,7 +60,7 @@ namespace forte::arch {
     TSocketDescriptor nSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 
     if (INVALID_SOCKET != nSocket) {
-      struct sockaddr_in stSockAddr = {};
+      struct sockaddr_in stSockAddr = {0};
       stSockAddr.sin_family = AF_INET;
       stSockAddr.sin_port = htons(paPort);
       stSockAddr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -58,6 +82,9 @@ namespace forte::arch {
           LocalFree(pacErrorMessage);
         } else {
           nRetVal = nSocket;
+        }
+        if (paPort == 0) {
+          displayActualPort(nSocket);
         }
       } else {
         int nLastError = WSAGetLastError();
@@ -303,12 +330,5 @@ namespace forte::arch {
       LocalFree(pacErrorMessage);
     }
     return nRetVal;
-  }
-
-  LPSTR CWin32SocketInterface::getErrorMessage(int paErrorNumber) {
-    LPSTR pacErrorMessage = nullptr;
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
-                  paErrorNumber, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), pacErrorMessage, 0, nullptr);
-    return pacErrorMessage;
   }
 } // namespace forte::arch


### PR DESCRIPTION


Also fixes #831, where connection information was not shown for log levels below `FORTE_LOGINFO`