### PR TITLE
Add FB instance name to DEVLOG_ERROR in IEC61131-3 FBs

### DIFF
--- a/modules/IEC61131-3/src/iec61131/arithmetic/F_ADD_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/arithmetic/F_ADD_fbt.cpp
@@ -62,14 +62,15 @@ namespace forte::iec61131::arithmetic {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_MAGNITUDE_VARIANT {
+            [this](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_MAGNITUDE_VARIANT {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               using deductedType = typename mpl::get_add_operator_result_type<T, U>::type;
               if constexpr (!std::is_same<deductedType, mpl::NullType>::value) {
                 return func_ADD(paIN1, paIN2);
               }
-              DEVLOG_ERROR("Adding incompatible types %s and %s\n", paIN1.getTypeNameID().data(),
+              DEVLOG_ERROR("Adding incompatible types in %s! IN1:%s, IN2:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                            paIN2.getTypeNameID().data());
               return CIEC_ANY_MAGNITUDE_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/arithmetic/F_DIV_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/arithmetic/F_DIV_fbt.cpp
@@ -60,14 +60,15 @@ namespace forte::iec61131::arithmetic {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_NUM_VARIANT {
+            [this](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_NUM_VARIANT {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               using deductedType = typename mpl::get_div_operator_result_type<T, U>::type;
               if constexpr (!std::is_same<deductedType, mpl::NullType>::value) {
                 return func_DIV(paIN1, paIN2);
               }
-              DEVLOG_ERROR("Dividing incompatible types %s and %s\n", paIN1.getTypeNameID().data(),
+              DEVLOG_ERROR("Dividing incompatible types in %s! IN1:%s, IN2:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                            paIN2.getTypeNameID().data());
               return CIEC_ANY_NUM_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/arithmetic/F_MOD_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/arithmetic/F_MOD_fbt.cpp
@@ -60,14 +60,15 @@ namespace forte::iec61131::arithmetic {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_NUM_VARIANT {
+            [this](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_NUM_VARIANT {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               using deductedType = typename mpl::get_castable_type<T, U>::type;
               if constexpr (!std::is_same<deductedType, mpl::NullType>::value) {
                 return func_MOD(paIN1, paIN2);
               }
-              DEVLOG_ERROR("Remainder of incompatible types %s and %s\n", paIN1.getTypeNameID().data(),
+              DEVLOG_ERROR("Remainder of incompatible types in %s! IN1:%s, IN2:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                            paIN2.getTypeNameID().data());
               return CIEC_ANY_NUM_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/arithmetic/F_MUL_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/arithmetic/F_MUL_fbt.cpp
@@ -60,14 +60,15 @@ namespace forte::iec61131::arithmetic {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_NUM_VARIANT {
+            [this](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_NUM_VARIANT {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               using deductedType = typename mpl::get_mul_operator_result_type<T, U>::type;
               if constexpr (!std::is_same<deductedType, mpl::NullType>::value) {
                 return func_MUL(paIN1, paIN2);
               }
-              DEVLOG_ERROR("Multiplying incompatible types %s and %s\n", paIN1.getTypeNameID().data(),
+              DEVLOG_ERROR("Multiplying incompatible types in %s! IN1:%s, IN2:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                            paIN2.getTypeNameID().data());
               return CIEC_ANY_NUM_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/arithmetic/F_SUB_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/arithmetic/F_SUB_fbt.cpp
@@ -60,14 +60,15 @@ namespace forte::iec61131::arithmetic {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_MAGNITUDE_VARIANT {
+            [this](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_MAGNITUDE_VARIANT {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               using deductedType = typename mpl::get_sub_operator_result_type<T, U>::type;
               if constexpr (!std::is_same<deductedType, mpl::NullType>::value) {
                 return func_SUB(paIN1, paIN2);
               }
-              DEVLOG_ERROR("Subtracting incompatible types %s and %s\n", paIN1.getTypeNameID().data(),
+              DEVLOG_ERROR("Subtracting incompatible types in %s! IN1:%s, IN2:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                            paIN2.getTypeNameID().data());
               return CIEC_ANY_MAGNITUDE_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/arithmetic/GEN_ADD_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/arithmetic/GEN_ADD_fbt.cpp
@@ -44,14 +44,15 @@ namespace forte::iec61131::arithmetic {
       var_OUT = mGenDIs[0];
       for (size_t i = 1; i < getFBInterfaceSpec().getNumDIs(); ++i) {
         var_OUT = std::visit(
-            [](auto &&paOUT, auto &&paIN) -> CIEC_ANY_MAGNITUDE_VARIANT {
+            [this](auto &&paOUT, auto &&paIN) -> CIEC_ANY_MAGNITUDE_VARIANT {
               using T = std::decay_t<decltype(paOUT)>;
               using U = std::decay_t<decltype(paIN)>;
               using deductedType = typename mpl::get_add_operator_result_type<T, U>::type;
               if constexpr (!std::is_same<deductedType, mpl::NullType>::value) {
                 return func_ADD(paOUT, paIN);
               }
-              DEVLOG_ERROR("Adding incompatible types %s and %s\n", paOUT.getTypeNameID().data(),
+              DEVLOG_ERROR("Adding incompatible types in %s! OUT:%s, IN:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paOUT.getTypeNameID().data(),
                            paIN.getTypeNameID().data());
               return paOUT;
             },

--- a/modules/IEC61131-3/src/iec61131/bitwiseOperators/F_ROL_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/bitwiseOperators/F_ROL_fbt.cpp
@@ -60,12 +60,13 @@ namespace forte::iec61131::bitwiseOperators {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN, auto &&paN) -> CIEC_ANY_BIT_VARIANT {
+            [this](auto &&paIN, auto &&paN) -> CIEC_ANY_BIT_VARIANT {
               using T = std::decay_t<decltype(paIN)>;
               if constexpr (!std::is_same<T, CIEC_BOOL>::value) {
                 return func_ROL(paIN, paN);
               }
-              DEVLOG_ERROR("Rotating left incompatible types %s and %s\n", paIN.getTypeNameID().data(),
+              DEVLOG_ERROR("Rotating left incompatible types in %s! IN:%s, N:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN.getTypeNameID().data(),
                            paN.getTypeNameID().data());
               return CIEC_ANY_BIT_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/bitwiseOperators/F_ROR_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/bitwiseOperators/F_ROR_fbt.cpp
@@ -60,12 +60,13 @@ namespace forte::iec61131::bitwiseOperators {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN, auto &&paN) -> CIEC_ANY_BIT_VARIANT {
+            [this](auto &&paIN, auto &&paN) -> CIEC_ANY_BIT_VARIANT {
               using T = std::decay_t<decltype(paIN)>;
               if constexpr (!std::is_same<T, CIEC_BOOL>::value) {
                 return func_ROR(paIN, paN);
               }
-              DEVLOG_ERROR("Rotating right incompatible types %s and %s\n", paIN.getTypeNameID().data(),
+              DEVLOG_ERROR("Rotating right incompatible types in %s! IN:%s, N:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN.getTypeNameID().data(),
                            paN.getTypeNameID().data());
               return CIEC_ANY_BIT_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/bitwiseOperators/F_SHL_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/bitwiseOperators/F_SHL_fbt.cpp
@@ -60,12 +60,13 @@ namespace forte::iec61131::bitwiseOperators {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN, auto &&paN) -> CIEC_ANY_BIT_VARIANT {
+            [this](auto &&paIN, auto &&paN) -> CIEC_ANY_BIT_VARIANT {
               using T = std::decay_t<decltype(paIN)>;
               if constexpr (!std::is_same<T, CIEC_BOOL>::value) {
                 return func_SHL(paIN, paN);
               }
-              DEVLOG_ERROR("Shifting left incompatible types %s and %s\n", paIN.getTypeNameID().data(),
+              DEVLOG_ERROR("Shifting left incompatible types in %s! IN:%s, N:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN.getTypeNameID().data(),
                            paN.getTypeNameID().data());
               return CIEC_ANY_BIT_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/bitwiseOperators/F_SHR_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/bitwiseOperators/F_SHR_fbt.cpp
@@ -60,12 +60,13 @@ namespace forte::iec61131::bitwiseOperators {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN, auto &&paN) -> CIEC_ANY_BIT_VARIANT {
+            [this](auto &&paIN, auto &&paN) -> CIEC_ANY_BIT_VARIANT {
               using T = std::decay_t<decltype(paIN)>;
               if constexpr (!std::is_same<T, CIEC_BOOL>::value) {
                 return func_SHR(paIN, paN);
               }
-              DEVLOG_ERROR("Shifting right incompatible types %s and %s\n", paIN.getTypeNameID().data(),
+              DEVLOG_ERROR("Shifting right incompatible types in %s! IN:%s, N:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN.getTypeNameID().data(),
                            paN.getTypeNameID().data());
               return CIEC_ANY_BIT_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/charString/F_CONCAT_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/charString/F_CONCAT_fbt.cpp
@@ -60,13 +60,14 @@ namespace forte::iec61131::charString {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_STRING_VARIANT {
+            [this](auto &&paIN1, auto &&paIN2) -> CIEC_ANY_STRING_VARIANT {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               if constexpr (std::is_same_v<T, U>) {
                 return func_CONCAT(paIN1, paIN2);
               }
-              DEVLOG_ERROR("Concatenating incompatible types %s and %s\n", paIN1.getTypeNameID().data(),
+              DEVLOG_ERROR("Concatenating incompatible types in %s! IN1:%s, IN2:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                            paIN2.getTypeNameID().data());
               return CIEC_ANY_STRING_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/charString/F_FIND_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/charString/F_FIND_fbt.cpp
@@ -60,7 +60,7 @@ namespace forte::iec61131::charString {
     switch (paEIID) {
       case scmEventREQID:
         std::visit(
-            [](auto &&paIN1, auto &&paIN2, auto &&paOUT) -> void {
+            [this](auto &&paIN1, auto &&paIN2, auto &&paOUT) -> void {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               if constexpr ((std::is_same_v<T, CIEC_STRING> &&
@@ -69,7 +69,8 @@ namespace forte::iec61131::charString {
                              (std::is_same_v<U, CIEC_WSTRING> || std::is_same_v<U, CIEC_WCHAR>) )) {
                 paOUT = func_FIND<std::remove_reference_t<decltype(paOUT)>>(paIN1, paIN2);
               } else {
-                DEVLOG_ERROR("Incompatible types IN1:%s and IN2:%s for FIND\n", paIN1.getTypeNameID().data(),
+                DEVLOG_ERROR("Incompatible types for FIND in %s! IN1:%s, IN2:%s\n",
+                             getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                              paIN2.getTypeNameID().data());
               }
             },

--- a/modules/IEC61131-3/src/iec61131/charString/F_INSERT_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/charString/F_INSERT_fbt.cpp
@@ -56,13 +56,14 @@ namespace forte::iec61131::charString {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN1, auto &&paIN2, auto &&paP) -> CIEC_ANY_STRING_VARIANT {
+            [this](auto &&paIN1, auto &&paIN2, auto &&paP) -> CIEC_ANY_STRING_VARIANT {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               if constexpr (std::is_same_v<T, U>) {
                 return func_INSERT(paIN1, paIN2, paP);
               }
-              DEVLOG_ERROR("Inserting incompatible types %s and %s\n", paIN1.getTypeNameID().data(),
+              DEVLOG_ERROR("Inserting incompatible types in %s! IN1:%s, IN2:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                            paIN2.getTypeNameID().data());
               return CIEC_ANY_STRING_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/charString/F_REPLACE_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/charString/F_REPLACE_fbt.cpp
@@ -58,13 +58,14 @@ namespace forte::iec61131::charString {
     switch (paEIID) {
       case scmEventREQID:
         var_OUT = std::visit(
-            [](auto &&paIN1, auto &&paIN2, auto &&paP, auto &&paL) -> CIEC_ANY_STRING_VARIANT {
+            [this](auto &&paIN1, auto &&paIN2, auto &&paP, auto &&paL) -> CIEC_ANY_STRING_VARIANT {
               using T = std::decay_t<decltype(paIN1)>;
               using U = std::decay_t<decltype(paIN2)>;
               if constexpr (std::is_same_v<T, U>) {
                 return func_REPLACE(paIN1, paIN2, paP, paL);
               }
-              DEVLOG_ERROR("Replacing incompatible types %s and %s\n", paIN1.getTypeNameID().data(),
+              DEVLOG_ERROR("Replacing incompatible types in %s! IN1:%s, IN2:%s\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), paIN1.getTypeNameID().data(),
                            paIN2.getTypeNameID().data());
               return CIEC_ANY_STRING_VARIANT();
             },

--- a/modules/IEC61131-3/src/iec61131/selection/GEN_F_MUX_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/selection/GEN_F_MUX_fbt.cpp
@@ -44,7 +44,6 @@ namespace forte::iec61131::selection {
       conn_K(nullptr),
       conn_OUT(*this, 0, var_OUT) {};
 
-
   void GEN_F_MUX::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
       case scmEventREQID:
@@ -56,8 +55,8 @@ namespace forte::iec61131::selection {
               if (valueK >= 0 && valueK < getFBInterfaceSpec().getNumDIs() - 1) {
                 return mGenDIs[valueK];
               }
-              DEVLOG_ERROR("Value of input K is out of range. Expected between 0 and %zu\n",
-                           getFBInterfaceSpec().getNumDIs() - 2);
+              DEVLOG_ERROR("Value of input K is out of range in %s! Expected between 0 and %zu\n",
+                           getFullQualifiedApplicationInstanceName('.').c_str(), getFBInterfaceSpec().getNumDIs() - 2);
               return CIEC_ANY_VARIANT();
             },
             static_cast<CIEC_ANY_INT_VARIANT::variant &>(var_K));
@@ -101,7 +100,8 @@ namespace forte::iec61131::selection {
     DEVLOG_DEBUG("DIs: %d;\n", numDIs);
 
     if (numDIs < 2) {
-      DEVLOG_ERROR("GEN_F_MUX must have at least 2 IN ports.\n");
+      DEVLOG_ERROR("GEN_F_MUX %s must have at least 2 IN ports.\n",
+                   getFullQualifiedApplicationInstanceName('.').c_str());
       return false;
     }
 


### PR DESCRIPTION
Add getFullQualifiedApplicationInstanceName to error messages in:
- charString: F_FIND, F_REPLACE, F_CONCAT, F_INSERT
- arithmetic: F_ADD, F_SUB, F_DIV, F_MUL, F_MOD, GEN_ADD
- bitwiseOperators: F_SHL, F SHR, F_ROL, F_ROR
- selection: GEN_F_MUX

This helps identify which function block caused the error.
