### PR TITLE
Add isComparable check for CIEC_ANY_ELEMENTARY_VARIANT in comparison FBs

### DIFF
--- a/core/include/forte/datatypes/forte_any_elementary_variant.h
+++ b/core/include/forte/datatypes/forte_any_elementary_variant.h
@@ -127,6 +127,8 @@ namespace forte {
 
       [[nodiscard]] const CIEC_ANY_ELEMENTARY &unwrap() const override;
 
+      [[nodiscard]] bool isComparable(const CIEC_ANY_ELEMENTARY_VARIANT &paOther) const;
+
       int fromString(const char *paValue) override;
 
       void toString(std::string &paTargetBuf) const override;

--- a/core/src/datatypes/forte_any_elementary_variant.cpp
+++ b/core/src/datatypes/forte_any_elementary_variant.cpp
@@ -150,6 +150,21 @@ namespace forte {
     }
   }
 
+  bool CIEC_ANY_ELEMENTARY_VARIANT::isComparable(const CIEC_ANY_ELEMENTARY_VARIANT &paOther) const {
+    return std::visit(
+        [](auto &&value, auto &&other) -> bool {
+          using T = std::decay_t<decltype(value)>;
+          using U = std::decay_t<decltype(other)>;
+          using commonType = std::conditional_t<std::is_same_v<T, U>, T, typename mpl::get_castable_type<T, U>::type>;
+          if constexpr (std::is_base_of_v<CIEC_ANY_STRING, commonType>) {
+            return std::is_same_v<T, U>;
+          } else {
+            return !std::is_same_v<commonType, mpl::NullType>;
+          }
+        },
+        static_cast<const variant &>(*this), static_cast<const variant &>(paOther));
+  }
+
   int CIEC_ANY_ELEMENTARY_VARIANT::compare(const CIEC_ANY_ELEMENTARY_VARIANT &paValue,
                                            const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
     return std::visit(

--- a/modules/IEC61131-3/src/iec61131/comparison/F_EQ_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/comparison/F_EQ_fbt.cpp
@@ -58,7 +58,14 @@ namespace forte::iec61131::comparison {
   void FORTE_F_EQ::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
       case scmEventREQID:
-        var_OUT = CIEC_BOOL(var_IN1 == var_IN2);
+        if (!var_IN1.isComparable(var_IN2)) {
+          DEVLOG_ERROR("Comparing incompatible types in %s! IN1=%s, IN2=%s\n",
+                       getFullQualifiedApplicationInstanceName('.').c_str(), var_IN1.getTypeNameID().data(),
+                       var_IN2.getTypeNameID().data());
+          var_OUT = false_BOOL;
+        } else {
+          var_OUT = CIEC_BOOL(var_IN1 == var_IN2);
+        }
         sendOutputEvent(scmEventCNFID, paECET);
         break;
     }

--- a/modules/IEC61131-3/src/iec61131/comparison/F_GE_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/comparison/F_GE_fbt.cpp
@@ -58,7 +58,14 @@ namespace forte::iec61131::comparison {
   void FORTE_F_GE::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
       case scmEventREQID:
-        var_OUT = CIEC_BOOL(var_IN1 >= var_IN2);
+        if (!var_IN1.isComparable(var_IN2)) {
+          DEVLOG_ERROR("Comparing incompatible types in %s! IN1=%s, IN2=%s\n",
+                       getFullQualifiedApplicationInstanceName('.').c_str(), var_IN1.getTypeNameID().data(),
+                       var_IN2.getTypeNameID().data());
+          var_OUT = false_BOOL;
+        } else {
+          var_OUT = CIEC_BOOL(var_IN1 >= var_IN2);
+        }
         sendOutputEvent(scmEventCNFID, paECET);
         break;
     }

--- a/modules/IEC61131-3/src/iec61131/comparison/F_GT_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/comparison/F_GT_fbt.cpp
@@ -58,7 +58,14 @@ namespace forte::iec61131::comparison {
   void FORTE_F_GT::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
       case scmEventREQID:
-        var_OUT = CIEC_BOOL(var_IN1 > var_IN2);
+        if (!var_IN1.isComparable(var_IN2)) {
+          DEVLOG_ERROR("Comparing incompatible types in %s! IN1=%s, IN2=%s\n",
+                       getFullQualifiedApplicationInstanceName('.').c_str(), var_IN1.getTypeNameID().data(),
+                       var_IN2.getTypeNameID().data());
+          var_OUT = false_BOOL;
+        } else {
+          var_OUT = CIEC_BOOL(var_IN1 > var_IN2);
+        }
         sendOutputEvent(scmEventCNFID, paECET);
         break;
     }

--- a/modules/IEC61131-3/src/iec61131/comparison/F_LE_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/comparison/F_LE_fbt.cpp
@@ -58,7 +58,14 @@ namespace forte::iec61131::comparison {
   void FORTE_F_LE::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
       case scmEventREQID:
-        var_OUT = CIEC_BOOL(var_IN1 <= var_IN2);
+        if (!var_IN1.isComparable(var_IN2)) {
+          DEVLOG_ERROR("Comparing incompatible types in %s! IN1=%s, IN2=%s\n",
+                       getFullQualifiedApplicationInstanceName('.').c_str(), var_IN1.getTypeNameID().data(),
+                       var_IN2.getTypeNameID().data());
+          var_OUT = false_BOOL;
+        } else {
+          var_OUT = CIEC_BOOL(var_IN1 <= var_IN2);
+        }
         sendOutputEvent(scmEventCNFID, paECET);
         break;
     }

--- a/modules/IEC61131-3/src/iec61131/comparison/F_LT_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/comparison/F_LT_fbt.cpp
@@ -58,7 +58,14 @@ namespace forte::iec61131::comparison {
   void FORTE_F_LT::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
       case scmEventREQID:
-        var_OUT = CIEC_BOOL(var_IN1 < var_IN2);
+        if (!var_IN1.isComparable(var_IN2)) {
+          DEVLOG_ERROR("Comparing incompatible types in %s! IN1=%s, IN2=%s\n",
+                       getFullQualifiedApplicationInstanceName('.').c_str(), var_IN1.getTypeNameID().data(),
+                       var_IN2.getTypeNameID().data());
+          var_OUT = false_BOOL;
+        } else {
+          var_OUT = CIEC_BOOL(var_IN1 < var_IN2);
+        }
         sendOutputEvent(scmEventCNFID, paECET);
         break;
     }

--- a/modules/IEC61131-3/src/iec61131/comparison/F_NE_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/comparison/F_NE_fbt.cpp
@@ -58,7 +58,14 @@ namespace forte::iec61131::comparison {
   void FORTE_F_NE::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
       case scmEventREQID:
-        var_OUT = CIEC_BOOL(var_IN1 != var_IN2);
+        if (!var_IN1.isComparable(var_IN2)) {
+          DEVLOG_ERROR("Comparing incompatible types in %s! IN1=%s, IN2=%s\n",
+                       getFullQualifiedApplicationInstanceName('.').c_str(), var_IN1.getTypeNameID().data(),
+                       var_IN2.getTypeNameID().data());
+          var_OUT = false_BOOL;
+        } else {
+          var_OUT = CIEC_BOOL(var_IN1 != var_IN2);
+        }
         sendOutputEvent(scmEventCNFID, paECET);
         break;
     }


### PR DESCRIPTION
- Add isComparable() method to CIEC_ANY_ELEMENTARY_VARIANT to check type compatibility
- Update F_EQ, F_NE, F_LT, F_LE, F_GT, F_GE FBs to use isComparable() before comparison
- Log error with FB instance name only when types are incompatible (deferred getFullQualifiedApplicationInstanceName)
- Avoid duplicate error messages by skipping compare() call when types are incompatible
