### PR TITLE
Add E_RF_TRIG for detecting boolean rising and falling edges

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
+++ b/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(forte-events PUBLIC
         E_N_TABLE_fbt.h
         E_PERMIT_fbt.h
         E_R_TRIG_fbt.h
+        E_RF_TRIG_fbt.h
         E_RDELAY_fbt.h
         E_REND_fbt.h
         E_RESTART_fbt.h

--- a/stdfblib/events/include/forte/iec61499/events/E_RF_TRIG_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_RF_TRIG_fbt.h
@@ -1,0 +1,61 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_RF_TRIG
+ *** Description: Boolean falling and rising edge detection
+ *** Version:
+ ***     1.0: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - initial API and implementation and/or initial
+ *documentation
+ *************************************************************************/
+
+#pragma once
+
+#include "forte/cfb.h"
+#include "forte/typelib.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/iec61499/events/E_D_FF_fbt.h"
+#include "forte/iec61499/events/E_SWITCH_fbt.h"
+
+namespace forte::iec61499::events {
+  class FORTE_E_RF_TRIG final : public CCompositeFB {
+      DECLARE_FIRMWARE_FB(FORTE_E_RF_TRIG)
+
+    private:
+      static const TEventID scmEventERID = 0;
+      static const TEventID scmEventEFID = 1;
+      static const TEventID scmEventEIID = 0;
+
+      CInternalFB<forte::iec61499::events::FORTE_E_D_FF> fb_E_D_FF;
+      CInternalFB<forte::iec61499::events::FORTE_E_SWITCH> fb_E_SWITCH;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    public:
+      FORTE_E_RF_TRIG(StringId paInstanceNameId, CFBContainer &paContainer);
+
+      CEventConnection conn_ER;
+      CEventConnection conn_EF;
+
+      CDataConnection *conn_QI;
+
+      COutDataConnection<CIEC_BOOL> conn_if2in_QI;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
+  };
+} // namespace forte::iec61499::events

--- a/stdfblib/events/src/CMakeLists.txt
+++ b/stdfblib/events/src/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(forte-events PRIVATE
         E_N_TABLE_fbt.cpp
         E_PERMIT_fbt.cpp
         E_R_TRIG_fbt.cpp
+        E_RF_TRIG_fbt.cpp
         E_RDELAY_fbt.cpp
         E_REND_fbt.cpp
         E_RESTART_fbt.cpp

--- a/stdfblib/events/src/E_RF_TRIG_fbt.cpp
+++ b/stdfblib/events/src/E_RF_TRIG_fbt.cpp
@@ -1,0 +1,131 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_RF_TRIG
+ *** Description: Boolean falling and rising edge detection
+ *** Version:
+ ***     1.0: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - initial API and implementation and/or initial
+ *documentation
+ *************************************************************************/
+
+#include "forte/iec61499/events/E_RF_TRIG_fbt.h"
+
+using namespace std::literals;
+using namespace forte::literals;
+
+namespace forte::iec61499::events {
+  namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"EI"_STRID};
+    const auto cEventOutputNames = std::array{"ER"_STRID, "EF"_STRID};
+    const auto cDataInputNames = std::array{"QI"_STRID};
+
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = {},
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = {},
+        .mDINames = cDataInputNames,
+        .mDONames = {},
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
+        {{}, "EI"_STRID, "E_D_FF"_STRID, "CLK"_STRID},
+        {"E_D_FF"_STRID, "EO"_STRID, "E_SWITCH"_STRID, "EI"_STRID},
+        {"E_SWITCH"_STRID, "EO1"_STRID, {}, "ER"_STRID},
+        {"E_SWITCH"_STRID, "EO0"_STRID, {}, "EF"_STRID},
+    });
+
+    const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
+        {{}, "QI"_STRID, "E_D_FF"_STRID, "D"_STRID},
+        {"E_D_FF"_STRID, "Q"_STRID, "E_SWITCH"_STRID, "G"_STRID},
+    });
+
+    const SCFB_FBNData cFBNData = {
+        .mEventConnections = cEventConnections,
+        .mDataConnections = cDataConnections,
+        .mAdapterConnections = {},
+    };
+  } // namespace
+
+  DEFINE_FIRMWARE_FB(FORTE_E_RF_TRIG, "iec61499::events::E_RF_TRIG"_STRID, TypeHash)
+
+  FORTE_E_RF_TRIG::FORTE_E_RF_TRIG(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
+      fb_E_D_FF("E_D_FF"_STRID, *this),
+      fb_E_SWITCH("E_SWITCH"_STRID, *this),
+      conn_ER(*this, 0),
+      conn_EF(*this, 1),
+      conn_QI(nullptr),
+      conn_if2in_QI(*this, 0, 0_BOOL) {};
+
+  void FORTE_E_RF_TRIG::setInitialValues() {
+    CCompositeFB::setInitialValues();
+    conn_if2in_QI.getValue() = 0_BOOL;
+  }
+
+  void FORTE_E_RF_TRIG::readInputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventEIID: {
+        readData(0, conn_if2in_QI.getValue(), conn_QI);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  void FORTE_E_RF_TRIG::writeOutputData(TEventID) {
+    // nothing to do
+  }
+
+  CIEC_ANY *FORTE_E_RF_TRIG::getDI(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_QI.getValue();
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_E_RF_TRIG::getDO(size_t) {
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_E_RF_TRIG::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_ER;
+      case 1: return &conn_EF;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_E_RF_TRIG::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QI;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_RF_TRIG::getDOConUnchecked(TPortId) {
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_RF_TRIG::getIf2InConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_QI;
+    }
+    return nullptr;
+  }
+
+} // namespace forte::iec61499::events


### PR DESCRIPTION
Implement the FORTE_E_RF_TRIG function block to enable detection of both rising and falling edges in boolean signals. This enhancement supports more complex event handling in IEC 61499 applications.

https://github.com/eclipse-4diac/4diac-ide/pull/2443
