### PR TITLE
Update timer function blocks to be non-retriggerable

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/timers/E_PULSE_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_PULSE_fbt.h
@@ -1,52 +1,52 @@
 /*************************************************************************
- *** Copyright (c) 2023, 2024 HR Agrartechnik GmbH
+ *** Copyright (c) 2023 HR Agrartechnik GmbH
  *** This program and the accompanying materials are made available under the
  *** terms of the Eclipse Public License 2.0 which is available at
  *** http://www.eclipse.org/legal/epl-2.0.
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_PULSE
- *** Description: standard timer function block (pulse)
+ *** Description: standard timer function block (pulse) - non-retriggerable
  *** Version:
- ***     1.0: 2023-08-21/Franz Hoepfinger - HR Agrartechnik GmbH - initial implementation as E_IMPULSE
- ***     1.0: 2024-03-05/Franz Hoepfinger - HR Agrartechnik GmbH - renamed to E_PULSE
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-04-19/Franz Höpfinger - HR Agrartechnik GmbH - Made non-retriggerable
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0.1: 2024-03-05/Franz Höpfinger - HR Agrartechnik GmbH - renamed to E_PULSE
+ ***     1.0: 2023-08-21/Franz Höpfinger - HR Agrartechnik GmbH - initial implementation as E_IMPULSE
  *************************************************************************/
 
 #pragma once
 
 #include "forte/cfb.h"
 #include "forte/typelib.h"
-#include "forte/datatypes/forte_time.h"
 #include "forte/datatypes/forte_bool.h"
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/datatypes/forte_time.h"
+#include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
-#include "forte/iec61499/events/E_SR_fbt.h"
+#include "forte/iec61499/events/E_PERMIT_fbt.h"
+#include "forte/iec61499/events/E_RS_fbt.h"
 
 namespace forte::iec61499::events::timers {
   class FORTE_E_PULSE final : public CCompositeFB {
       DECLARE_FIRMWARE_FB(FORTE_E_PULSE)
 
     private:
+      static const TEventID scmEventCNFID = 0;
       static const TEventID scmEventREQID = 0;
       static const TEventID scmEventRID = 1;
-      static const TEventID scmEventCNFID = 0;
 
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
-      CInternalFB<forte::iec61499::events::FORTE_E_SR> fb_E_SR;
+      CInternalFB<forte::iec61499::events::FORTE_E_RS> fb_E_RS;
+      CInternalFB<forte::iec61499::events::FORTE_E_PERMIT> fb_CheckRunning;
 
       void readInputData(TEventID paEIID) override;
       void writeOutputData(TEventID paEIID) override;
       void setInitialValues() override;
-      CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
     public:
       FORTE_E_PULSE(StringId paInstanceNameId, CFBContainer &paContainer);
@@ -64,5 +64,6 @@ namespace forte::iec61499::events::timers {
       CEventConnection *getEOConUnchecked(TPortId) override;
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
   };
 } // namespace forte::iec61499::events::timers

--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TP_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TP_fbt.h
@@ -6,14 +6,17 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TP
- *** Description: standard timer function block (pulse)
+ *** Description: standard timer function block (pulse) - non-retriggerable
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-04-19/Franz Höpfinger - HR Agrartechnik GmbH - Made non-retriggerable
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #pragma once
@@ -22,32 +25,29 @@
 #include "forte/typelib.h"
 #include "forte/datatypes/forte_bool.h"
 #include "forte/datatypes/forte_time.h"
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
-#include "forte/iec61499/events/E_RS_fbt.h"
 #include "forte/iec61499/events/E_PERMIT_fbt.h"
+#include "forte/iec61499/events/E_R_TRIG_fbt.h"
+#include "forte/iec61499/events/E_SR_fbt.h"
 
 namespace forte::iec61499::events::timers {
   class FORTE_E_TP final : public CCompositeFB {
       DECLARE_FIRMWARE_FB(FORTE_E_TP)
 
     private:
+      static const TEventID scmEventCNFID = 0;
       static const TEventID scmEventREQID = 0;
       static const TEventID scmEventRID = 1;
-      static const TEventID scmEventCNFID = 0;
 
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
-      CInternalFB<forte::iec61499::events::FORTE_E_RS> fb_E_RS;
-      CInternalFB<forte::iec61499::events::FORTE_E_PERMIT> fb_E_PERMIT;
+      CInternalFB<forte::iec61499::events::FORTE_E_SR> fb_E_SR;
+      CInternalFB<forte::iec61499::events::FORTE_E_R_TRIG> fb_E_R_TRIG;
+      CInternalFB<forte::iec61499::events::FORTE_E_PERMIT> fb_CheckRunning;
 
       void readInputData(TEventID paEIID) override;
       void writeOutputData(TEventID paEIID) override;
       void setInitialValues() override;
-      CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
     public:
       FORTE_E_TP(StringId paInstanceNameId, CFBContainer &paContainer);
@@ -67,5 +67,6 @@ namespace forte::iec61499::events::timers {
       CEventConnection *getEOConUnchecked(TPortId) override;
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
   };
 } // namespace forte::iec61499::events::timers

--- a/stdfblib/events/src/timers/E_PULSE_fbt.cpp
+++ b/stdfblib/events/src/timers/E_PULSE_fbt.cpp
@@ -1,47 +1,46 @@
 /*************************************************************************
- *** Copyright (c) 2023, 2024 HR Agrartechnik GmbH
+ *** Copyright (c) 2023 HR Agrartechnik GmbH
  *** This program and the accompanying materials are made available under the
  *** terms of the Eclipse Public License 2.0 which is available at
  *** http://www.eclipse.org/legal/epl-2.0.
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_PULSE
- *** Description: standard timer function block (pulse)
+ *** Description: standard timer function block (pulse) - non-retriggerable
  *** Version:
- ***     1.0: 2023-08-21/Franz Hoepfinger - HR Agrartechnik GmbH - initial implementation as E_IMPULSE
- ***     1.0: 2024-03-05/Franz Hoepfinger - HR Agrartechnik GmbH - renamed to E_PULSE
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-04-19/Franz Höpfinger - HR Agrartechnik GmbH - Made non-retriggerable
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0.1: 2024-03-05/Franz Höpfinger - HR Agrartechnik GmbH - renamed to E_PULSE
+ ***     1.0: 2023-08-21/Franz Höpfinger - HR Agrartechnik GmbH - initial implementation as E_IMPULSE
  *************************************************************************/
 
 #include "forte/iec61499/events/timers/E_PULSE_fbt.h"
 
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 
 using namespace std::literals;
 using namespace forte::literals;
 
 namespace forte::iec61499::events::timers {
   namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
     const auto cDataInputNames = std::array{"PT"_STRID};
     const auto cDataOutputNames = std::array{"Q"_STRID};
-    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
 
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
-        .mEITypeNames = cEventInputTypeIds,
+        .mEITypeNames = {},
         .mEONames = cEventOutputNames,
-        .mEOTypeNames = cEventOutputTypeIds,
+        .mEOTypeNames = {},
         .mDINames = cDataInputNames,
         .mDONames = cDataOutputNames,
         .mDIONames = {},
@@ -50,17 +49,20 @@ namespace forte::iec61499::events::timers {
     };
 
     const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
-        {{}, "REQ"_STRID, "E_DELAY"_STRID, "START"_STRID},
-        {{}, "REQ"_STRID, "E_SR"_STRID, "S"_STRID},
-        {"E_DELAY"_STRID, "EO"_STRID, "E_SR"_STRID, "R"_STRID},
-        {"E_SR"_STRID, "EO"_STRID, {}, "CNF"_STRID},
+        {{}, "REQ"_STRID, "CheckRunning"_STRID, "EI"_STRID},
+        {"CheckRunning"_STRID, "EO"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {"CheckRunning"_STRID, "EO"_STRID, "E_RS"_STRID, "S"_STRID},
+        {"E_DELAY"_STRID, "EO"_STRID, "E_RS"_STRID, "R"_STRID},
+        {"E_RS"_STRID, "EO"_STRID, {}, "CNF"_STRID},
         {{}, "R"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
-        {{}, "R"_STRID, "E_SR"_STRID, "R"_STRID},
+        {{}, "R"_STRID, "E_RS"_STRID, "R"_STRID},
     });
 
+    const auto ep_Q__NOT = std::array{"Q"_STRID, "NOT"_STRID};
     const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
         {{}, "PT"_STRID, "E_DELAY"_STRID, "DT"_STRID},
-        {"E_SR"_STRID, "Q"_STRID, {}, "Q"_STRID},
+        {"E_RS"_STRID, "Q"_STRID, {}, "Q"_STRID},
+        {"E_RS"_STRID, ep_Q__NOT, "CheckRunning"_STRID, "PERMIT"_STRID},
     });
 
     const SCFB_FBNData cFBNData = {
@@ -70,12 +72,13 @@ namespace forte::iec61499::events::timers {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_E_PULSE, "iec61499::events::timers::E_PULSE"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_E_PULSE, "iec61499::events::timers::E_PULSE"_STRID, TypeHash)
 
   FORTE_E_PULSE::FORTE_E_PULSE(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
       fb_E_DELAY("E_DELAY"_STRID, *this),
-      fb_E_SR("E_SR"_STRID, *this),
+      fb_E_RS("E_RS"_STRID, *this),
+      fb_CheckRunning("CheckRunning"_STRID, *this),
       conn_CNF(*this, 0),
       conn_PT(nullptr),
       conn_Q(*this, 0, 0_BOOL),
@@ -84,7 +87,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_PULSE::setInitialValues() {
     CCompositeFB::setInitialValues();
     conn_if2in_PT.getValue() = 0_TIME;
-    fb_E_SR->conn_Q.getValue() = 0_BOOL;
+    fb_E_RS->conn_Q.getValue() = 0_BOOL;
   }
 
   void FORTE_E_PULSE::readInputData(const TEventID paEIID) {
@@ -100,7 +103,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_PULSE::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, fb_E_SR->conn_Q.getValue(), conn_Q);
+        writeData(1, fb_E_RS->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -116,7 +119,7 @@ namespace forte::iec61499::events::timers {
 
   CIEC_ANY *FORTE_E_PULSE::getDO(const size_t paIndex) {
     switch (paIndex) {
-      case 0: return &fb_E_SR->conn_Q.getValue();
+      case 0: return &fb_E_RS->conn_Q.getValue();
     }
     return nullptr;
   }
@@ -142,7 +145,7 @@ namespace forte::iec61499::events::timers {
     return nullptr;
   }
 
-  CDataConnection *FORTE_E_PULSE::getIf2InConUnchecked(TPortId paIndex) {
+  CDataConnection *FORTE_E_PULSE::getIf2InConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
       case 0: return &conn_if2in_PT;
     }

--- a/stdfblib/events/src/timers/E_TP_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TP_fbt.cpp
@@ -6,41 +6,40 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TP
- *** Description: standard timer function block (pulse)
+ *** Description: standard timer function block (pulse) - non-retriggerable
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-04-19/Franz Höpfinger - HR Agrartechnik GmbH - Made non-retriggerable
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #include "forte/iec61499/events/timers/E_TP_fbt.h"
 
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 
 using namespace std::literals;
 using namespace forte::literals;
 
 namespace forte::iec61499::events::timers {
   namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
     const auto cDataInputNames = std::array{"IN"_STRID, "PT"_STRID};
     const auto cDataOutputNames = std::array{"Q"_STRID};
-    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
 
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
-        .mEITypeNames = cEventInputTypeIds,
+        .mEITypeNames = {},
         .mEONames = cEventOutputNames,
-        .mEOTypeNames = cEventOutputTypeIds,
+        .mEOTypeNames = {},
         .mDINames = cDataInputNames,
         .mDONames = cDataOutputNames,
         .mDIONames = {},
@@ -49,19 +48,22 @@ namespace forte::iec61499::events::timers {
     };
 
     const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
-        {"E_RS"_STRID, "EO"_STRID, {}, "CNF"_STRID},
+        {"E_SR"_STRID, "EO"_STRID, {}, "CNF"_STRID},
         {{}, "R"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
-        {{}, "R"_STRID, "E_RS"_STRID, "R"_STRID},
-        {"E_DELAY"_STRID, "EO"_STRID, "E_RS"_STRID, "R"_STRID},
-        {{}, "REQ"_STRID, "E_PERMIT"_STRID, "EI"_STRID},
-        {"E_PERMIT"_STRID, "EO"_STRID, "E_RS"_STRID, "S"_STRID},
-        {"E_PERMIT"_STRID, "EO"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {{}, "R"_STRID, "E_SR"_STRID, "R"_STRID},
+        {"E_DELAY"_STRID, "EO"_STRID, "E_SR"_STRID, "R"_STRID},
+        {"E_R_TRIG"_STRID, "EO"_STRID, "E_SR"_STRID, "S"_STRID},
+        {"E_R_TRIG"_STRID, "EO"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {{}, "REQ"_STRID, "CheckRunning"_STRID, "EI"_STRID},
+        {"CheckRunning"_STRID, "EO"_STRID, "E_R_TRIG"_STRID, "EI"_STRID},
     });
 
+    const auto ep_Q__NOT = std::array{"Q"_STRID, "NOT"_STRID};
     const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
         {{}, "PT"_STRID, "E_DELAY"_STRID, "DT"_STRID},
-        {"E_RS"_STRID, "Q"_STRID, {}, "Q"_STRID},
-        {{}, "IN"_STRID, "E_PERMIT"_STRID, "PERMIT"_STRID},
+        {"E_SR"_STRID, "Q"_STRID, {}, "Q"_STRID},
+        {{}, "IN"_STRID, "E_R_TRIG"_STRID, "QI"_STRID},
+        {"E_SR"_STRID, ep_Q__NOT, "CheckRunning"_STRID, "PERMIT"_STRID},
     });
 
     const SCFB_FBNData cFBNData = {
@@ -71,13 +73,14 @@ namespace forte::iec61499::events::timers {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_E_TP, "iec61499::events::timers::E_TP"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_E_TP, "iec61499::events::timers::E_TP"_STRID, TypeHash)
 
   FORTE_E_TP::FORTE_E_TP(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
       fb_E_DELAY("E_DELAY"_STRID, *this),
-      fb_E_RS("E_RS"_STRID, *this),
-      fb_E_PERMIT("E_PERMIT"_STRID, *this),
+      fb_E_SR("E_SR"_STRID, *this),
+      fb_E_R_TRIG("E_R_TRIG"_STRID, *this),
+      fb_CheckRunning("CheckRunning"_STRID, *this),
       conn_CNF(*this, 0),
       conn_IN(nullptr),
       conn_PT(nullptr),
@@ -89,7 +92,7 @@ namespace forte::iec61499::events::timers {
     CCompositeFB::setInitialValues();
     conn_if2in_IN.getValue() = 0_BOOL;
     conn_if2in_PT.getValue() = 0_TIME;
-    fb_E_RS->conn_Q.getValue() = 0_BOOL;
+    fb_E_SR->conn_Q.getValue() = 0_BOOL;
   }
 
   void FORTE_E_TP::readInputData(const TEventID paEIID) {
@@ -99,10 +102,6 @@ namespace forte::iec61499::events::timers {
         readData(1, conn_if2in_PT.getValue(), conn_PT);
         break;
       }
-      case scmEventRID: {
-        readData(0, conn_if2in_IN.getValue(), conn_IN);
-        break;
-      }
       default: break;
     }
   }
@@ -110,7 +109,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_TP::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, fb_E_RS->conn_Q.getValue(), conn_Q);
+        writeData(2, fb_E_SR->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -127,7 +126,7 @@ namespace forte::iec61499::events::timers {
 
   CIEC_ANY *FORTE_E_TP::getDO(const size_t paIndex) {
     switch (paIndex) {
-      case 0: return &fb_E_RS->conn_Q.getValue();
+      case 0: return &fb_E_SR->conn_Q.getValue();
     }
     return nullptr;
   }
@@ -154,7 +153,7 @@ namespace forte::iec61499::events::timers {
     return nullptr;
   }
 
-  CDataConnection *FORTE_E_TP::getIf2InConUnchecked(TPortId paIndex) {
+  CDataConnection *FORTE_E_TP::getIf2InConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
       case 0: return &conn_if2in_IN;
       case 1: return &conn_if2in_PT;


### PR DESCRIPTION
Refactor E_PULSE and E_TP blocks to make them non-retriggerable.

https://github.com/eclipse-4diac/4diac-ide/pull/2400
