### PR TITLE
Add E_TMIN and time-constrained D flip-flop event FBs

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
+++ b/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
@@ -54,5 +54,8 @@ target_sources(forte-events PUBLIC
         GEN_E_REND_fbt.h
         GEN_E_SPLIT_fbt.h
         timedfb.h
+        E_TMIN_fbt.h
+	E_D_FF_TMIN_fbt.h
+	E_D_FF_ANY_TMIN_fbt.h
 )
 add_subdirectory(timers)

--- a/stdfblib/events/include/forte/iec61499/events/E_D_FF_ANY_TMIN_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_D_FF_ANY_TMIN_fbt.h
@@ -1,0 +1,67 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_D_FF_ANY_TMIN
+ *** Description: Data latch (d) flip flop, with a Minimum inter-disposal Time between EO
+ *** Version:
+ ***     1.0: 2026-05-14/Franz Höpfinger - HR Agrartechnik GmbH - Inital API
+ *************************************************************************/
+
+#pragma once
+
+#include "forte/cfb.h"
+#include "forte/typelib.h"
+#include "forte/datatypes/forte_any_variant.h"
+#include "forte/datatypes/forte_time.h"
+#include "forte/forte_st_util.h"
+#include "forte/iec61499/events/E_D_FF_ANY_fbt.h"
+#include "forte/iec61499/events/E_TMIN_fbt.h"
+
+namespace forte::iec61499::events {
+  class FORTE_E_D_FF_ANY_TMIN final : public CCompositeFB {
+      DECLARE_FIRMWARE_FB(FORTE_E_D_FF_ANY_TMIN)
+
+    private:
+      static const TEventID scmEventINITOID = 0;
+      static const TEventID scmEventEOID = 1;
+      static const TEventID scmEventINITID = 0;
+      static const TEventID scmEventCLKID = 1;
+
+      CInternalFB<forte::iec61499::events::FORTE_E_D_FF_ANY> fb_E_D_FF_ANY;
+      CInternalFB<forte::iec61499::events::FORTE_E_TMIN> fb_E_TMIN;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    public:
+      FORTE_E_D_FF_ANY_TMIN(StringId paInstanceNameId, CFBContainer &paContainer);
+
+      CEventConnection conn_INITO;
+      CEventConnection conn_EO;
+
+      CDataConnection *conn_D;
+      CDataConnection *conn_Tmin;
+
+      COutDataConnection<CIEC_ANY_VARIANT> conn_Q;
+
+      COutDataConnection<CIEC_ANY_VARIANT> conn_if2in_D;
+      COutDataConnection<CIEC_TIME> conn_if2in_Tmin;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
+  };
+} // namespace forte::iec61499::events

--- a/stdfblib/events/include/forte/iec61499/events/E_D_FF_TMIN_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_D_FF_TMIN_fbt.h
@@ -1,0 +1,67 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_D_FF_TMIN
+ *** Description: Data latch (d) flip flop, with a Minimum inter-disposal Time between EO
+ *** Version:
+ ***     1.0: 2026-05-14/Franz Höpfinger - HR Agrartechnik GmbH - Inital API
+ *************************************************************************/
+
+#pragma once
+
+#include "forte/cfb.h"
+#include "forte/typelib.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_time.h"
+#include "forte/forte_st_util.h"
+#include "forte/iec61499/events/E_D_FF_fbt.h"
+#include "forte/iec61499/events/E_TMIN_fbt.h"
+
+namespace forte::iec61499::events {
+  class FORTE_E_D_FF_TMIN final : public CCompositeFB {
+      DECLARE_FIRMWARE_FB(FORTE_E_D_FF_TMIN)
+
+    private:
+      static const TEventID scmEventINITOID = 0;
+      static const TEventID scmEventEOID = 1;
+      static const TEventID scmEventINITID = 0;
+      static const TEventID scmEventCLKID = 1;
+
+      CInternalFB<forte::iec61499::events::FORTE_E_D_FF> fb_E_D_FF;
+      CInternalFB<forte::iec61499::events::FORTE_E_TMIN> fb_E_TMIN;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    public:
+      FORTE_E_D_FF_TMIN(StringId paInstanceNameId, CFBContainer &paContainer);
+
+      CEventConnection conn_INITO;
+      CEventConnection conn_EO;
+
+      CDataConnection *conn_D;
+      CDataConnection *conn_Tmin;
+
+      COutDataConnection<CIEC_BOOL> conn_Q;
+
+      COutDataConnection<CIEC_BOOL> conn_if2in_D;
+      COutDataConnection<CIEC_TIME> conn_if2in_Tmin;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
+  };
+} // namespace forte::iec61499::events

--- a/stdfblib/events/include/forte/iec61499/events/E_TMIN_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/E_TMIN_fbt.h
@@ -1,0 +1,61 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_TMIN
+ *** Description: Forwards Events with a minimum inter-arrival time between EI events
+ *** Version:
+ ***     1.0: 2026-05-14/Franz Höpfinger - HR Agrartechnik GmbH - Initial API
+ *************************************************************************/
+
+#pragma once
+
+#include "forte/cfb.h"
+#include "forte/typelib.h"
+#include "forte/datatypes/forte_time.h"
+#include "forte/iec61499/events/E_DELAY_fbt.h"
+#include "forte/iec61499/events/E_REND_fbt.h"
+
+namespace forte::iec61499::events {
+  class FORTE_E_TMIN final : public CCompositeFB {
+      DECLARE_FIRMWARE_FB(FORTE_E_TMIN)
+
+    private:
+      static const TEventID scmEventINITOID = 0;
+      static const TEventID scmEventEOID = 1;
+      static const TEventID scmEventINITID = 0;
+      static const TEventID scmEventEIID = 1;
+
+      CInternalFB<forte::iec61499::events::FORTE_E_REND> fb_E_REND;
+      CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    public:
+      FORTE_E_TMIN(StringId paInstanceNameId, CFBContainer &paContainer);
+
+      CEventConnection conn_INITO;
+      CEventConnection conn_EO;
+
+      CDataConnection *conn_Tmin;
+
+      COutDataConnection<CIEC_TIME> conn_if2in_Tmin;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
+  };
+} // namespace forte::iec61499::events

--- a/stdfblib/events/src/CMakeLists.txt
+++ b/stdfblib/events/src/CMakeLists.txt
@@ -52,6 +52,9 @@ target_sources(forte-events PRIVATE
         GEN_E_REND_fbt.cpp
         GEN_E_SPLIT_fbt.cpp
         timedfb.cpp
+        E_TMIN_fbt.cpp
+	E_D_FF_TMIN_fbt.cpp
+	E_D_FF_ANY_TMIN_fbt.cpp
 )
 
 add_subdirectory(timers)

--- a/stdfblib/events/src/E_D_FF_ANY_TMIN_fbt.cpp
+++ b/stdfblib/events/src/E_D_FF_ANY_TMIN_fbt.cpp
@@ -1,0 +1,161 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_D_FF_ANY_TMIN
+ *** Description: Data latch (d) flip flop, with a Minimum inter-disposal Time between EO
+ *** Version:
+ ***     1.0: 2026-05-14/Franz Höpfinger - HR Agrartechnik GmbH - Inital API
+ *************************************************************************/
+
+#include "forte/iec61499/events/E_D_FF_ANY_TMIN_fbt.h"
+
+#include "forte/forte_st_util.h"
+
+using namespace std::literals;
+using namespace forte::literals;
+
+namespace forte::iec61499::events {
+  namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"INIT"_STRID, "CLK"_STRID};
+    const auto cEventInputTypeIds = std::array{"EInit"_STRID, "Event"_STRID};
+    const auto cEventOutputNames = std::array{"INITO"_STRID, "EO"_STRID};
+    const auto cEventOutputTypeIds = std::array{"EInit"_STRID, "Event"_STRID};
+    const auto cDataInputNames = std::array{"D"_STRID, "Tmin"_STRID};
+    const auto cDataOutputNames = std::array{"Q"_STRID};
+
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = cEventInputTypeIds,
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = cEventOutputTypeIds,
+        .mDINames = cDataInputNames,
+        .mDONames = cDataOutputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
+        {{}, "CLK"_STRID, "E_D_FF_ANY"_STRID, "CLK"_STRID},
+        {{}, "INIT"_STRID, "E_TMIN"_STRID, "INIT"_STRID},
+        {"E_TMIN"_STRID, "INITO"_STRID, {}, "INITO"_STRID},
+        {"E_TMIN"_STRID, "EO"_STRID, {}, "EO"_STRID},
+        {"E_D_FF_ANY"_STRID, "EO"_STRID, "E_TMIN"_STRID, "EI"_STRID},
+    });
+
+    const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
+        {"E_D_FF_ANY"_STRID, "Q"_STRID, {}, "Q"_STRID},
+        {{}, "D"_STRID, "E_D_FF_ANY"_STRID, "D"_STRID},
+        {{}, "Tmin"_STRID, "E_TMIN"_STRID, "Tmin"_STRID},
+    });
+
+    const SCFB_FBNData cFBNData = {
+        .mEventConnections = cEventConnections,
+        .mDataConnections = cDataConnections,
+        .mAdapterConnections = {},
+    };
+  } // namespace
+
+  DEFINE_FIRMWARE_FB(FORTE_E_D_FF_ANY_TMIN, "iec61499::events::E_D_FF_ANY_TMIN"_STRID, TypeHash)
+
+  FORTE_E_D_FF_ANY_TMIN::FORTE_E_D_FF_ANY_TMIN(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
+      fb_E_D_FF_ANY("E_D_FF_ANY"_STRID, *this),
+      fb_E_TMIN("E_TMIN"_STRID, *this),
+      conn_INITO(*this, 0),
+      conn_EO(*this, 1),
+      conn_D(nullptr),
+      conn_Tmin(nullptr),
+      conn_Q(*this, 0, CIEC_ANY_VARIANT()),
+      conn_if2in_D(*this, 0, CIEC_ANY_VARIANT()),
+      conn_if2in_Tmin(*this, 1, 0_TIME) {};
+
+  void FORTE_E_D_FF_ANY_TMIN::setInitialValues() {
+    CCompositeFB::setInitialValues();
+    conn_if2in_D.getValue() = CIEC_ANY_VARIANT();
+    conn_if2in_Tmin.getValue() = 0_TIME;
+    fb_E_D_FF_ANY->conn_Q.getValue() = CIEC_ANY_VARIANT();
+  }
+
+  void FORTE_E_D_FF_ANY_TMIN::readInputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventINITID: {
+        readData(1, conn_if2in_Tmin.getValue(), conn_Tmin);
+        break;
+      }
+      case scmEventCLKID: {
+        readData(0, conn_if2in_D.getValue(), conn_D);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  void FORTE_E_D_FF_ANY_TMIN::writeOutputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventEOID: {
+        writeData(2, fb_E_D_FF_ANY->conn_Q.getValue(), conn_Q);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_E_D_FF_ANY_TMIN::getDI(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_D.getValue();
+      case 1: return &conn_if2in_Tmin.getValue();
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_E_D_FF_ANY_TMIN::getDO(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &fb_E_D_FF_ANY->conn_Q.getValue();
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_E_D_FF_ANY_TMIN::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_INITO;
+      case 1: return &conn_EO;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_E_D_FF_ANY_TMIN::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_D;
+      case 1: return &conn_Tmin;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_D_FF_ANY_TMIN::getDOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_Q;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_D_FF_ANY_TMIN::getIf2InConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_D;
+      case 1: return &conn_if2in_Tmin;
+    }
+    return nullptr;
+  }
+
+} // namespace forte::iec61499::events

--- a/stdfblib/events/src/E_D_FF_TMIN_fbt.cpp
+++ b/stdfblib/events/src/E_D_FF_TMIN_fbt.cpp
@@ -1,0 +1,161 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_D_FF_TMIN
+ *** Description: Data latch (d) flip flop, with a Minimum inter-disposal Time between EO
+ *** Version:
+ ***     1.0: 2026-05-14/Franz Höpfinger - HR Agrartechnik GmbH - Inital API
+ *************************************************************************/
+
+#include "forte/iec61499/events/E_D_FF_TMIN_fbt.h"
+
+#include "forte/forte_st_util.h"
+
+using namespace std::literals;
+using namespace forte::literals;
+
+namespace forte::iec61499::events {
+  namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"INIT"_STRID, "CLK"_STRID};
+    const auto cEventInputTypeIds = std::array{"EInit"_STRID, "Event"_STRID};
+    const auto cEventOutputNames = std::array{"INITO"_STRID, "EO"_STRID};
+    const auto cEventOutputTypeIds = std::array{"EInit"_STRID, "Event"_STRID};
+    const auto cDataInputNames = std::array{"D"_STRID, "Tmin"_STRID};
+    const auto cDataOutputNames = std::array{"Q"_STRID};
+
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = cEventInputTypeIds,
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = cEventOutputTypeIds,
+        .mDINames = cDataInputNames,
+        .mDONames = cDataOutputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
+        {{}, "CLK"_STRID, "E_D_FF"_STRID, "CLK"_STRID},
+        {{}, "INIT"_STRID, "E_TMIN"_STRID, "INIT"_STRID},
+        {"E_TMIN"_STRID, "INITO"_STRID, {}, "INITO"_STRID},
+        {"E_D_FF"_STRID, "EO"_STRID, "E_TMIN"_STRID, "EI"_STRID},
+        {"E_TMIN"_STRID, "EO"_STRID, {}, "EO"_STRID},
+    });
+
+    const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
+        {"E_D_FF"_STRID, "Q"_STRID, {}, "Q"_STRID},
+        {{}, "D"_STRID, "E_D_FF"_STRID, "D"_STRID},
+        {{}, "Tmin"_STRID, "E_TMIN"_STRID, "Tmin"_STRID},
+    });
+
+    const SCFB_FBNData cFBNData = {
+        .mEventConnections = cEventConnections,
+        .mDataConnections = cDataConnections,
+        .mAdapterConnections = {},
+    };
+  } // namespace
+
+  DEFINE_FIRMWARE_FB(FORTE_E_D_FF_TMIN, "iec61499::events::E_D_FF_TMIN"_STRID, TypeHash)
+
+  FORTE_E_D_FF_TMIN::FORTE_E_D_FF_TMIN(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
+      fb_E_D_FF("E_D_FF"_STRID, *this),
+      fb_E_TMIN("E_TMIN"_STRID, *this),
+      conn_INITO(*this, 0),
+      conn_EO(*this, 1),
+      conn_D(nullptr),
+      conn_Tmin(nullptr),
+      conn_Q(*this, 0, 0_BOOL),
+      conn_if2in_D(*this, 0, 0_BOOL),
+      conn_if2in_Tmin(*this, 1, 0_TIME) {};
+
+  void FORTE_E_D_FF_TMIN::setInitialValues() {
+    CCompositeFB::setInitialValues();
+    conn_if2in_D.getValue() = 0_BOOL;
+    conn_if2in_Tmin.getValue() = 0_TIME;
+    fb_E_D_FF->conn_Q.getValue() = 0_BOOL;
+  }
+
+  void FORTE_E_D_FF_TMIN::readInputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventINITID: {
+        readData(1, conn_if2in_Tmin.getValue(), conn_Tmin);
+        break;
+      }
+      case scmEventCLKID: {
+        readData(0, conn_if2in_D.getValue(), conn_D);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  void FORTE_E_D_FF_TMIN::writeOutputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventEOID: {
+        writeData(2, fb_E_D_FF->conn_Q.getValue(), conn_Q);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_E_D_FF_TMIN::getDI(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_D.getValue();
+      case 1: return &conn_if2in_Tmin.getValue();
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_E_D_FF_TMIN::getDO(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &fb_E_D_FF->conn_Q.getValue();
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_E_D_FF_TMIN::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_INITO;
+      case 1: return &conn_EO;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_E_D_FF_TMIN::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_D;
+      case 1: return &conn_Tmin;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_D_FF_TMIN::getDOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_Q;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_D_FF_TMIN::getIf2InConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_D;
+      case 1: return &conn_if2in_Tmin;
+    }
+    return nullptr;
+  }
+
+} // namespace forte::iec61499::events

--- a/stdfblib/events/src/E_TMIN_fbt.cpp
+++ b/stdfblib/events/src/E_TMIN_fbt.cpp
@@ -1,0 +1,133 @@
+/*************************************************************************
+ *** Copyright (c) 2026 HR Agrartechnik GmbH
+ *** This program and the accompanying materials are made available under the
+ *** terms of the Eclipse Public License 2.0 which is available at
+ *** http://www.eclipse.org/legal/epl-2.0.
+ ***
+ *** SPDX-License-Identifier: EPL-2.0
+ ***
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ ***
+ *** Name: E_TMIN
+ *** Description: Forwards Events with a minimum inter-arrival time between EI events
+ *** Version:
+ ***     1.0: 2026-05-14/Franz Höpfinger - HR Agrartechnik GmbH - Initial API
+ *************************************************************************/
+
+#include "forte/iec61499/events/E_TMIN_fbt.h"
+
+using namespace std::literals;
+using namespace forte::literals;
+
+namespace forte::iec61499::events {
+  namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"INIT"_STRID, "EI"_STRID};
+    const auto cEventInputTypeIds = std::array{"EInit"_STRID, "Event"_STRID};
+    const auto cEventOutputNames = std::array{"INITO"_STRID, "EO"_STRID};
+    const auto cEventOutputTypeIds = std::array{"EInit"_STRID, "Event"_STRID};
+    const auto cDataInputNames = std::array{"Tmin"_STRID};
+
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = cEventInputTypeIds,
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = cEventOutputTypeIds,
+        .mDINames = cDataInputNames,
+        .mDONames = {},
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
+        {"E_DELAY"_STRID, "EO"_STRID, "E_REND"_STRID, "EI2"_STRID},
+        {"E_REND"_STRID, "EO"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {{}, "INIT"_STRID, {}, "INITO"_STRID},
+        {{}, "INIT"_STRID, "E_REND"_STRID, "EI2"_STRID},
+        {{}, "EI"_STRID, "E_REND"_STRID, "EI1"_STRID},
+        {"E_REND"_STRID, "EO"_STRID, {}, "EO"_STRID},
+    });
+
+    const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
+        {{}, "Tmin"_STRID, "E_DELAY"_STRID, "DT"_STRID},
+    });
+
+    const SCFB_FBNData cFBNData = {
+        .mEventConnections = cEventConnections,
+        .mDataConnections = cDataConnections,
+        .mAdapterConnections = {},
+    };
+  } // namespace
+
+  DEFINE_FIRMWARE_FB(FORTE_E_TMIN, "iec61499::events::E_TMIN"_STRID, TypeHash)
+
+  FORTE_E_TMIN::FORTE_E_TMIN(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
+      fb_E_REND("E_REND"_STRID, *this),
+      fb_E_DELAY("E_DELAY"_STRID, *this),
+      conn_INITO(*this, 0),
+      conn_EO(*this, 1),
+      conn_Tmin(nullptr),
+      conn_if2in_Tmin(*this, 0, 0_TIME) {};
+
+  void FORTE_E_TMIN::setInitialValues() {
+    CCompositeFB::setInitialValues();
+    conn_if2in_Tmin.getValue() = 0_TIME;
+  }
+
+  void FORTE_E_TMIN::readInputData(const TEventID paEIID) {
+    switch (paEIID) {
+      case scmEventINITID: {
+        readData(0, conn_if2in_Tmin.getValue(), conn_Tmin);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  void FORTE_E_TMIN::writeOutputData(TEventID) {
+    // nothing to do
+  }
+
+  CIEC_ANY *FORTE_E_TMIN::getDI(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_Tmin.getValue();
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_E_TMIN::getDO(size_t) {
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_E_TMIN::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_INITO;
+      case 1: return &conn_EO;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_E_TMIN::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_Tmin;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_TMIN::getDOConUnchecked(TPortId) {
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_E_TMIN::getIf2InConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_if2in_Tmin;
+    }
+    return nullptr;
+  }
+
+} // namespace forte::iec61499::events


### PR DESCRIPTION
Introduce new function blocks for event timing control:
- E_TMIN: Forwards events with a minimum inter-arrival time.
- E_D_FF_TMIN: A D flip-flop with minimum inter-disposal time for boolean outputs.
- E_D_FF_ANY_TMIN: A D flip-flop with minimum inter-disposal time for ANY_VARIANT outputs.

These blocks enable debouncing and rate limiting of events and data latches.

https://github.com/eclipse-4diac/4diac-ide/pull/2460
