### PR TITLE
Replace E_PERMIT with E_R_TRIG in E_TP timer function block

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TP_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TP_fbt.h
@@ -6,14 +6,17 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TP
  *** Description: standard timer function block (pulse)
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-05-13/Franz Höpfinger - HR Agrartechnik GmbH - E_R_TRIG instead of E_PERMIT
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #pragma once
@@ -22,32 +25,27 @@
 #include "forte/typelib.h"
 #include "forte/datatypes/forte_bool.h"
 #include "forte/datatypes/forte_time.h"
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
 #include "forte/iec61499/events/E_RS_fbt.h"
-#include "forte/iec61499/events/E_PERMIT_fbt.h"
+#include "forte/iec61499/events/E_R_TRIG_fbt.h"
 
 namespace forte::iec61499::events::timers {
   class FORTE_E_TP final : public CCompositeFB {
       DECLARE_FIRMWARE_FB(FORTE_E_TP)
 
     private:
+      static const TEventID scmEventCNFID = 0;
       static const TEventID scmEventREQID = 0;
       static const TEventID scmEventRID = 1;
-      static const TEventID scmEventCNFID = 0;
 
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
       CInternalFB<forte::iec61499::events::FORTE_E_RS> fb_E_RS;
-      CInternalFB<forte::iec61499::events::FORTE_E_PERMIT> fb_E_PERMIT;
+      CInternalFB<forte::iec61499::events::FORTE_E_R_TRIG> fb_E_R_TRIG;
 
       void readInputData(TEventID paEIID) override;
       void writeOutputData(TEventID paEIID) override;
       void setInitialValues() override;
-      CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
     public:
       FORTE_E_TP(StringId paInstanceNameId, CFBContainer &paContainer);
@@ -67,5 +65,6 @@ namespace forte::iec61499::events::timers {
       CEventConnection *getEOConUnchecked(TPortId) override;
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
   };
 } // namespace forte::iec61499::events::timers

--- a/stdfblib/events/src/timers/E_TP_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TP_fbt.cpp
@@ -6,41 +6,40 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
  ***
  *** Name: E_TP
  *** Description: standard timer function block (pulse)
  *** Version:
- ***     1.0: 2024-03-04/Franz Hoepfinger - HR Agrartechnik GmbH -
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-05-13/Franz Höpfinger - HR Agrartechnik GmbH - E_R_TRIG instead of E_PERMIT
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #include "forte/iec61499/events/timers/E_TP_fbt.h"
 
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 
 using namespace std::literals;
 using namespace forte::literals;
 
 namespace forte::iec61499::events::timers {
   namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
     const auto cDataInputNames = std::array{"IN"_STRID, "PT"_STRID};
     const auto cDataOutputNames = std::array{"Q"_STRID};
-    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
 
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
-        .mEITypeNames = cEventInputTypeIds,
+        .mEITypeNames = {},
         .mEONames = cEventOutputNames,
-        .mEOTypeNames = cEventOutputTypeIds,
+        .mEOTypeNames = {},
         .mDINames = cDataInputNames,
         .mDONames = cDataOutputNames,
         .mDIONames = {},
@@ -53,15 +52,15 @@ namespace forte::iec61499::events::timers {
         {{}, "R"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
         {{}, "R"_STRID, "E_RS"_STRID, "R"_STRID},
         {"E_DELAY"_STRID, "EO"_STRID, "E_RS"_STRID, "R"_STRID},
-        {{}, "REQ"_STRID, "E_PERMIT"_STRID, "EI"_STRID},
-        {"E_PERMIT"_STRID, "EO"_STRID, "E_RS"_STRID, "S"_STRID},
-        {"E_PERMIT"_STRID, "EO"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {{}, "REQ"_STRID, "E_R_TRIG"_STRID, "EI"_STRID},
+        {"E_R_TRIG"_STRID, "EO"_STRID, "E_RS"_STRID, "S"_STRID},
+        {"E_R_TRIG"_STRID, "EO"_STRID, "E_DELAY"_STRID, "START"_STRID},
     });
 
     const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
         {{}, "PT"_STRID, "E_DELAY"_STRID, "DT"_STRID},
         {"E_RS"_STRID, "Q"_STRID, {}, "Q"_STRID},
-        {{}, "IN"_STRID, "E_PERMIT"_STRID, "PERMIT"_STRID},
+        {{}, "IN"_STRID, "E_R_TRIG"_STRID, "QI"_STRID},
     });
 
     const SCFB_FBNData cFBNData = {
@@ -71,13 +70,13 @@ namespace forte::iec61499::events::timers {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_E_TP, "iec61499::events::timers::E_TP"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_E_TP, "iec61499::events::timers::E_TP"_STRID, TypeHash)
 
   FORTE_E_TP::FORTE_E_TP(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
       fb_E_DELAY("E_DELAY"_STRID, *this),
       fb_E_RS("E_RS"_STRID, *this),
-      fb_E_PERMIT("E_PERMIT"_STRID, *this),
+      fb_E_R_TRIG("E_R_TRIG"_STRID, *this),
       conn_CNF(*this, 0),
       conn_IN(nullptr),
       conn_PT(nullptr),
@@ -110,7 +109,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_TP::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, fb_E_RS->conn_Q.getValue(), conn_Q);
+        writeData(2, fb_E_RS->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -154,7 +153,7 @@ namespace forte::iec61499::events::timers {
     return nullptr;
   }
 
-  CDataConnection *FORTE_E_TP::getIf2InConUnchecked(TPortId paIndex) {
+  CDataConnection *FORTE_E_TP::getIf2InConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
       case 0: return &conn_if2in_IN;
       case 1: return &conn_if2in_PT;


### PR DESCRIPTION
Update the internal logic of the E_TP pulse timer to use E_R_TRIG for rising edge detection. This replaces E_PERMIT, ensuring more precise triggering of the timer's internal state.

https://github.com/eclipse-4diac/4diac-ide/pull/2455
