### PR TITLE
Fix memory leaks by avoiding unnecessary dynamic allocations

### DIFF
--- a/core/src/fbcontainer.cpp
+++ b/core/src/fbcontainer.cpp
@@ -63,8 +63,11 @@ namespace forte {
   }
 
   CFBContainer::~CFBContainer() {
-    for (TFBContainerList::iterator itRunner(mChildren.begin()); itRunner != mChildren.end(); ++itRunner) {
-      delete (*itRunner);
+    for (auto *child : mChildren) {
+      child->deinitialize();
+    }
+    for (auto *child : mChildren) {
+      delete child;
     }
     mChildren.clear();
   }

--- a/core/src/typelib.cpp
+++ b/core/src/typelib.cpp
@@ -29,23 +29,23 @@ using namespace std::string_literals;
 namespace forte {
   namespace {
     std::vector<CFBTypeEntry *> &getFBTypeLib() {
-      static std::vector<CFBTypeEntry *> *fbTypeLib = new std::vector<CFBTypeEntry *>();
-      return *fbTypeLib;
+      static std::vector<CFBTypeEntry *> fbTypeLib;
+      return fbTypeLib;
     }
 
     std::vector<CAdapterTypeEntry *> &getAdapterTypeLib() {
-      static std::vector<CAdapterTypeEntry *> *adapterTypeLib = new std::vector<CAdapterTypeEntry *>();
-      return *adapterTypeLib;
+      static std::vector<CAdapterTypeEntry *> adapterTypeLib;
+      return adapterTypeLib;
     }
 
     std::vector<CDataTypeEntry *> &getDataTypeLib() {
-      static std::vector<CDataTypeEntry *> *dataTypeLib = new std::vector<CDataTypeEntry *>();
-      return *dataTypeLib;
+      static std::vector<CDataTypeEntry *> dataTypeLib;
+      return dataTypeLib;
     }
 
     std::vector<CGlobalConstEntry *> &getGlobalConstTypeLib() {
-      static std::vector<CGlobalConstEntry *> *globalConstTypeLib = new std::vector<CGlobalConstEntry *>();
-      return *globalConstTypeLib;
+      static std::vector<CGlobalConstEntry *> globalConstTypeLib;
+      return globalConstTypeLib;
     }
 
     CFunctionBlock *createGenericFB(StringId paInstanceNameId,


### PR DESCRIPTION
Replaced dynamic allocation of type libraries with static allocation to prevent memory leaks. Modified destruction process in CFBContainer to properly deinitialize children before deletion.

This should fix thefrequent  "Detected memory leaks!" Error in the Test Pipeline. 