### PR TITLE
Use std::partial_ordering in CIEC_ANY_ELEMENTARY_VARIANT::compare and F_EQ

### DIFF
--- a/core/include/forte/datatypes/forte_any_elementary_variant.h
+++ b/core/include/forte/datatypes/forte_any_elementary_variant.h
@@ -14,6 +14,7 @@
  *******************************************************************************/
 #pragma once
 
+#include <compare>
 #include <variant>
 
 #include "forte/datatypes/forte_any.h"
@@ -135,33 +136,17 @@ namespace forte {
         return unwrap().equals(paOther.unwrap());
       }
 
-      [[nodiscard]] static int compare(const CIEC_ANY_ELEMENTARY_VARIANT &paValue,
-                                       const CIEC_ANY_ELEMENTARY_VARIANT &paOther);
+      [[nodiscard]] static std::partial_ordering compare(const CIEC_ANY_ELEMENTARY_VARIANT &paValue,
+                                                         const CIEC_ANY_ELEMENTARY_VARIANT &paOther);
   };
 
-  inline bool operator==(const CIEC_ANY_ELEMENTARY_VARIANT &paValue, const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
-    return CIEC_ANY_ELEMENTARY_VARIANT::compare(paValue, paOther) == 0;
-  }
+  // operator<=> replaces <, <=, >, >=
+  // operator== is still needed explicitly (not automatically generated from <=>)
+  // operator!= is automatically generated from operator==
+  std::partial_ordering operator<=>(const CIEC_ANY_ELEMENTARY_VARIANT &paValue,
+                                    const CIEC_ANY_ELEMENTARY_VARIANT &paOther);
 
-  inline bool operator!=(const CIEC_ANY_ELEMENTARY_VARIANT &paValue, const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
-    return CIEC_ANY_ELEMENTARY_VARIANT::compare(paValue, paOther) != 0;
-  }
-
-  inline bool operator<(const CIEC_ANY_ELEMENTARY_VARIANT &paValue, const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
-    return CIEC_ANY_ELEMENTARY_VARIANT::compare(paValue, paOther) < 0;
-  }
-
-  inline bool operator<=(const CIEC_ANY_ELEMENTARY_VARIANT &paValue, const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
-    return CIEC_ANY_ELEMENTARY_VARIANT::compare(paValue, paOther) <= 0;
-  }
-
-  inline bool operator>(const CIEC_ANY_ELEMENTARY_VARIANT &paValue, const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
-    return CIEC_ANY_ELEMENTARY_VARIANT::compare(paValue, paOther) > 0;
-  }
-
-  inline bool operator>=(const CIEC_ANY_ELEMENTARY_VARIANT &paValue, const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
-    return CIEC_ANY_ELEMENTARY_VARIANT::compare(paValue, paOther) >= 0;
-  }
+  bool operator==(const CIEC_ANY_ELEMENTARY_VARIANT &paValue, const CIEC_ANY_ELEMENTARY_VARIANT &paOther);
 
   static_assert(std::is_copy_constructible_v<CIEC_ANY_ELEMENTARY_VARIANT>);
   static_assert(std::is_move_constructible_v<CIEC_ANY_ELEMENTARY_VARIANT>);

--- a/core/include/forte/datatypes/forte_string.h
+++ b/core/include/forte/datatypes/forte_string.h
@@ -31,6 +31,7 @@
 #include "forte/datatypes/forte_any_int.h"
 #include "forte/datatypes/forte_char.h"
 #include "forte/util/devlog.h"
+#include <compare>
 #include <string>
 #include <stdlib.h>
 
@@ -201,7 +202,7 @@ namespace forte {
 
       virtual void append(const std::string_view paValue);
 
-      int compare(const CIEC_STRING &paValue) const;
+      std::strong_ordering compare(const CIEC_STRING &paValue) const;
 
       [[deprecated("Don't use this anymore, use c_str() instead")]]
       virtual char *getValue() override {

--- a/core/src/datatypes/forte_any_elementary_variant.cpp
+++ b/core/src/datatypes/forte_any_elementary_variant.cpp
@@ -150,10 +150,10 @@ namespace forte {
     }
   }
 
-  int CIEC_ANY_ELEMENTARY_VARIANT::compare(const CIEC_ANY_ELEMENTARY_VARIANT &paValue,
-                                           const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
+  std::partial_ordering CIEC_ANY_ELEMENTARY_VARIANT::compare(const CIEC_ANY_ELEMENTARY_VARIANT &paValue,
+                                                             const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
     return std::visit(
-        [](auto &&value, auto &&other) -> int {
+        [](auto &&value, auto &&other) -> std::partial_ordering {
           using T = std::decay_t<decltype(value)>;
           using U = std::decay_t<decltype(other)>;
           using commonType = std::conditional_t<std::is_same_v<T, U>, T, typename mpl::get_castable_type<T, U>::type>;
@@ -161,22 +161,29 @@ namespace forte {
             if constexpr (std::is_same_v<T, U> && std::is_same_v<T, CIEC_STRING>) {
               return static_cast<CIEC_STRING>(value).compare(static_cast<CIEC_STRING>(other));
             } else if constexpr (std::is_same_v<T, U> && std::is_same_v<T, CIEC_WSTRING>) {
-              return strcmp(static_cast<commonType>(value).getValue(), static_cast<commonType>(other).getValue());
+              const auto wstringValue = static_cast<commonType>(value).getValue();
+              const auto wstringOther = static_cast<commonType>(other).getValue();
+              return wstringValue <=> wstringOther;
             } else {
-              DEVLOG_ERROR("Comparing incompatible types %s and %s\n", value.getTypeNameID().data(),
-                           other.getTypeNameID().data());
-              return -1;
+              return std::partial_ordering::unordered;
             }
           } else if constexpr (!std::is_same_v<commonType, mpl::NullType>) {
-            auto primitiveValue = static_cast<typename commonType::TValueType>(static_cast<commonType>(value));
-            auto primitiveOther = static_cast<typename commonType::TValueType>(static_cast<commonType>(other));
-            return (primitiveValue > primitiveOther) - (primitiveValue < primitiveOther);
+            const auto primitiveValue = static_cast<typename commonType::TValueType>(static_cast<commonType>(value));
+            const auto primitiveOther = static_cast<typename commonType::TValueType>(static_cast<commonType>(other));
+            return primitiveValue <=> primitiveOther;
           } else {
-            DEVLOG_ERROR("Comparing incompatible types %s and %s\n", value.getTypeNameID().data(),
-                         other.getTypeNameID().data());
-            return -1;
+            return std::partial_ordering::unordered;
           }
         },
         static_cast<const variant &>(paValue), static_cast<const variant &>(paOther));
+  }
+
+  std::partial_ordering operator<=>(const CIEC_ANY_ELEMENTARY_VARIANT &paValue,
+                                    const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
+    return CIEC_ANY_ELEMENTARY_VARIANT::compare(paValue, paOther);
+  }
+
+  bool operator==(const CIEC_ANY_ELEMENTARY_VARIANT &paValue, const CIEC_ANY_ELEMENTARY_VARIANT &paOther) {
+    return CIEC_ANY_ELEMENTARY_VARIANT::compare(paValue, paOther) == std::partial_ordering::equivalent;
   }
 } // namespace forte

--- a/core/src/datatypes/forte_string.cpp
+++ b/core/src/datatypes/forte_string.cpp
@@ -144,8 +144,8 @@ namespace forte {
     mValue.append(paValue);
   }
 
-  int CIEC_STRING::compare(const CIEC_STRING &paValue) const {
-    return mValue.compare(paValue.getStorage());
+  std::strong_ordering CIEC_STRING::compare(const CIEC_STRING &paValue) const {
+    return mValue <=> paValue.getStorage();
   }
 
   void CIEC_STRING::toString(std::string &paTargetBuf) const {

--- a/modules/IEC61131-3/src/iec61131/comparison/F_EQ_fbt.cpp
+++ b/modules/IEC61131-3/src/iec61131/comparison/F_EQ_fbt.cpp
@@ -57,10 +57,18 @@ namespace forte::iec61131::comparison {
 
   void FORTE_F_EQ::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
-      case scmEventREQID:
-        var_OUT = CIEC_BOOL(var_IN1 == var_IN2);
+      case scmEventREQID: {
+        const auto result = CIEC_ANY_ELEMENTARY_VARIANT::compare(var_IN1, var_IN2);
+        if (result == std::partial_ordering::unordered) {
+          DEVLOG_ERROR("Comparing incompatible types %s and %s in %s!\n", var_IN1.getTypeNameID().data(),
+                       var_IN2.getTypeNameID().data(), getFullQualifiedApplicationInstanceName('.').c_str());
+          var_OUT = false_BOOL;
+        } else {
+          var_OUT = CIEC_BOOL(result == std::partial_ordering::equivalent);
+        }
         sendOutputEvent(scmEventCNFID, paECET);
         break;
+      }
     }
   }
 

--- a/tests/core/datatypes/CIEC_ANY_ELEMENTARY_VARIANT_test.cpp
+++ b/tests/core/datatypes/CIEC_ANY_ELEMENTARY_VARIANT_test.cpp
@@ -133,6 +133,12 @@ namespace forte::test {
     BOOST_CHECK(!(test1 < test2));
     BOOST_CHECK(test1 >= test2);
     BOOST_CHECK(!(test1 > test2));
+    BOOST_CHECK(std::is_eq(test1 <=> test2));
+    BOOST_CHECK(!std::is_neq(test1 <=> test2));
+    BOOST_CHECK(!std::is_lt(test1 <=> test2));
+    BOOST_CHECK(std::is_lteq(test1 <=> test2));
+    BOOST_CHECK(!std::is_gt(test1 <=> test2));
+    BOOST_CHECK(std::is_gteq(test1 <=> test2));
 
     // same types
     test1 = CIEC_DINT(17);
@@ -144,6 +150,13 @@ namespace forte::test {
     BOOST_CHECK(!(test1 < test2));
     BOOST_CHECK(test1 >= test2);
     BOOST_CHECK(test1 > test2);
+    // std::is_* helpers should work for comparable types
+    BOOST_CHECK(!std::is_eq(test1 <=> test2));
+    BOOST_CHECK(std::is_neq(test1 <=> test2));
+    BOOST_CHECK(!std::is_lt(test1 <=> test2));
+    BOOST_CHECK(!std::is_lteq(test1 <=> test2));
+    BOOST_CHECK(std::is_gt(test1 <=> test2));
+    BOOST_CHECK(std::is_gteq(test1 <=> test2));
 
     test2 = CIEC_DINT(21);
 
@@ -153,6 +166,12 @@ namespace forte::test {
     BOOST_CHECK(test1 < test2);
     BOOST_CHECK(!(test1 >= test2));
     BOOST_CHECK(!(test1 > test2));
+    BOOST_CHECK(!std::is_eq(test1 <=> test2));
+    BOOST_CHECK(std::is_neq(test1 <=> test2));
+    BOOST_CHECK(std::is_lt(test1 <=> test2));
+    BOOST_CHECK(std::is_lteq(test1 <=> test2));
+    BOOST_CHECK(!std::is_gt(test1 <=> test2));
+    BOOST_CHECK(!std::is_gteq(test1 <=> test2));
 
     // different types (signed)
     test1 = CIEC_DINT(17);
@@ -164,6 +183,15 @@ namespace forte::test {
     BOOST_CHECK(!(test1 < test2));
     BOOST_CHECK(test1 >= test2);
     BOOST_CHECK(test1 > test2);
+
+    // same value, different types - should be equal via type promotion
+    test2 = CIEC_LINT(17);
+    BOOST_CHECK(test1 == test2);
+    BOOST_CHECK(!(test1 != test2));
+    BOOST_CHECK(test1 <= test2);
+    BOOST_CHECK(!(test1 < test2));
+    BOOST_CHECK(test1 >= test2);
+    BOOST_CHECK(!(test1 > test2));
 
     test2 = CIEC_SINT(21);
 
@@ -215,13 +243,16 @@ namespace forte::test {
     BOOST_CHECK(!(test1 > test2));
 
     // different types (incomparable)
+    // Previously these asserted test1 < test2 / test1 <= test2 etc.
+    // That was wrong: incomparable types (e.g. DINT vs STRING) are not ordered.
+    // They are simply unequal (unordered in std::partial_ordering terms).
     test1 = CIEC_DINT(17);
     test2 = "abc"_STRING;
 
     BOOST_CHECK(!(test1 == test2));
     BOOST_CHECK(test1 != test2);
-    BOOST_CHECK(test1 <= test2);
-    BOOST_CHECK(test1 < test2);
+    BOOST_CHECK(!(test1 <= test2));
+    BOOST_CHECK(!(test1 < test2));
     BOOST_CHECK(!(test1 >= test2));
     BOOST_CHECK(!(test1 > test2));
 
@@ -230,10 +261,33 @@ namespace forte::test {
 
     BOOST_CHECK(!(test1 == test2));
     BOOST_CHECK(test1 != test2);
-    BOOST_CHECK(test1 <= test2);
-    BOOST_CHECK(test1 < test2);
+    BOOST_CHECK(!(test1 <= test2));
+    BOOST_CHECK(!(test1 < test2));
     BOOST_CHECK(!(test1 >= test2));
     BOOST_CHECK(!(test1 > test2));
+
+    // check that the spaceship operator returns unordered for incomparable types
+    test1 = CIEC_DINT(17);
+    test2 = "abc"_STRING;
+    BOOST_CHECK((test1 <=> test2) == std::partial_ordering::unordered);
+    // For unordered, only is_eq is false and is_neq is true (not equivalent != unordered)
+    // is_lt/is_lteq/is_gt/is_gteq are all false since unordered is not comparable
+    BOOST_CHECK(!std::is_eq(test1 <=> test2));
+    BOOST_CHECK(std::is_neq(test1 <=> test2));
+    BOOST_CHECK(!std::is_lt(test1 <=> test2));
+    BOOST_CHECK(!std::is_lteq(test1 <=> test2));
+    BOOST_CHECK(!std::is_gt(test1 <=> test2));
+    BOOST_CHECK(!std::is_gteq(test1 <=> test2));
+
+    test1 = "abc"_STRING;
+    test2 = CIEC_DINT(17);
+    BOOST_CHECK((test1 <=> test2) == std::partial_ordering::unordered);
+    BOOST_CHECK(!std::is_eq(test1 <=> test2));
+    BOOST_CHECK(std::is_neq(test1 <=> test2));
+    BOOST_CHECK(!std::is_lt(test1 <=> test2));
+    BOOST_CHECK(!std::is_lteq(test1 <=> test2));
+    BOOST_CHECK(!std::is_gt(test1 <=> test2));
+    BOOST_CHECK(!std::is_gteq(test1 <=> test2));
 
     // large difference
     test1 = CIEC_ULINT(std::numeric_limits<CIEC_ULINT::TValueType>::min());


### PR DESCRIPTION
compare() now returns std::partial_ordering instead of int, using
unordered for incompatible types to avoid the ambiguity with -1 as both
a valid less-than result and an error sentinel. F_EQ detects unordered
and logs the FB instance name alongside the type mismatch.

https://github.com/eclipse-4diac/4diac-forte/issues/888

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
