### PR TITLE
Add distance subdirectory to signal processing module

### DIFF
--- a/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/CMakeLists.txt
+++ b/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/CMakeLists.txt
@@ -23,3 +23,4 @@ target_sources(forte-signalprocessing PUBLIC
         SCALE_fct.h
         SCALE_LIM_fct.h
 )
+add_subdirectory(distance)

--- a/modules/signalprocessing/src/eclipse4diac/signalprocessing/CMakeLists.txt
+++ b/modules/signalprocessing/src/eclipse4diac/signalprocessing/CMakeLists.txt
@@ -21,3 +21,4 @@ target_sources(forte-signalprocessing PRIVATE
         SCALE_fct.cpp
         SCALE_LIM_fct.cpp
 )
+add_subdirectory(distance)


### PR DESCRIPTION
This integrates new distance-related components into the module's build system.
