### PR TITLE
Add E_TLIM function block for time-limiting and timeout functionality

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/timers/CMakeLists.txt
+++ b/stdfblib/events/include/forte/iec61499/events/timers/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(forte-events PUBLIC
         FILE_SET HEADERS
         FILES
         E_PULSE_fbt.h
+        E_TLIM_fbt.h
         E_TOF_fbt.h
         E_TONOF_fbt.h
         E_TON_fbt.h

--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TLIM_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TLIM_fbt.h
@@ -1,0 +1,67 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_TLIM
+ *** Description: standard timer function block (time-limiting, timeout)
+ *** Version:
+ ***     1.0: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - initial API and implementation and/or initial
+ *documentation
+ *************************************************************************/
+
+#pragma once
+
+#include "forte/cfb.h"
+#include "forte/typelib.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_time.h"
+#include "forte/forte_st_util.h"
+#include "forte/iec61499/events/E_DELAY_fbt.h"
+#include "forte/iec61499/events/E_RF_TRIG_fbt.h"
+#include "forte/iec61499/events/E_SR_fbt.h"
+
+namespace forte::iec61499::events::timers {
+  class FORTE_E_TLIM final : public CCompositeFB {
+      DECLARE_FIRMWARE_FB(FORTE_E_TLIM)
+
+    private:
+      static const TEventID scmEventCNFID = 0;
+      static const TEventID scmEventREQID = 0;
+
+      CInternalFB<forte::iec61499::events::FORTE_E_RF_TRIG> fb_E_RF_TRIG;
+      CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
+      CInternalFB<forte::iec61499::events::FORTE_E_SR> fb_E_SR;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    public:
+      FORTE_E_TLIM(StringId paInstanceNameId, CFBContainer &paContainer);
+
+      CEventConnection conn_CNF;
+
+      CDataConnection *conn_IN;
+      CDataConnection *conn_PT;
+
+      COutDataConnection<CIEC_BOOL> conn_Q;
+
+      COutDataConnection<CIEC_BOOL> conn_if2in_IN;
+      COutDataConnection<CIEC_TIME> conn_if2in_PT;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
+  };
+} // namespace forte::iec61499::events::timers

--- a/stdfblib/events/src/timers/CMakeLists.txt
+++ b/stdfblib/events/src/timers/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 target_sources(forte-events PRIVATE
         E_PULSE_fbt.cpp
+        E_TLIM_fbt.cpp
         E_TOF_fbt.cpp
         E_TONOF_fbt.cpp
         E_TON_fbt.cpp

--- a/stdfblib/events/src/timers/E_TLIM_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TLIM_fbt.cpp
@@ -1,0 +1,158 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_TLIM
+ *** Description: standard timer function block (time-limiting, timeout)
+ *** Version:
+ ***     1.0: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - initial API and implementation and/or initial
+ *documentation
+ *************************************************************************/
+
+#include "forte/iec61499/events/timers/E_TLIM_fbt.h"
+
+#include "forte/forte_st_util.h"
+
+using namespace std::literals;
+using namespace forte::literals;
+
+namespace forte::iec61499::events::timers {
+  namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
+    const auto cDataInputNames = std::array{"IN"_STRID, "PT"_STRID};
+    const auto cDataOutputNames = std::array{"Q"_STRID};
+
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = {},
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = {},
+        .mDINames = cDataInputNames,
+        .mDONames = cDataOutputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
+        {{}, "REQ"_STRID, "E_RF_TRIG"_STRID, "EI"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
+        {"E_DELAY"_STRID, "EO"_STRID, "E_SR"_STRID, "R"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_SR"_STRID, "R"_STRID},
+        {"E_SR"_STRID, "EO"_STRID, {}, "CNF"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_SR"_STRID, "S"_STRID},
+    });
+
+    const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
+        {{}, "IN"_STRID, "E_RF_TRIG"_STRID, "QI"_STRID},
+        {{}, "PT"_STRID, "E_DELAY"_STRID, "DT"_STRID},
+        {"E_SR"_STRID, "Q"_STRID, {}, "Q"_STRID},
+    });
+
+    const SCFB_FBNData cFBNData = {
+        .mEventConnections = cEventConnections,
+        .mDataConnections = cDataConnections,
+        .mAdapterConnections = {},
+    };
+  } // namespace
+
+  DEFINE_FIRMWARE_FB(FORTE_E_TLIM, "iec61499::events::timers::E_TLIM"_STRID, TypeHash)
+
+  FORTE_E_TLIM::FORTE_E_TLIM(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
+      fb_E_RF_TRIG("E_RF_TRIG"_STRID, *this),
+      fb_E_DELAY("E_DELAY"_STRID, *this),
+      fb_E_SR("E_SR"_STRID, *this),
+      conn_CNF(*this, 0),
+      conn_IN(nullptr),
+      conn_PT(nullptr),
+      conn_Q(*this, 0, 0_BOOL),
+      conn_if2in_IN(*this, 0, 0_BOOL),
+      conn_if2in_PT(*this, 1, 0_TIME) {};
+
+  void FORTE_E_TLIM::setInitialValues() {
+    CCompositeFB::setInitialValues();
+    conn_if2in_IN.getValue() = 0_BOOL;
+    conn_if2in_PT.getValue() = 0_TIME;
+    fb_E_SR->conn_Q.getValue() = 0_BOOL;
+  }
+
+  void FORTE_E_TLIM::readInputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventREQID: {
+        readData(0, conn_if2in_IN.getValue(), conn_IN);
+        readData(1, conn_if2in_PT.getValue(), conn_PT);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  void FORTE_E_TLIM::writeOutputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventCNFID: {
+        writeData(2, fb_E_SR->conn_Q.getValue(), conn_Q);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_E_TLIM::getDI(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_IN.getValue();
+      case 1: return &conn_if2in_PT.getValue();
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_E_TLIM::getDO(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &fb_E_SR->conn_Q.getValue();
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_E_TLIM::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_CNF;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_E_TLIM::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_IN;
+      case 1: return &conn_PT;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_TLIM::getDOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_Q;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_TLIM::getIf2InConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_IN;
+      case 1: return &conn_if2in_PT;
+    }
+    return nullptr;
+  }
+
+} // namespace forte::iec61499::events::timers


### PR DESCRIPTION
Introduce the E_TLIM function block, which provides a standard timer for time-limiting and timeout requirements in the IEC 61499 framework. This new block enhances the library's timer capabilities, allowing developers to manage time constraints effectively.

https://github.com/eclipse-4diac/4diac-ide/pull/2439
