### PR TITLE
Fix incorrect parameter type in getErrorMessage for Win32 socket interface

### DIFF
--- a/core/arch/win32/src/win32socketinterf.cpp
+++ b/core/arch/win32/src/win32socketinterf.cpp
@@ -26,7 +26,8 @@ namespace forte::arch {
     LPSTR getErrorMessage(int paErrorNumber) {
       LPSTR pacErrorMessage = nullptr;
       FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                    nullptr, paErrorNumber, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), pacErrorMessage, 0, nullptr);
+                    nullptr, paErrorNumber, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) &pacErrorMessage, 0,
+                    nullptr);
       return pacErrorMessage;
     }
 


### PR DESCRIPTION
Corrects the parameter type for FormatMessage to ensure proper allocation of the error message buffer on Win32 systems.