### PR TITLE
Fix: Extract unique_ptr deleter to named struct

### DIFF
--- a/core/arch/freeRTOS/include/forte/arch/forte_thread.h
+++ b/core/arch/freeRTOS/include/forte/arch/forte_thread.h
@@ -103,7 +103,15 @@ namespace forte::arch {
       static const int scmForteTaskPriority;
 
       std::vector<StackType_t> mFreeRTOSStack;
-      std::unique_ptr<StaticTask_t, decltype([](StaticTask_t *paTask) { vPortFree(paTask); })> mTask;
+
+      // use a functor instead a lambda, to avoid a "internal linkage warning" at compile-time.
+      struct STCBDeleter {
+          void operator()(StaticTask_t *paTask) const {
+            vPortFree(paTask);
+          }
+      };
+
+      std::unique_ptr<StaticTask_t, STCBDeleter> mTask;
       TaskHandle_t mFreeRTOSThreadHandle = nullptr;
   };
 


### PR DESCRIPTION
Replaces an inline lambda deleter with a named struct `STCBDeleter` for the `mTask` unique_ptr. This avoids a Compiler Warning about internal linking.

https://github.com/eclipse-4diac/4diac-forte/pull/863

this fixes this Warning: 

```
/home/franz/git/hr/LOGIBUS_integration_datapanel/4diac-forte/core/arch/freeRTOS/include/forte/arch/forte_thread.h:48:9: warning: 'forte::arch::CFreeRTOSThread' has a field 'std::unique_ptr<xSTATIC_TCB, forte::arch::CFreeRTOSThread::<lambda(StaticTask_t*)> > forte::arch::CFreeRTOSThread::mTask' whose type has internal linkage [-Wsubobject-linkage]
   48 |   class CFreeRTOSThread : public CThreadBase<TaskHandle_t> {
      |         ^~~~~~~~~~~~~~~
```
