### PR TITLE
Fix out-of-bounds array access in COPC_UA_Local_Handler

### DIFF
--- a/com/opc_ua/src/opcua_local_handler.cpp
+++ b/com/opc_ua/src/opcua_local_handler.cpp
@@ -718,13 +718,8 @@ namespace forte::com_infra::opc_ua {
         UA_NodeId parent = UA_NODEID_NUMERIC(0, UA_NS0ID_ROOTFOLDER);
 
         // look for parent object
-        for (auto itPresentNodes = presentNodes.begin(); itPresentNodes != presentNodes.end();) {
-          auto currentIterator = itPresentNodes;
-          ++itPresentNodes;
-          if (*itPresentNodes == presentNodes.back()) {
-            parent = **currentIterator;
-            break;
-          }
+        if (presentNodes.size() > 1) {
+          parent = *presentNodes[presentNodes.size() - 2];
         }
 
         retVal = handleExistingMethod(paActionInfo, parent);


### PR DESCRIPTION
The parent lookup in `COPC_UA_Local_Handler::initializeCreateMethod` did read beyond the end of `presentNodes` when comparing elements to look for the parent. This simplifies the code to use simple index-based access.