### PR TITLE
Fix memory leak in OPC UA logger

### DIFF
--- a/com/opc_ua/src/opcua_client_information.cpp
+++ b/com/opc_ua/src/opcua_client_information.cpp
@@ -55,41 +55,44 @@ namespace forte::com_infra::opc_ua {
   }
 
   bool CUA_ClientInformation::configureClient() {
-    bool retVal = true;
-    mClient = UA_Client_new();
-    UA_ClientConfig *configPointer = UA_Client_getConfig(mClient);
+    UA_ClientConfig config{
+        .logging = &COPC_UA_HandlerAbstract::getLogger(),
+        .stateCallback = CUA_RemoteCallbackFunctions::clientStateChangeCallback,
+    };
 
-    if (configureClientFromFile(*configPointer)) {
-      configPointer->stateCallback = CUA_RemoteCallbackFunctions::clientStateChangeCallback;
-      configPointer->logging = &COPC_UA_HandlerAbstract::getLogger();
-      configPointer->timeout = scmClientTimeoutInMilli;
-    } else {
-      UA_Client_delete(mClient);
-      mClient = nullptr;
-      retVal = false;
+    // set default config
+    if (const UA_StatusCode status = UA_ClientConfig_setDefault(&config); status != UA_STATUSCODE_GOOD) {
+      DEVLOG_ERROR("[OPC UA CLIENT]: Error setting client configuration. Error: %s\n", UA_StatusCode_name(status));
+      return false;
     }
-    return retVal;
+
+    // override defaults
+    config.timeout = scmClientTimeoutInMilli;
+
+    // load configuration from file
+    if (!configureClientFromFile(config)) {
+      UA_ClientConfig_clear(&config);
+      return false;
+    }
+
+    mClient = UA_Client_newWithConfig(&config);
+    if (!mClient) {
+      UA_ClientConfig_clear(&config);
+      return false;
+    }
+    return true;
   }
 
   bool CUA_ClientInformation::configureClientFromFile(UA_ClientConfig &paConfig) {
-    bool retVal = true;
-
-    if (!gOpcuaClientConfigFile.mArgument.empty()) { // file was provided
-      std::string endpoint = mEndpointUrl;
-      CUA_ClientConfigFileParser::UA_ConfigFromFile result =
-          CUA_ClientConfigFileParser::UA_ConfigFromFile(paConfig, mUsername, mPassword);
-
-      retVal = CUA_ClientConfigFileParser::loadConfig(gOpcuaClientConfigFile.mArgument, endpoint, result);
-    } else {
-      UA_StatusCode retValOpcUa = UA_ClientConfig_setDefault(&paConfig);
-      if (UA_STATUSCODE_GOOD != retValOpcUa) {
-        DEVLOG_ERROR("[OPC UA CLIENT]: Error setting client configuration. Error: %s\n",
-                     UA_StatusCode_name(retValOpcUa));
-        retVal = false;
-      }
+    if (gOpcuaClientConfigFile.mArgument.empty()) { // no file was provided
+      return true;
     }
 
-    return retVal;
+    std::string endpoint = mEndpointUrl;
+    CUA_ClientConfigFileParser::UA_ConfigFromFile result =
+        CUA_ClientConfigFileParser::UA_ConfigFromFile(paConfig, mUsername, mPassword);
+
+    return CUA_ClientConfigFileParser::loadConfig(gOpcuaClientConfigFile.mArgument, endpoint, result);
   }
 
   void CUA_ClientInformation::uninitializeClient() {

--- a/com/opc_ua/src/opcua_local_handler.cpp
+++ b/com/opc_ua/src/opcua_local_handler.cpp
@@ -25,6 +25,7 @@
 #include "opcua_local_handler.h"
 
 #include <open62541/server.h>
+#include <open62541/server_config_default.h>
 
 #include "forte/iec61131_functions.h"
 #include "forte/cominfra/basecommfb.h"
@@ -97,20 +98,23 @@ namespace forte::com_infra::opc_ua {
   void COPC_UA_Local_Handler::run() {
     DEVLOG_INFO("[OPC UA LOCAL]: Starting OPC UA Server: opc.tcp://localhost:%d\n", gOpcuaServerPort.mArgument);
 
-    mUaServer = UA_Server_new();
+    UA_ServerConfig config{
+        config.logging = &getLogger(),
+    };
+
+    // set default config
+    if (const UA_StatusCode status = UA_ServerConfig_setDefault(&config); status != UA_STATUSCODE_GOOD) {
+      DEVLOG_ERROR("[OPC UA LOCAL]: Error setting server configuration. Error: %s\n", UA_StatusCode_name(status));
+      mServerStarted.inc(); // this will avoid locking startServer() for all cases where the starting of server failed
+      return;
+    }
+
+    UA_ServerStrings serverStrings;
+    generateServerStrings(gOpcuaServerPort.mArgument, serverStrings);
+    configureUAServer(serverStrings, config);
+
+    mUaServer = UA_Server_newWithConfig(&config);
     if (mUaServer) {
-      UA_ServerConfig *uaServerConfig = UA_Server_getConfig(mUaServer);
-      /* The original logger is needed to avoid memory leak on shutdown.
-       * It is reassigned before the server shutdown so that freeing the memory
-       * works properly.
-       */
-      UA_Logger uaLogger = *uaServerConfig->logging;
-      *uaServerConfig->logging = getLogger();
-
-      UA_ServerStrings serverStrings;
-      generateServerStrings(gOpcuaServerPort.mArgument, serverStrings);
-      configureUAServer(serverStrings, *uaServerConfig);
-
       if (initializeNodesets(*mUaServer)) {
         UA_StatusCode retVal = UA_Server_run_startup(mUaServer);
         if (UA_STATUSCODE_GOOD == retVal) {
@@ -150,10 +154,11 @@ namespace forte::com_infra::opc_ua {
       } else {
         DEVLOG_ERROR("[OPC UA LOCAL]: Couldn't initialize Nodesets\n", gOpcuaServerPort.mArgument);
       }
-      /* Reassign original logger to avoid memory leak. */
-      *uaServerConfig->logging = uaLogger;
       UA_Server_delete(mUaServer);
       mUaServer = nullptr;
+    } else {
+      DEVLOG_ERROR("[OPC UA LOCAL]: Couldn't initialize server\n");
+      UA_ServerConfig_clear(&config);
     }
     mServerStarted.inc(); // this will avoid locking startServer() for all cases where the starting of server failed
   }


### PR DESCRIPTION
The previous logger was not cleared properly when assigning a custom logger, which led to a memory leak. This first creates a config with the custom logger and then creates a client or server from it[^1], thus avoiding either memory leaks or dangling pointers.

[^1]: see also https://github.com/open62541/open62541/issues/6769#issuecomment-4621348961