### PR TITLE
Introduce optional RAM disk for file I/O

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -39,6 +39,10 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
             architecture: "posix"
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+            architecture: "posix-systemtests-ramdisk"
         exclude:
           - os: windows-latest
             c_compiler: gcc
@@ -77,7 +81,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
           -S ${{ github.workspace }}
-          --preset ${{ matrix.architecture }}-systemtests
+          --preset ${{ matrix.architecture == 'posix-systemtests-ramdisk' && 'posix-systemtests-ramdisk' || format('{0}-systemtests', matrix.architecture) }}
           ${{ matrix.os == 'windows-latest' && format('-DFORTE_TESTS_INC_DIRS={0}/boost.1.84.0/lib/native/include', github.workspace) || '' }}
 
       - name: Build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -231,6 +231,20 @@
       ]
     },
     {
+      "name": "posix-systemtests-ramdisk",
+      "displayName": "System Tests (Posix, RAMDISK)",
+      "inherits": [
+        "systemtests",
+        "posix"
+      ],
+      "cacheVariables": {
+        "FORTE_FILEIO_RAMDISK": {
+          "type": "BOOL",
+          "value": "ON"
+        }
+      }
+    },
+    {
       "name": "windows",
       "hidden": true,
       "inherits": "base",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,5 +49,19 @@ spec:
         }
       }
     }
+    stage('Build static RAMDISK') {
+      steps {
+        container('build') {
+          cmakeBuild installation: 'CMake 3.14.5', buildDir: 'static-ramdisk', generator: 'Unix Makefiles', buildType: 'Debug', cmakeArgs: '-DFORTE_ARCHITECTURE=Posix -DFORTE_TESTS=ON -DFORTE_SYSTEM_TESTS=ON -DFORTE_FILEIO_RAMDISK=ON -DFORTE_LOGLEVEL=LOGDEBUG -DFORTE_EventChainExternalEventListSize=32 -DFORTE_MODULE_CONVERT=ON -DFORTE_MODULE_IEC61131=ON -DFORTE_MODULE_UTILS=ON -DFORTE_MODULE_RT_Events=ON -DFORTE_MODULE_RECONFIGURATION=ON -DFORTE_IO=ON -DFORTE_COM_ETH=ON -DFORTE_COM_FBDK=ON -DFORTE_COM_LOCAL=ON -DFORTE_COM_RAW=ON -DFORTE_COM_HTTP=ON -DFORTE_COM_OPC_UA=ON -DFORTE_COM_OPC_UA_INCLUDE_DIR=${WORKDIR}/open62541/binStatic -DFORTE_COM_OPC_UA_LIB_DIR=${WORKDIR}/open62541/binStatic/bin -DFORTE_COM_OPC_UA_LIB=libopen62541.a', steps: [[args: 'all']]
+        }
+      }
+    }
+    stage('Test static RAMDISK') {
+      steps {
+        container('build') {
+          ctest installation: 'CMake 3.14.5', workingDir: 'static-ramdisk', arguments: '--verbose'
+        }
+      }
+    }
   }
 }

--- a/core/arch/common/include/forte/arch/CMakeLists.txt
+++ b/core/arch/common/include/forte/arch/CMakeLists.txt
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2025 Martin Erich Jobst
+# Copyright (c) 2025 Martin Erich Jobst and others
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -21,6 +21,7 @@ target_sources(forte-core PUBLIC
         forte_printer.h
         forte_specific_architecture.h
         threadbase.h
+        $<$<BOOL:${FORTE_FILEIO_RAMDISK}>:${CMAKE_CURRENT_SOURCE_DIR}/forte_ramdisk.h>
 )
 
 set_source_files_properties(

--- a/core/arch/common/include/forte/arch/forte_ramdisk.h
+++ b/core/arch/common/include/forte/arch/forte_ramdisk.h
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agrartechnik GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int forte_ramdisk_load(const char *filename);
+void forte_ramdisk_unload(const char *filename);
+
+#ifdef __cplusplus
+}
+#endif

--- a/core/arch/common/src/genforte_fileio_ramdisk.cpp
+++ b/core/arch/common/src/genforte_fileio_ramdisk.cpp
@@ -50,11 +50,15 @@ int forte_ramdisk_load(const char *filename) {
 
   std::ifstream file(filename, std::ios::binary | std::ios::ate);
   if (!file) {
+    std::lock_guard<std::mutex> lock(g_ramdiskMutex);
+    g_ramdiskEntries[filename] = std::vector<char>();
     return -1;
   }
 
   std::streamsize size = file.tellg();
   if (size < 0) {
+    std::lock_guard<std::mutex> lock(g_ramdiskMutex);
+    g_ramdiskEntries[filename] = std::vector<char>();
     return -1;
   }
 
@@ -62,6 +66,8 @@ int forte_ramdisk_load(const char *filename) {
 
   std::vector<char> buffer(static_cast<size_t>(size));
   if (!file.read(buffer.data(), size)) {
+    std::lock_guard<std::mutex> lock(g_ramdiskMutex);
+    g_ramdiskEntries[filename] = std::vector<char>();
     return -1;
   }
 
@@ -85,6 +91,9 @@ void *forte_fopen(const char *filename, const char *mode) {
     if (it != g_ramdiskEntries.end()) {
       // Only use RAMDISK for read modes; write modes fallback to real file
       if (mode[0] == 'r') {
+        if (it->second.empty()) {
+          return nullptr;
+        }
         FILE *file = fmemopen(it->second.data(), it->second.size(), mode);
         if (file != nullptr) {
           g_ramdiskOpenFiles[file] = {filename, mode[0]};

--- a/core/arch/common/src/genforte_fileio_ramdisk.cpp
+++ b/core/arch/common/src/genforte_fileio_ramdisk.cpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agrartechnik GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include "forte/arch/forte_fileio.h"
+#include "forte/arch/forte_ramdisk.h"
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+struct RamdiskFileInfo {
+    std::string filename;
+    char mode;
+};
+
+static std::map<std::string, std::vector<char>> g_ramdiskEntries;
+static std::map<void *, RamdiskFileInfo> g_ramdiskOpenFiles;
+static std::mutex g_ramdiskMutex;
+
+extern "C" {
+
+char *forte_getenv(const char *env_var) {
+  return getenv(env_var);
+}
+
+size_t forte_strnlen_s(const char *str, size_t strsz) {
+  if (nullptr == str) {
+    return 0;
+  }
+  return strnlen(str, strsz);
+}
+
+int forte_ramdisk_load(const char *filename) {
+  if (filename == nullptr) {
+    return -1;
+  }
+
+  std::ifstream file(filename, std::ios::binary | std::ios::ate);
+  if (!file) {
+    return -1;
+  }
+
+  std::streamsize size = file.tellg();
+  if (size < 0) {
+    return -1;
+  }
+
+  file.seekg(0, std::ios::beg);
+
+  std::vector<char> buffer(static_cast<size_t>(size));
+  if (!file.read(buffer.data(), size)) {
+    return -1;
+  }
+
+  std::lock_guard<std::mutex> lock(g_ramdiskMutex);
+  g_ramdiskEntries[filename] = std::move(buffer);
+  return 0;
+}
+
+void forte_ramdisk_unload(const char *filename) {
+  if (filename == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(g_ramdiskMutex);
+  g_ramdiskEntries.erase(filename);
+}
+
+void *forte_fopen(const char *filename, const char *mode) {
+  if (filename != nullptr && mode != nullptr) {
+    std::lock_guard<std::mutex> lock(g_ramdiskMutex);
+    auto it = g_ramdiskEntries.find(filename);
+    if (it != g_ramdiskEntries.end()) {
+      // Only use RAMDISK for read modes; write modes fallback to real file
+      if (mode[0] == 'r') {
+        FILE *file = fmemopen(it->second.data(), it->second.size(), mode);
+        if (file != nullptr) {
+          g_ramdiskOpenFiles[file] = {filename, mode[0]};
+        }
+        return file;
+      }
+    }
+  }
+  return fopen(filename, mode);
+}
+
+int forte_fclose(void *file) {
+  FILE *f = static_cast<FILE *>(file);
+  {
+    std::lock_guard<std::mutex> lock(g_ramdiskMutex);
+    auto it = g_ramdiskOpenFiles.find(f);
+    if (it != g_ramdiskOpenFiles.end()) {
+      if (it->second.mode == 'r') {
+        // Remove from RAMDISK; vector memory freed automatically by RAII
+        g_ramdiskEntries.erase(it->second.filename);
+      }
+      g_ramdiskOpenFiles.erase(it);
+    }
+  }
+  return fclose(f);
+}
+
+char *forte_fgets(char *str, int count, void *file) {
+  return fgets(str, count, static_cast<FILE *>(file));
+}
+
+int forte_fseek(void *file, long offset, int whence) {
+  return fseek(static_cast<FILE *>(file), offset, whence);
+}
+
+long forte_ftell(void *file) {
+  return ftell(static_cast<FILE *>(file));
+}
+
+int forte_feof(void *file) {
+  return feof(static_cast<FILE *>(file));
+}
+
+size_t forte_fread(void *ptr, size_t itemsize, size_t nitems, void *file) {
+  return fread(ptr, itemsize, nitems, static_cast<FILE *>(file));
+}
+
+size_t forte_fwrite(const void *ptr, size_t itemsize, size_t nitems, void *file) {
+  return fwrite(ptr, itemsize, nitems, static_cast<FILE *>(file));
+}
+
+} // extern "C"

--- a/core/arch/posix/src/CMakeLists.txt
+++ b/core/arch/posix/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2010 - 2024 ACIN, Profactor GmbH, fortiss GmbH, Jose Cabral
+# Copyright (c) 2010 ACIN, Profactor GmbH, fortiss GmbH, Jose Cabral and others
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
 # http://www.eclipse.org/legal/epl-2.0.
@@ -13,8 +13,17 @@
 # *******************************************************************************/
 
 option(FORTE_COM_SER "Enable Forte serial line communication" OFF)
+option(FORTE_FILEIO_RAMDISK "Use RAM disk for file I/O" OFF)
 
 include(CheckSymbolExists)
+
+if(FORTE_FILEIO_RAMDISK)
+    check_symbol_exists(fmemopen stdio.h HAVE_FMEMOPEN)
+    if(NOT HAVE_FMEMOPEN)
+        message(FATAL_ERROR "fmemopen not found, but FORTE_FILEIO_RAMDISK is enabled")
+    endif()
+    target_compile_definitions(forte-core PUBLIC FORTE_FILEIO_RAMDISK)
+endif()
 
 target_sources(forte-core PRIVATE
         forte_architecture_time.cpp
@@ -26,7 +35,8 @@ target_sources(forte-core PRIVATE
         ../../common/src/forte_specific_architecture.cpp
         ../../common/src/forte_standard_time.cpp
         ../../common/src/genforte_printer.cpp
-        ../../common/src/genforte_fileio.cpp
+        $<$<NOT:$<BOOL:${FORTE_FILEIO_RAMDISK}>>:${CMAKE_CURRENT_SOURCE_DIR}/../../common/src/genforte_fileio.cpp>
+        $<$<BOOL:${FORTE_FILEIO_RAMDISK}>:${CMAKE_CURRENT_SOURCE_DIR}/../../common/src/genforte_fileio_ramdisk.cpp>
         ../../common/src/utils/timespec_utils.cpp
         $<$<BOOL:${BUILD_SHARED_LIBS}>:${CMAKE_CURRENT_SOURCE_DIR}/load_option.cpp>
         $<$<BOOL:${FORTE_COM_SER}>:${CMAKE_CURRENT_SOURCE_DIR}/posixsercommlayer.cpp>

--- a/tests/core/util/CMakeLists.txt
+++ b/tests/core/util/CMakeLists.txt
@@ -17,4 +17,5 @@ forte_test_add_sourcefile_cpp(
   testsingleton.cpp singeltontest.cpp singletontest2ndunit.cpp
   parameterParserTest.cpp
   string_utils_test.cpp
+  ramdisk_test.cpp
 )

--- a/tests/core/util/ramdisk_test.cpp
+++ b/tests/core/util/ramdisk_test.cpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agrartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include <boost/test/unit_test.hpp>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+#ifdef FORTE_FILEIO_RAMDISK
+#include "forte/arch/forte_ramdisk.h"
+#include "forte/arch/forte_fileio.h"
+
+namespace forte::arch::test {
+
+  BOOST_AUTO_TEST_SUITE(RAMDISK_function_test)
+
+  BOOST_AUTO_TEST_CASE(ramdisk_load_and_read_test) {
+    // Create a temporary file with known content
+    const char *testContent = "Line1;Content1\nLine2;Content2\nLine3;Content3\n";
+    const char *tempFileName = "/tmp/forte_ramdisk_test_file.txt";
+
+    std::ofstream outFile(tempFileName);
+    outFile << testContent;
+    outFile.close();
+
+    // Load file into RAMDISK
+    int result = forte_ramdisk_load(tempFileName);
+    BOOST_CHECK_EQUAL(result, 0);
+
+    // Open via RAMDISK (should use fmemopen internally)
+    void *file = forte_fopen(tempFileName, "r");
+    BOOST_CHECK(file != nullptr);
+
+    if (file != nullptr) {
+      char buffer[256];
+
+      // Read first line
+      char *line1 = forte_fgets(buffer, sizeof(buffer), file);
+      BOOST_CHECK(line1 != nullptr);
+      BOOST_CHECK(strcmp(buffer, "Line1;Content1\n") == 0);
+
+      // Read second line
+      char *line2 = forte_fgets(buffer, sizeof(buffer), file);
+      BOOST_CHECK(line2 != nullptr);
+      BOOST_CHECK(strcmp(buffer, "Line2;Content2\n") == 0);
+
+      // Read third line
+      char *line3 = forte_fgets(buffer, sizeof(buffer), file);
+      BOOST_CHECK(line3 != nullptr);
+      BOOST_CHECK(strcmp(buffer, "Line3;Content3\n") == 0);
+
+      // Close should free the buffer for read mode
+      int closeResult = forte_fclose(file);
+      BOOST_CHECK_EQUAL(closeResult, 0);
+    }
+
+    // Clean up temporary file
+    std::remove(tempFileName);
+  }
+
+  BOOST_AUTO_TEST_CASE(ramdisk_fallback_to_real_file_test) {
+    // Test that files NOT in RAMDISK still work via normal fopen
+    const char *testContent = "FallbackTest;Data\n";
+    const char *tempFileName = "/tmp/forte_ramdisk_fallback_test.txt";
+
+    std::ofstream outFile(tempFileName);
+    outFile << testContent;
+    outFile.close();
+
+    // Do NOT load into RAMDISK - should fallback to real file
+    void *file = forte_fopen(tempFileName, "r");
+    BOOST_CHECK(file != nullptr);
+
+    if (file != nullptr) {
+      char buffer[256];
+      char *line = forte_fgets(buffer, sizeof(buffer), file);
+      BOOST_CHECK(line != nullptr);
+      BOOST_CHECK(strcmp(buffer, "FallbackTest;Data\n") == 0);
+
+      int closeResult = forte_fclose(file);
+      BOOST_CHECK_EQUAL(closeResult, 0);
+    }
+
+    // Clean up temporary file
+    std::remove(tempFileName);
+  }
+
+  BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace forte::arch::test
+
+#else // FORTE_FILEIO_RAMDISK not defined
+// Provide an empty test suite so the file compiles even without RAMDISK
+namespace forte::arch::test {
+  BOOST_AUTO_TEST_SUITE(RAMDISK_function_test)
+  BOOST_AUTO_TEST_CASE(dummy_test) {
+    BOOST_CHECK(true); // Always passes when RAMDISK is not available
+  }
+  BOOST_AUTO_TEST_SUITE_END()
+} // namespace forte::arch::test
+#endif // FORTE_FILEIO_RAMDISK


### PR DESCRIPTION
Adds a new build option, `FORTE_FILEIO_RAMDISK`, to enable an in-memory file system using `fmemopen`. This allows files to be loaded into RAM and accessed via standard file I/O functions.

This feature is particularly useful for embedded systems or performance-critical scenarios where traditional file system access is not feasible or desired. Enabling the option requires the `fmemopen` function to be available on the target system.
