### PR TITLE
Added CodeQL Actions Analyzis Workflow

### DIFF
--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,52 @@
+################################################################################
+# Copyright (c) 2026 Johannes Kepler University Linz
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Alois Zoitl - initial API and implementation and/or initial documentation
+################################################################################
+name: CodeQL Action Analysis
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze Actions
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: actions
+        build-mode: none
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:actions"
+


### PR DESCRIPTION
Workflow updates need to be on release branch (i.e. Github default branch for 4diac FORTE) to be used for all branches.