### PR TITLE
Fix: Correct data type in DWORD splitting function

### DIFF
--- a/modules/utils/src/eclipse4diac/utils/splitting/SPLIT_DWORD_INTO_WORDS_fct.cpp
+++ b/modules/utils/src/eclipse4diac/utils/splitting/SPLIT_DWORD_INTO_WORDS_fct.cpp
@@ -137,6 +137,6 @@ namespace forte::eclipse4diac::utils::splitting {
 #line 13 "SPLIT_DWORD_INTO_WORDS.fct"
     st_lv_WORD_00 = st_lv_IN.cpartial<CIEC_WORD>(0);
 #line 14 "SPLIT_DWORD_INTO_WORDS.fct"
-    st_lv_WORD_01 = st_lv_IN.cpartial<CIEC_BOOL>(1);
+    st_lv_WORD_01 = st_lv_IN.cpartial<CIEC_WORD>(1);
   }
 } // namespace forte::eclipse4diac::utils::splitting


### PR DESCRIPTION
Change the data type for the second word extraction from CIEC_BOOL to CIEC_WORD to ensure correct data representation in the DWORD splitting process.

https://github.com/eclipse-4diac/4diac-ide/pull/2476
