### PR TITLE
Fix BCD conversion when target is larger than source type

### DIFF
--- a/core/include/forte/iec61131_functions/func_TO_BCD.h
+++ b/core/include/forte/iec61131_functions/func_TO_BCD.h
@@ -38,9 +38,9 @@ namespace forte {
 
     TargetPrimitive bcdValue = 0;
     for (size_t i = 0; i < targetWidth; ++i) {
-      bcdValue += static_cast<TargetPrimitive>((sourceValue % divisor) << (i * 8));
+      bcdValue += static_cast<TargetPrimitive>(sourceValue % divisor) << (i * 8);
       sourceValue /= divisor;
-      bcdValue += static_cast<TargetPrimitive>((sourceValue % divisor) << (i * 8 + 4));
+      bcdValue += static_cast<TargetPrimitive>(sourceValue % divisor) << (i * 8 + 4);
       sourceValue /= divisor;
     }
     return U(bcdValue);


### PR DESCRIPTION
The BCD digit value must be cast to the target type before bit shifting, otherwise the shift index may exceed the width of the source value.