### PR TITLE
Fix buffer overflow in FBDK ASN1 layer

### DIFF
--- a/core/src/cominfra/fbdkasn1layer.cpp
+++ b/core/src/cominfra/fbdkasn1layer.cpp
@@ -106,12 +106,11 @@ namespace forte::com_infra {
 
     if (mBottomLayer != nullptr) {
       const CIEC_ANY **apoSDs = static_cast<const CIEC_ANY **>(paData);
-      size_t unNeededBufferSize = 0;
+      size_t unNeededBufferSize = paSize ? 0 : 1; // ensure enough space for Null tag
 
       if (nullptr == apoSDs) {
         return e_ProcessDataDataTypeError;
       }
-
       for (size_t i = 0; i < paSize; ++i) {
         unNeededBufferSize += getRequiredSerializationSize(*apoSDs[i]);
       }
@@ -269,8 +268,10 @@ namespace forte::com_infra {
                                                  size_t paDataNum) {
     int nRetVal = -1;
     if (0 == paDataNum) {
-      serializeNull(paBytes);
-      nRetVal = 1;
+      if (paStreamSize > 0) {
+        serializeNull(paBytes);
+        nRetVal = 1;
+      }
     } else {
       if (paStreamSize > std::numeric_limits<int>::max()) {
         DEVLOG_ERROR("FBDK ASN1 Layer: paStreamSize too big!\n");


### PR DESCRIPTION
The `sendData` function did not reserve enough space for the *Null* tag in case there was no data to send. This ensures enough space for the *Null* tag and also adds a capacity check in `serializeDataPointArray`.