### PR TITLE
Replace E_SWITCH with E_RF_TRIG in timer function blocks

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TOF_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TOF_fbt.h
@@ -6,14 +6,17 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TOF
  *** Description: standard timer function block (off-delay timing)
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #pragma once
@@ -22,13 +25,9 @@
 #include "forte/typelib.h"
 #include "forte/datatypes/forte_bool.h"
 #include "forte/datatypes/forte_time.h"
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
-#include "forte/iec61499/events/E_SWITCH_fbt.h"
+#include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
+#include "forte/iec61499/events/E_RF_TRIG_fbt.h"
 #include "forte/iec61499/events/E_RS_fbt.h"
 
 namespace forte::iec61499::events::timers {
@@ -36,18 +35,17 @@ namespace forte::iec61499::events::timers {
       DECLARE_FIRMWARE_FB(FORTE_E_TOF)
 
     private:
+      static const TEventID scmEventCNFID = 0;
       static const TEventID scmEventREQID = 0;
       static const TEventID scmEventRID = 1;
-      static const TEventID scmEventCNFID = 0;
 
-      CInternalFB<forte::iec61499::events::FORTE_E_SWITCH> fb_E_SWITCH;
+      CInternalFB<forte::iec61499::events::FORTE_E_RF_TRIG> fb_E_RF_TRIG;
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
       CInternalFB<forte::iec61499::events::FORTE_E_RS> fb_E_RS;
 
       void readInputData(TEventID paEIID) override;
       void writeOutputData(TEventID paEIID) override;
       void setInitialValues() override;
-      CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
     public:
       FORTE_E_TOF(StringId paInstanceNameId, CFBContainer &paContainer);
@@ -67,5 +65,6 @@ namespace forte::iec61499::events::timers {
       CEventConnection *getEOConUnchecked(TPortId) override;
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
   };
 } // namespace forte::iec61499::events::timers

--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TONOF_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TONOF_fbt.h
@@ -6,14 +6,17 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TONOF
  *** Description: standard timer function block (on/off-delay timing)
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #pragma once
@@ -22,13 +25,9 @@
 #include "forte/typelib.h"
 #include "forte/datatypes/forte_bool.h"
 #include "forte/datatypes/forte_time.h"
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
-#include "forte/iec61499/events/E_SWITCH_fbt.h"
+#include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
+#include "forte/iec61499/events/E_RF_TRIG_fbt.h"
 #include "forte/iec61499/events/E_RS_fbt.h"
 
 namespace forte::iec61499::events::timers {
@@ -36,11 +35,11 @@ namespace forte::iec61499::events::timers {
       DECLARE_FIRMWARE_FB(FORTE_E_TONOF)
 
     private:
+      static const TEventID scmEventCNFID = 0;
       static const TEventID scmEventREQID = 0;
       static const TEventID scmEventRID = 1;
-      static const TEventID scmEventCNFID = 0;
 
-      CInternalFB<forte::iec61499::events::FORTE_E_SWITCH> fb_E_SWITCH;
+      CInternalFB<forte::iec61499::events::FORTE_E_RF_TRIG> fb_E_RF_TRIG;
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY_ON;
       CInternalFB<forte::iec61499::events::FORTE_E_RS> fb_E_RS;
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY_OFF;
@@ -48,7 +47,6 @@ namespace forte::iec61499::events::timers {
       void readInputData(TEventID paEIID) override;
       void writeOutputData(TEventID paEIID) override;
       void setInitialValues() override;
-      CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
     public:
       FORTE_E_TONOF(StringId paInstanceNameId, CFBContainer &paContainer);
@@ -70,5 +68,6 @@ namespace forte::iec61499::events::timers {
       CEventConnection *getEOConUnchecked(TPortId) override;
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
   };
 } // namespace forte::iec61499::events::timers

--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TON_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TON_fbt.h
@@ -6,13 +6,16 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TON
  *** Description: standard timer function block (on-delay timing)
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
+ ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #pragma once
@@ -21,31 +24,26 @@
 #include "forte/typelib.h"
 #include "forte/datatypes/forte_bool.h"
 #include "forte/datatypes/forte_time.h"
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
-#include "forte/iec61499/events/E_SWITCH_fbt.h"
+#include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
-#include "forte/iec61499/events/E_RS_fbt.h"
+#include "forte/iec61499/events/E_RF_TRIG_fbt.h"
+#include "forte/iec61499/events/E_SR_fbt.h"
 
 namespace forte::iec61499::events::timers {
   class FORTE_E_TON final : public CCompositeFB {
       DECLARE_FIRMWARE_FB(FORTE_E_TON)
 
     private:
-      static const TEventID scmEventREQID = 0;
       static const TEventID scmEventCNFID = 0;
+      static const TEventID scmEventREQID = 0;
 
-      CInternalFB<forte::iec61499::events::FORTE_E_SWITCH> fb_E_SWITCH;
+      CInternalFB<forte::iec61499::events::FORTE_E_RF_TRIG> fb_E_RF_TRIG;
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
-      CInternalFB<forte::iec61499::events::FORTE_E_RS> fb_E_RS;
+      CInternalFB<forte::iec61499::events::FORTE_E_SR> fb_E_SR;
 
       void readInputData(TEventID paEIID) override;
       void writeOutputData(TEventID paEIID) override;
       void setInitialValues() override;
-      CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
     public:
       FORTE_E_TON(StringId paInstanceNameId, CFBContainer &paContainer);
@@ -65,5 +63,6 @@ namespace forte::iec61499::events::timers {
       CEventConnection *getEOConUnchecked(TPortId) override;
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
   };
 } // namespace forte::iec61499::events::timers

--- a/stdfblib/events/src/timers/E_TOF_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TOF_fbt.cpp
@@ -6,41 +6,40 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TOF
  *** Description: standard timer function block (off-delay timing)
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #include "forte/iec61499/events/timers/E_TOF_fbt.h"
 
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 
 using namespace std::literals;
 using namespace forte::literals;
 
 namespace forte::iec61499::events::timers {
   namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
     const auto cDataInputNames = std::array{"IN"_STRID, "PT"_STRID};
     const auto cDataOutputNames = std::array{"Q"_STRID};
-    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
 
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
-        .mEITypeNames = cEventInputTypeIds,
+        .mEITypeNames = {},
         .mEONames = cEventOutputNames,
-        .mEOTypeNames = cEventOutputTypeIds,
+        .mEOTypeNames = {},
         .mDINames = cDataInputNames,
         .mDONames = cDataOutputNames,
         .mDIONames = {},
@@ -49,18 +48,18 @@ namespace forte::iec61499::events::timers {
     };
 
     const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
-        {{}, "REQ"_STRID, "E_SWITCH"_STRID, "EI"_STRID},
+        {{}, "REQ"_STRID, "E_RF_TRIG"_STRID, "EI"_STRID},
         {"E_RS"_STRID, "EO"_STRID, {}, "CNF"_STRID},
         {"E_DELAY"_STRID, "EO"_STRID, "E_RS"_STRID, "R"_STRID},
-        {"E_SWITCH"_STRID, "EO1"_STRID, "E_RS"_STRID, "S"_STRID},
-        {"E_SWITCH"_STRID, "EO1"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
-        {"E_SWITCH"_STRID, "EO0"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_RS"_STRID, "S"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
         {{}, "R"_STRID, "E_RS"_STRID, "R"_STRID},
         {{}, "R"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
     });
 
     const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
-        {{}, "IN"_STRID, "E_SWITCH"_STRID, "G"_STRID},
+        {{}, "IN"_STRID, "E_RF_TRIG"_STRID, "QI"_STRID},
         {{}, "PT"_STRID, "E_DELAY"_STRID, "DT"_STRID},
         {"E_RS"_STRID, "Q"_STRID, {}, "Q"_STRID},
     });
@@ -72,11 +71,11 @@ namespace forte::iec61499::events::timers {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_E_TOF, "iec61499::events::timers::E_TOF"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_E_TOF, "iec61499::events::timers::E_TOF"_STRID, TypeHash)
 
   FORTE_E_TOF::FORTE_E_TOF(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
-      fb_E_SWITCH("E_SWITCH"_STRID, *this),
+      fb_E_RF_TRIG("E_RF_TRIG"_STRID, *this),
       fb_E_DELAY("E_DELAY"_STRID, *this),
       fb_E_RS("E_RS"_STRID, *this),
       conn_CNF(*this, 0),
@@ -107,7 +106,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_TOF::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, fb_E_RS->conn_Q.getValue(), conn_Q);
+        writeData(2, fb_E_RS->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -151,7 +150,7 @@ namespace forte::iec61499::events::timers {
     return nullptr;
   }
 
-  CDataConnection *FORTE_E_TOF::getIf2InConUnchecked(TPortId paIndex) {
+  CDataConnection *FORTE_E_TOF::getIf2InConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
       case 0: return &conn_if2in_IN;
       case 1: return &conn_if2in_PT;

--- a/stdfblib/events/src/timers/E_TONOF_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TONOF_fbt.cpp
@@ -6,41 +6,40 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TONOF
  *** Description: standard timer function block (on/off-delay timing)
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #include "forte/iec61499/events/timers/E_TONOF_fbt.h"
 
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 
 using namespace std::literals;
 using namespace forte::literals;
 
 namespace forte::iec61499::events::timers {
   namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
     const auto cDataInputNames = std::array{"IN"_STRID, "PT_ON"_STRID, "PT_OFF"_STRID};
     const auto cDataOutputNames = std::array{"Q"_STRID};
-    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
 
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
-        .mEITypeNames = cEventInputTypeIds,
+        .mEITypeNames = {},
         .mEONames = cEventOutputNames,
-        .mEOTypeNames = cEventOutputTypeIds,
+        .mEOTypeNames = {},
         .mDINames = cDataInputNames,
         .mDONames = cDataOutputNames,
         .mDIONames = {},
@@ -49,20 +48,20 @@ namespace forte::iec61499::events::timers {
     };
 
     const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
-        {{}, "REQ"_STRID, "E_SWITCH"_STRID, "EI"_STRID},
-        {"E_SWITCH"_STRID, "EO1"_STRID, "E_DELAY_ON"_STRID, "START"_STRID},
-        {"E_SWITCH"_STRID, "EO1"_STRID, "E_DELAY_OFF"_STRID, "STOP"_STRID},
-        {"E_SWITCH"_STRID, "EO0"_STRID, "E_DELAY_ON"_STRID, "STOP"_STRID},
-        {"E_SWITCH"_STRID, "EO0"_STRID, "E_DELAY_OFF"_STRID, "START"_STRID},
+        {{}, "REQ"_STRID, "E_RF_TRIG"_STRID, "EI"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY_ON"_STRID, "START"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY_ON"_STRID, "STOP"_STRID},
         {"E_DELAY_ON"_STRID, "EO"_STRID, "E_RS"_STRID, "S"_STRID},
         {"E_RS"_STRID, "EO"_STRID, {}, "CNF"_STRID},
         {"E_DELAY_OFF"_STRID, "EO"_STRID, "E_RS"_STRID, "R"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY_OFF"_STRID, "START"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY_OFF"_STRID, "STOP"_STRID},
         {{}, "R"_STRID, "E_RS"_STRID, "R"_STRID},
         {{}, "R"_STRID, "E_DELAY_OFF"_STRID, "STOP"_STRID},
     });
 
     const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
-        {{}, "IN"_STRID, "E_SWITCH"_STRID, "G"_STRID},
+        {{}, "IN"_STRID, "E_RF_TRIG"_STRID, "QI"_STRID},
         {{}, "PT_ON"_STRID, "E_DELAY_ON"_STRID, "DT"_STRID},
         {"E_RS"_STRID, "Q"_STRID, {}, "Q"_STRID},
         {{}, "PT_OFF"_STRID, "E_DELAY_OFF"_STRID, "DT"_STRID},
@@ -75,11 +74,11 @@ namespace forte::iec61499::events::timers {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_E_TONOF, "iec61499::events::timers::E_TONOF"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_E_TONOF, "iec61499::events::timers::E_TONOF"_STRID, TypeHash)
 
   FORTE_E_TONOF::FORTE_E_TONOF(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
-      fb_E_SWITCH("E_SWITCH"_STRID, *this),
+      fb_E_RF_TRIG("E_RF_TRIG"_STRID, *this),
       fb_E_DELAY_ON("E_DELAY_ON"_STRID, *this),
       fb_E_RS("E_RS"_STRID, *this),
       fb_E_DELAY_OFF("E_DELAY_OFF"_STRID, *this),
@@ -93,6 +92,7 @@ namespace forte::iec61499::events::timers {
       conn_if2in_PT_OFF(*this, 2, 0_TIME) {};
 
   void FORTE_E_TONOF::setInitialValues() {
+    CCompositeFB::setInitialValues();
     conn_if2in_IN.getValue() = 0_BOOL;
     conn_if2in_PT_ON.getValue() = 0_TIME;
     conn_if2in_PT_OFF.getValue() = 0_TIME;
@@ -114,7 +114,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_TONOF::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, fb_E_RS->conn_Q.getValue(), conn_Q);
+        writeData(3, fb_E_RS->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -160,7 +160,7 @@ namespace forte::iec61499::events::timers {
     return nullptr;
   }
 
-  CDataConnection *FORTE_E_TONOF::getIf2InConUnchecked(TPortId paIndex) {
+  CDataConnection *FORTE_E_TONOF::getIf2InConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
       case 0: return &conn_if2in_IN;
       case 1: return &conn_if2in_PT_ON;

--- a/stdfblib/events/src/timers/E_TON_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TON_fbt.cpp
@@ -6,40 +6,39 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TON
  *** Description: standard timer function block (on-delay timing)
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
+ ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #include "forte/iec61499/events/timers/E_TON_fbt.h"
 
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 
 using namespace std::literals;
 using namespace forte::literals;
 
 namespace forte::iec61499::events::timers {
   namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
     const auto cDataInputNames = std::array{"IN"_STRID, "PT"_STRID};
     const auto cDataOutputNames = std::array{"Q"_STRID};
-    const auto cEventInputNames = std::array{"REQ"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
 
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
-        .mEITypeNames = cEventInputTypeIds,
+        .mEITypeNames = {},
         .mEONames = cEventOutputNames,
-        .mEOTypeNames = cEventOutputTypeIds,
+        .mEOTypeNames = {},
         .mDINames = cDataInputNames,
         .mDONames = cDataOutputNames,
         .mDIONames = {},
@@ -48,18 +47,18 @@ namespace forte::iec61499::events::timers {
     };
 
     const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
-        {{}, "REQ"_STRID, "E_SWITCH"_STRID, "EI"_STRID},
-        {"E_SWITCH"_STRID, "EO1"_STRID, "E_DELAY"_STRID, "START"_STRID},
-        {"E_SWITCH"_STRID, "EO0"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
-        {"E_SWITCH"_STRID, "EO0"_STRID, "E_RS"_STRID, "R"_STRID},
-        {"E_DELAY"_STRID, "EO"_STRID, "E_RS"_STRID, "S"_STRID},
-        {"E_RS"_STRID, "EO"_STRID, {}, "CNF"_STRID},
+        {{}, "REQ"_STRID, "E_RF_TRIG"_STRID, "EI"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
+        {"E_DELAY"_STRID, "EO"_STRID, "E_SR"_STRID, "S"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_SR"_STRID, "R"_STRID},
+        {"E_SR"_STRID, "EO"_STRID, {}, "CNF"_STRID},
     });
 
     const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
-        {{}, "IN"_STRID, "E_SWITCH"_STRID, "G"_STRID},
+        {{}, "IN"_STRID, "E_RF_TRIG"_STRID, "QI"_STRID},
         {{}, "PT"_STRID, "E_DELAY"_STRID, "DT"_STRID},
-        {"E_RS"_STRID, "Q"_STRID, {}, "Q"_STRID},
+        {"E_SR"_STRID, "Q"_STRID, {}, "Q"_STRID},
     });
 
     const SCFB_FBNData cFBNData = {
@@ -69,13 +68,13 @@ namespace forte::iec61499::events::timers {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_E_TON, "iec61499::events::timers::E_TON"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_E_TON, "iec61499::events::timers::E_TON"_STRID, TypeHash)
 
   FORTE_E_TON::FORTE_E_TON(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
-      fb_E_SWITCH("E_SWITCH"_STRID, *this),
+      fb_E_RF_TRIG("E_RF_TRIG"_STRID, *this),
       fb_E_DELAY("E_DELAY"_STRID, *this),
-      fb_E_RS("E_RS"_STRID, *this),
+      fb_E_SR("E_SR"_STRID, *this),
       conn_CNF(*this, 0),
       conn_IN(nullptr),
       conn_PT(nullptr),
@@ -87,7 +86,7 @@ namespace forte::iec61499::events::timers {
     CCompositeFB::setInitialValues();
     conn_if2in_IN.getValue() = 0_BOOL;
     conn_if2in_PT.getValue() = 0_TIME;
-    fb_E_RS->conn_Q.getValue() = 0_BOOL;
+    fb_E_SR->conn_Q.getValue() = 0_BOOL;
   }
 
   void FORTE_E_TON::readInputData(const TEventID paEIID) {
@@ -104,7 +103,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_TON::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, fb_E_RS->conn_Q.getValue(), conn_Q);
+        writeData(2, fb_E_SR->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -121,7 +120,7 @@ namespace forte::iec61499::events::timers {
 
   CIEC_ANY *FORTE_E_TON::getDO(const size_t paIndex) {
     switch (paIndex) {
-      case 0: return &fb_E_RS->conn_Q.getValue();
+      case 0: return &fb_E_SR->conn_Q.getValue();
     }
     return nullptr;
   }
@@ -148,7 +147,7 @@ namespace forte::iec61499::events::timers {
     return nullptr;
   }
 
-  CDataConnection *FORTE_E_TON::getIf2InConUnchecked(TPortId paIndex) {
+  CDataConnection *FORTE_E_TON::getIf2InConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
       case 0: return &conn_if2in_IN;
       case 1: return &conn_if2in_PT;


### PR DESCRIPTION
Update E_TOF, E_TON, and E_TONOF function blocks to use E_RF_TRIG instead of E_SWITCH for improved reliability and adherence to the latest specification.

https://github.com/eclipse-4diac/4diac-ide/pull/2438
