### PR TITLE
Fix illegal cast to CIPComSocketHandler

### DIFF
--- a/com/HTTP/http_handler.cpp
+++ b/com/HTTP/http_handler.cpp
@@ -119,7 +119,7 @@ namespace forte::com_infra::http {
         accepted.mSocket = newConnection;
         accepted.mStartTime = func_NOW_MONOTONIC();
         mAcceptedSockets.emplace_back(std::move(accepted));
-        mDeviceExecution.getExtEvHandler<arch::CIPComSocketHandler>().addComCallback(newConnection, this);
+        mDeviceExecution.getExtEvHandler<arch::CFDSelectHandler>().addComCallback(newConnection, this);
         resumeSelfsuspend();
       } else {
         DEVLOG_ERROR("[HTTP Handler] Couldn't accept new HTTP connection\n");
@@ -262,7 +262,7 @@ namespace forte::com_infra::http {
         toAdd.mStartTime = func_NOW_MONOTONIC();
         startTimeoutThread();
         mClientLayers.emplace_back(std::move(toAdd));
-        mDeviceExecution.getExtEvHandler<arch::CIPComSocketHandler>().addComCallback(newSocket, this);
+        mDeviceExecution.getExtEvHandler<arch::CFDSelectHandler>().addComCallback(newSocket, this);
         resumeSelfsuspend();
         return true;
       } else {
@@ -407,7 +407,7 @@ namespace forte::com_infra::http {
       char address[] = "127.0.0.1";
       smServerListeningSocket = arch::CIPComSocketHandler::openTCPServerConnection(address, gHTTPServerPort.mArgument);
       if (arch::CIPComSocketHandler::scmInvalidSocketDescriptor != smServerListeningSocket) {
-        mDeviceExecution.getExtEvHandler<arch::CIPComSocketHandler>().addComCallback(smServerListeningSocket, this);
+        mDeviceExecution.getExtEvHandler<arch::CFDSelectHandler>().addComCallback(smServerListeningSocket, this);
         DEVLOG_INFO("[HTTP Handler] HTTP server listening on port %u\n", gHTTPServerPort.mArgument);
       } else {
         DEVLOG_ERROR("[HTTP Handler] Couldn't start HTTP server on port %u\n", gHTTPServerPort.mArgument);
@@ -423,8 +423,8 @@ namespace forte::com_infra::http {
   }
 
   void CHTTP_Handler::removeAndCloseSocket(const arch::CIPComSocketHandler::TSocketDescriptor paSocket) {
-    mDeviceExecution.getExtEvHandler<arch::CIPComSocketHandler>().removeComCallback(paSocket);
-    mDeviceExecution.getExtEvHandler<arch::CIPComSocketHandler>().closeSocket(paSocket);
+    mDeviceExecution.getExtEvHandler<arch::CFDSelectHandler>().removeComCallback(paSocket);
+    arch::CIPComSocketHandler::closeSocket(paSocket);
   }
 
   void CHTTP_Handler::resumeSelfsuspend() {

--- a/com/tsn/tsn_layer.cpp
+++ b/com/tsn/tsn_layer.cpp
@@ -76,7 +76,7 @@ namespace forte::com_infra::tsn {
       if (arch::CIPComSocketHandler::scmInvalidSocketDescriptor != nSockDes && e_InitOk == eRetVal) {
         if (e_Publisher != mFb->getComServiceType()) {
           // Publishers should not be registered for receiving data
-          getExtEvHandler<arch::CIPComSocketHandler>().addComCallback(nSockDes, this);
+          getExtEvHandler<arch::CFDSelectHandler>().addComCallback(nSockDes, this);
         }
         eRetVal = e_InitOk;
       } else {

--- a/core/src/cominfra/ipcomlayer.cpp
+++ b/core/src/cominfra/ipcomlayer.cpp
@@ -101,7 +101,7 @@ namespace forte::com_infra {
         mSocketID = arch::CIPComSocketHandler::acceptTCPConnection(mListeningID);
         if (arch::CIPComSocketHandler::scmInvalidSocketDescriptor != mSocketID) {
           DEVLOG_INFO("Connection established by client\n");
-          getExtEvHandler<arch::CIPComSocketHandler>().addComCallback(mSocketID, this);
+          getExtEvHandler<arch::CFDSelectHandler>().addComCallback(mSocketID, this);
           mConnectionState = e_Connected;
         }
         break;
@@ -158,7 +158,7 @@ namespace forte::com_infra {
       if (arch::CIPComSocketHandler::scmInvalidSocketDescriptor != nSockDes) {
         if (e_Publisher != mFb->getComServiceType()) {
           // Publishers should not be registered for receiving data
-          getExtEvHandler<arch::CIPComSocketHandler>().addComCallback(nSockDes, this);
+          getExtEvHandler<arch::CFDSelectHandler>().addComCallback(nSockDes, this);
         }
         eRetVal = e_InitOk;
       } else {
@@ -178,7 +178,7 @@ namespace forte::com_infra {
 
   void CIPComLayer::closeSocket(arch::CIPComSocketHandler::TSocketDescriptor *paSocketID) {
     if (arch::CIPComSocketHandler::scmInvalidSocketDescriptor != *paSocketID) {
-      getExtEvHandler<arch::CIPComSocketHandler>().removeComCallback(*paSocketID);
+      getExtEvHandler<arch::CFDSelectHandler>().removeComCallback(*paSocketID);
       arch::CIPComSocketHandler::closeSocket(*paSocketID);
       *paSocketID = arch::CIPComSocketHandler::scmInvalidSocketDescriptor;
     }


### PR DESCRIPTION
The `CIPComSocketHandler` is a placeholder type with no instances. This replaces illegal casts to `CIPComSocketHandler` with `CFDSelectHandler`.