### PR TITLE
Replace obsolete FORTE_TEST_SANITIZE with FORTE_SANITIZE option

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -83,7 +83,7 @@
           "type": "BOOL",
           "value": "ON"
         },
-        "FORTE_TEST_SANITIZE": {
+        "FORTE_SANITIZE": {
           "type": "BOOL",
           "value": "ON"
         }

--- a/core/arch/CMakeLists.txt
+++ b/core/arch/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 include(CMakeDependentOption)
 include(CheckCXXCompilerFlag)
+include(CheckLinkerFlag)
 
 check_cxx_compiler_flag(-frtti HAVE_RTTI_FLAG)
 check_cxx_compiler_flag(-fexceptions HAVE_EXCEPTIONS_FLAG)
@@ -24,6 +25,31 @@ mark_as_advanced(FORTE_RTTI_AND_EXCEPTIONS)
 target_compile_options(forte-core PUBLIC
         $<$<COMPILE_LANGUAGE:CXX>:$<$<BOOL:${HAVE_RTTI_FLAG}>:$<IF:$<BOOL:${FORTE_RTTI_AND_EXCEPTIONS}>,-frtti,-fno-rtti>>>
         $<$<COMPILE_LANGUAGE:CXX>:$<$<BOOL:${HAVE_EXCEPTIONS_FLAG}>:$<IF:$<BOOL:${FORTE_RTTI_AND_EXCEPTIONS}>,-fexceptions,-fno-exceptions>>>
+)
+
+function(forte_check_sanitizer flag variable)
+    list(APPEND CMAKE_REQUIRED_LINK_OPTIONS ${flag})
+    check_cxx_compiler_flag(${flag} ${variable})
+endfunction()
+
+forte_check_sanitizer("-fsanitize=address" HAVE_SANITIZE_ADDRESS_FLAG)
+forte_check_sanitizer("-fsanitize=leak" HAVE_SANITIZE_LEAK_FLAG)
+forte_check_sanitizer("-fsanitize=undefined" HAVE_SANITIZE_UNDEFINED_FLAG)
+forte_check_sanitizer("-fsanitize-address-use-after-scope" HAVE_SANITIZE_ADDRESS_USE_AFTER_SCOPE_FLAG)
+
+cmake_dependent_option(FORTE_SANITIZE "Enable sanitizer" OFF "HAVE_SANITIZE_ADDRESS_FLAG OR HAVE_SANITIZE_LEAK_FLAG OR HAVE_SANITIZE_UNDEFINED_FLAG" OFF)
+
+target_compile_options(forte-core PUBLIC
+        $<$<AND:$<BOOL:${FORTE_SANITIZE}>,$<BOOL:${HAVE_SANITIZE_ADDRESS_FLAG}>>:-fsanitize=address>
+        $<$<AND:$<BOOL:${FORTE_SANITIZE}>,$<BOOL:${HAVE_SANITIZE_LEAK_FLAG}>>:-fsanitize=leak>
+        $<$<AND:$<BOOL:${FORTE_SANITIZE}>,$<BOOL:${HAVE_SANITIZE_UNDEFINED_FLAG}>>:-fsanitize=undefined>
+        $<$<AND:$<BOOL:${FORTE_SANITIZE}>,$<BOOL:${HAVE_SANITIZE_ADDRESS_USE_AFTER_SCOPE_FLAG}>>:-fsanitize-address-use-after-scope>
+)
+target_link_options(forte-core PUBLIC
+        $<$<AND:$<BOOL:${FORTE_SANITIZE}>,$<BOOL:${HAVE_SANITIZE_ADDRESS_FLAG}>>:-fsanitize=address>
+        $<$<AND:$<BOOL:${FORTE_SANITIZE}>,$<BOOL:${HAVE_SANITIZE_LEAK_FLAG}>>:-fsanitize=leak>
+        $<$<AND:$<BOOL:${FORTE_SANITIZE}>,$<BOOL:${HAVE_SANITIZE_UNDEFINED_FLAG}>>:-fsanitize=undefined>
+        $<$<AND:$<BOOL:${FORTE_SANITIZE}>,$<BOOL:${HAVE_SANITIZE_ADDRESS_USE_AFTER_SCOPE_FLAG}>>:-fsanitize-address-use-after-scope>
 )
 
 ###############################################################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,67 +13,66 @@
 # *******************************************************************************/
 
 if (NOT FORTE_TESTS)
-  return()
-endif()
+    return()
+endif ()
 
 # Several stdfblib tests require the IEC61131-3 module, so we need to enable it for the test build
-if(NOT FORTE_MODULE_IEC61131)
-  message(STATUS "Tests are enabled: Forcing FORTE_MODULE_IEC61131 to ON.")
-endif()
+if (NOT FORTE_MODULE_IEC61131)
+    message(STATUS "Tests are enabled: Forcing FORTE_MODULE_IEC61131 to ON.")
+endif ()
 set(FORTE_MODULE_IEC61131 ON CACHE BOOL "IEC61131-3 Function blocks" FORCE)
 
 if (FORTE_ARCHITECTURE STREQUAL "Posix")
-  option(FORTE_TEST_CODE_COVERAGE_ANALYSIS "Perform code coverage analyis with GCOV and presentation with LCOV" OFF)
-  mark_as_advanced(FORTE_TEST_CODE_COVERAGE_ANALYSIS)
-  option(FORTE_TEST_SANITIZE "Perform address sanitizer analysis" OFF)
-endif()
+    option(FORTE_TEST_CODE_COVERAGE_ANALYSIS "Perform code coverage analyis with GCOV and presentation with LCOV" OFF)
+    mark_as_advanced(FORTE_TEST_CODE_COVERAGE_ANALYSIS)
+endif ()
 
 
 #######################################################################################
 # functions for test generation
 #######################################################################################
 MACRO(forte_test_add_subdirectory DIRECTORY)
-  SET(SOURCE_GROUP_BACKUP ${SOURCE_GROUP})
-  SET(SOURCE_GROUP ${SOURCE_GROUP}\\${DIRECTORY})
-  add_subdirectory(${DIRECTORY})
-  SET(SOURCE_GROUP ${SOURCE_GROUP_BACKUP})
+    SET(SOURCE_GROUP_BACKUP ${SOURCE_GROUP})
+    SET(SOURCE_GROUP ${SOURCE_GROUP}\\${DIRECTORY})
+    add_subdirectory(${DIRECTORY})
+    SET(SOURCE_GROUP ${SOURCE_GROUP_BACKUP})
 ENDMACRO(forte_test_add_subdirectory)
 
 FUNCTION(forte_test_add_sourcefile_with_path_cpp)
-  FOREACH(ARG ${ARGV})
-  SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_SOURCE_CPP ${ARG})
-    SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_SOURCE_CPP_GROUP ${SOURCE_GROUP})
-  ENDFOREACH(ARG)
+    FOREACH (ARG ${ARGV})
+        SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_SOURCE_CPP ${ARG})
+        SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_SOURCE_CPP_GROUP ${SOURCE_GROUP})
+    ENDFOREACH (ARG)
 ENDFUNCTION(forte_test_add_sourcefile_with_path_cpp)
 
 FUNCTION(forte_test_add_sourcefile_cpp)
-  FOREACH(ARG ${ARGV})
-  forte_test_add_sourcefile_with_path_cpp(${CMAKE_CURRENT_SOURCE_DIR}/${ARG})
-  ENDFOREACH(ARG)
+    FOREACH (ARG ${ARGV})
+        forte_test_add_sourcefile_with_path_cpp(${CMAKE_CURRENT_SOURCE_DIR}/${ARG})
+    ENDFOREACH (ARG)
 ENDFUNCTION(forte_test_add_sourcefile_cpp)
 
 FUNCTION(forte_test_add_link_directories)
-  FOREACH(ARG ${ARGV})
-    SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_LINK_DIRECTORIES ${ARG})
-  ENDFOREACH(ARG)
+    FOREACH (ARG ${ARGV})
+        SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_LINK_DIRECTORIES ${ARG})
+    ENDFOREACH (ARG)
 ENDFUNCTION(forte_test_add_link_directories)
 
 FUNCTION(forte_test_add_inc_directories)
-  FOREACH(ARG ${ARGV})
-    SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_INC_DIRECTORIES ${ARG})
-  ENDFOREACH(ARG)
+    FOREACH (ARG ${ARGV})
+        SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_INC_DIRECTORIES ${ARG})
+    ENDFOREACH (ARG)
 ENDFUNCTION(forte_test_add_inc_directories)
 
 FUNCTION(forte_test_add_inc_system_directories)
-  FOREACH(ARG ${ARGV})
-    SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_INC_SYSTEM_DIRECTORIES ${ARG})
-  ENDFOREACH(ARG)
+    FOREACH (ARG ${ARGV})
+        SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_INC_SYSTEM_DIRECTORIES ${ARG})
+    ENDFOREACH (ARG)
 ENDFUNCTION(forte_test_add_inc_system_directories)
 
 FUNCTION(forte_test_add_link_library)
-  FOREACH(ARG ${ARGV})
-    SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_LIBRARIES ${ARG})
-  ENDFOREACH(ARG)
+    FOREACH (ARG ${ARGV})
+        SET_PROPERTY(GLOBAL APPEND PROPERTY FORTE_TEST_LIBRARIES ${ARG})
+    ENDFOREACH (ARG)
 ENDFUNCTION(forte_test_add_link_library)
 
 #######################################################################################
@@ -101,16 +100,16 @@ LINK_DIRECTORIES(${LINK_DIRECTORIES})
 
 GET_PROPERTY(FORTE_TEST_SOURCE_H GLOBAL PROPERTY FORTE_SOURCE_H)
 
-GET_PROPERTY(SOURCE_H              GLOBAL PROPERTY FORTE_TEST_SOURCE_H)
-GET_PROPERTY(SOURCE_H_GROUP        GLOBAL PROPERTY FORTE_TEST_SOURCE_H_GROUP)
+GET_PROPERTY(SOURCE_H GLOBAL PROPERTY FORTE_TEST_SOURCE_H)
+GET_PROPERTY(SOURCE_H_GROUP GLOBAL PROPERTY FORTE_TEST_SOURCE_H_GROUP)
 
-GET_PROPERTY(SOURCE_CPP              GLOBAL PROPERTY FORTE_TEST_SOURCE_CPP)
+GET_PROPERTY(SOURCE_CPP GLOBAL PROPERTY FORTE_TEST_SOURCE_CPP)
 GET_PROPERTY(SOURCE_CPP_GROUP_STRUCT GLOBAL PROPERTY FORTE_TEST_SOURCE_CPP_GROUP)
 
 SET(WRITE_FILE "")
-FOREACH(FILE ${SOURCE_CPP} ${SOURCE_H})
-  SET(WRITE_FILE "${WRITE_FILE}${FILE}\n")
-ENDFOREACH(FILE)
+FOREACH (FILE ${SOURCE_CPP} ${SOURCE_H})
+    SET(WRITE_FILE "${WRITE_FILE}${FILE}\n")
+ENDFOREACH (FILE)
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/file_test_list.txt "${WRITE_FILE}")
 
 #######################################################################################
@@ -128,13 +127,13 @@ target_include_directories(forte_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 # Add definitions
 #######################################################################################
 
-if("${FORTE_ARCHITECTURE}" STREQUAL "Win32")
- ADD_DEFINITIONS (-DBOOST_TEST_NO_LIB)
- if(MINGW)
-  #force MINGW to statically link libc and lib stdc++ so that no mingw dlls are needed for forte_test.exe
-  TARGET_LINK_OPTIONS(forte_test PRIVATE -static-libgcc -static-libstdc++)
- endif()
-endif("${FORTE_ARCHITECTURE}" STREQUAL "Win32")
+if ("${FORTE_ARCHITECTURE}" STREQUAL "Win32")
+    ADD_DEFINITIONS(-DBOOST_TEST_NO_LIB)
+    if (MINGW)
+        #force MINGW to statically link libc and lib stdc++ so that no mingw dlls are needed for forte_test.exe
+        TARGET_LINK_OPTIONS(forte_test PRIVATE -static-libgcc -static-libstdc++)
+    endif ()
+endif ("${FORTE_ARCHITECTURE}" STREQUAL "Win32")
 
 SET_TARGET_PROPERTIES(forte_test PROPERTIES LINKER_LANGUAGE CXX)
 
@@ -143,12 +142,12 @@ add_test(forte_test ${EXECUTABLE_OUTPUT_PATH}/forte_test)
 
 set_tests_properties(forte_test PROPERTIES TIMEOUT 300)
 
-if("${FORTE_ARCHITECTURE}" STREQUAL "Posix")
-  if(FORTE_TEST_CODE_COVERAGE_ANALYSIS)
-      INCLUDE(GCov.cmake)
-      SETUP_GCOV(TestCoverage ctest coverage)
-  endif()
-endif()
+if ("${FORTE_ARCHITECTURE}" STREQUAL "Posix")
+    if (FORTE_TEST_CODE_COVERAGE_ANALYSIS)
+        INCLUDE(GCov.cmake)
+        SETUP_GCOV(TestCoverage ctest coverage)
+    endif ()
+endif ()
 
 #######################################################################################
 # add includes
@@ -164,10 +163,10 @@ GET_PROPERTY(INCLUDE_TEST_SYSTEM_DIRECTORIES GLOBAL PROPERTY FORTE_TEST_INC_SYST
 LIST(APPEND INCLUDE_TEST_SYSTEM_DIRECTORIES ${INCLUDE_SYSTEM_DIRECTORIES})
 
 LIST(LENGTH INCLUDE_TEST_SYSTEM_DIRECTORIES len)
-IF(len GREATER 0)
-  LIST(REMOVE_DUPLICATES INCLUDE_TEST_SYSTEM_DIRECTORIES)
-  LIST(REVERSE INCLUDE_TEST_SYSTEM_DIRECTORIES) # bugfix, for replaced include files
-ENDIF(len GREATER 0)
+IF (len GREATER 0)
+    LIST(REMOVE_DUPLICATES INCLUDE_TEST_SYSTEM_DIRECTORIES)
+    LIST(REVERSE INCLUDE_TEST_SYSTEM_DIRECTORIES) # bugfix, for replaced include files
+ENDIF (len GREATER 0)
 
 INCLUDE_DIRECTORIES(SYSTEM ${INCLUDE_TEST_SYSTEM_DIRECTORIES})
 


### PR DESCRIPTION
This replaces the obsolete `FORTE_TEST_SANITIZE` option with the new `FORTE_SANITIZE` option, which also includes sanitizers for memory leaks and undefined behavior.

This PR also includes the corresponding fixes:
- #949
- #950 
- #951 
- #952 
- #953 
- #954 
- #955 
- #956
- #958 
- #959 

It is therefore still a draft until the fixes have been merged.

Fixes #940