### PR TITLE
Add modular EtherCAT IO module

### DIFF
--- a/core/include/forte/io/configFB/CMakeLists.txt
+++ b/core/include/forte/io/configFB/CMakeLists.txt
@@ -10,6 +10,8 @@
 # Contributors:
 #    Martin Erich Jobst
 #      - initial API and implementation and/or initial documentation
+#    Sichuan Qunyuan Technology Co., Ltd.
+#      - add io_slave_multi_handler
 #############################################################################
 
 target_sources(forte-core PUBLIC
@@ -20,4 +22,5 @@ target_sources(forte-core PUBLIC
         io_configFB_controller.h
         io_master_multi.h
         io_slave_multi.h
+        io_slave_multi_handler.h
 )

--- a/core/include/forte/io/configFB/io_slave_multi_handler.h
+++ b/core/include/forte/io/configFB/io_slave_multi_handler.h
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/io/configFB/io_base.h"
+#include "forte/io/device/io_controller_multi.h"
+#include "forte/io/configFB/io_adapter_multi.h"
+#include "forte/io/configFB/io_master_multi.h"
+
+namespace forte::io {
+
+  class IOConfigHandlerFBMultiSlave : public IOConfigFBBase {
+    public:
+      IOConfigHandlerFBMultiSlave(const TForteUInt8 *const paSlaveConfigurationIO,
+                                  const TForteUInt8 paSlaveConfigurationIONum,
+                                  int paType,
+                                  CFBContainer &paContainer,
+                                  const SFBInterfaceSpec &paInterfaceSpec,
+                                  const StringId paInstanceNameId);
+
+      IOConfigHandlerFBMultiSlave(CFBContainer &paContainer,
+                                  const SFBInterfaceSpec &paInterfaceSpec,
+                                  forte::StringId paInstanceNameId,
+                                  const TForteUInt8 *const paSlaveConfigurationIO,
+                                  TForteUInt8 paSlaveConfigurationIONum,
+                                  int paType);
+                                  
+      ~IOConfigHandlerFBMultiSlave() override;
+    
+    protected:
+      CIEC_BOOL &QI() {
+        return *static_cast<CIEC_BOOL *>(getDI(0));
+      }
+
+      CIEC_BOOL &QO() {
+        return *static_cast<CIEC_BOOL *>(getDO(0));
+      }
+
+      CIEC_WSTRING &STATUS() {
+        return *static_cast<CIEC_WSTRING *>(getDO(1));
+      }
+
+      static const TEventID scmEventMAPID = 0;
+
+      static const TEventID scmEventMAPOID = 0;
+      static const TEventID scmEventINDID = 1;
+
+      IOConfigFBMultiAdapter &BusAdapterOut() {
+        return (*static_cast<IOConfigFBMultiAdapter *>(getPlugPinUnchecked(0)->getAdapterBlock()));
+      }
+
+      IOConfigFBMultiAdapter &BusAdapterIn() {
+        return (*static_cast<IOConfigFBMultiAdapter *>(getSocketPinUnchecked(0)->getAdapterBlock()));
+      }
+
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      IODeviceMultiController &getController() {
+        return (*static_cast<IODeviceMultiController *>(mMaster->getDeviceController()));
+      }
+
+      virtual const char *init() {
+        return nullptr;
+      }
+
+      virtual void deInit() {
+        // do nothing
+      }
+
+      virtual void initHandles() = 0;
+
+      virtual bool createSlaveHandler() = 0;
+
+      void initHandle(IODeviceController::HandleDescriptor &paHandleDescriptor);
+
+      static const CIEC_WSTRING scmOK;
+      static const char *const scmMasterNotFound;
+
+      size_t mIndex;
+
+      const TForteUInt8 *mSlaveConfigurationIO;
+
+    private:
+      IOConfigFBMultiMaster *mMaster;
+
+      int mType;
+
+      bool mInitialized;
+
+      TForteUInt8 mSlaveConfigurationIONum;
+      bool *mSlaveConfigurationIOIsDefault;
+
+      const char *handleInitEvent();
+
+      static const CIEC_WSTRING scmStopped;
+      static const char *const scmNotFound;
+      static const char *const scmIncorrectType;
+
+  };
+}

--- a/core/src/io/configFB/CMakeLists.txt
+++ b/core/src/io/configFB/CMakeLists.txt
@@ -7,6 +7,7 @@
 #
 # Contributors: Johannes Messmer *   - initial API and implementation and/or
 # initial documentation
+#    Sichuan Qunyuan Technology Co., Ltd. - add io_slave_multi_handler
 # *******************************************************************************/
 
 # ############################################################################
@@ -19,4 +20,5 @@ target_sources(forte-core PRIVATE
         io_configFB_controller.cpp
         io_master_multi.cpp
         io_slave_multi.cpp
+        io_slave_multi_handler.cpp
 )

--- a/core/src/io/configFB/io_slave_multi_handler.cpp
+++ b/core/src/io/configFB/io_slave_multi_handler.cpp
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "forte/io/configFB/io_slave_multi_handler.h"
+#include "forte/iec61131_functions/func_ADD.h"
+#include "forte/iec61131_functions/func_AND.h"
+
+namespace forte::io {
+  const CIEC_WSTRING IOConfigHandlerFBMultiSlave::scmOK("OK");
+  const CIEC_WSTRING IOConfigHandlerFBMultiSlave::scmStopped("Stopped");
+  const char *const IOConfigHandlerFBMultiSlave::scmMasterNotFound("Master not found");
+  const char *const IOConfigHandlerFBMultiSlave::scmNotFound("Module not found");
+  const char *const IOConfigHandlerFBMultiSlave::scmIncorrectType("Module type is incorrect");
+
+  IOConfigHandlerFBMultiSlave::IOConfigHandlerFBMultiSlave(const TForteUInt8 *const paSlaveConfigurationIO,
+                                                           const TForteUInt8 paSlaveConfigurationIONum,
+                                                           int paType,
+                                                           CFBContainer &paContainer,
+                                                           const SFBInterfaceSpec &paInterfaceSpec,
+                                                           const StringId paInstanceNameId) :
+                                                           IOConfigFBBase(paContainer, paInterfaceSpec, paInstanceNameId),
+      mIndex(static_cast<size_t>(-1)),
+      mSlaveConfigurationIO(paSlaveConfigurationIO),
+      mMaster(nullptr),
+      mType(paType),
+      mInitialized(false),
+      mSlaveConfigurationIONum(paSlaveConfigurationIONum),
+      mSlaveConfigurationIOIsDefault(new bool[paSlaveConfigurationIONum]()) {
+    for (int i = 0; i < mSlaveConfigurationIONum; i++) {
+      mSlaveConfigurationIOIsDefault[i] = false;
+    }
+  }
+
+  IOConfigHandlerFBMultiSlave::IOConfigHandlerFBMultiSlave(CFBContainer &paContainer,
+                                                           const SFBInterfaceSpec &paInterfaceSpec,
+                                                           forte::StringId paInstanceNameId,
+                                                           const TForteUInt8 *const paSlaveConfigurationIO,
+                                                           TForteUInt8 paSlaveConfigurationIONum,
+                                                           int paType) : 
+                                IOConfigHandlerFBMultiSlave(paSlaveConfigurationIO,
+                                                            paSlaveConfigurationIONum,
+                                                            paType,
+                                                            paContainer,
+                                                            paInterfaceSpec,
+                                                            paInstanceNameId) {
+  }
+
+  IOConfigHandlerFBMultiSlave::~IOConfigHandlerFBMultiSlave() {
+    delete[] mSlaveConfigurationIOIsDefault;
+  }
+
+  void IOConfigHandlerFBMultiSlave::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    if (BusAdapterIn().INIT() == paEIID) {    
+      if (BusAdapterIn().var_QI == true) {
+        // Handle initialization event
+        const char *const error = handleInitEvent();
+        QO() = CIEC_BOOL(mInitialized = error == nullptr);
+
+        if (mInitialized) {
+          STATUS() = scmOK;
+        } else {
+          STATUS() = CIEC_WSTRING(error);
+        }
+
+        if (BusAdapterOut().getPeer() != nullptr) {
+          // Initialize next slave
+          BusAdapterOut().var_QI = BusAdapterIn().var_QI;
+          BusAdapterOut().var_Index = func_ADD(BusAdapterIn().var_Index, CIEC_UINT(1));
+          BusAdapterOut().var_MasterId = BusAdapterIn().var_MasterId;
+
+          for (auto it : BusAdapterIn().cmSlaveConfigurationIO) {
+            CIEC_ANY *inConfigPin = BusAdapterIn().getDeviceConfigPin(it);
+            if (inConfigPin != nullptr) {
+              BusAdapterOut().getDeviceConfigPin(it)->setValue(*inConfigPin);
+            } else {
+              DEVLOG_WARNING("[IOConfigHandlerFBMultiSlave] Unable to get device config pin #%d. Skip adapter configuration\n",it);
+            }
+          }
+
+          sendAdapterEvent(BusAdapterOut(), IOConfigFBMultiAdapter::scmEventINITID, paECET);
+          sendOutputEvent(scmEventINDID, paECET);
+        } else {
+          // Send confirmation of init
+          BusAdapterIn().var_QO = QO();
+          sendAdapterEvent(BusAdapterIn(), IOConfigFBMultiAdapter::scmEventINITOID, paECET);
+        }
+      } else {
+        deInit();
+
+        QO() = false_BOOL;
+        STATUS() = scmStopped;
+
+        if (BusAdapterOut().getPeer() != nullptr) {
+          // DeInit next slave
+          BusAdapterOut().var_QI = BusAdapterIn().var_QI;
+
+          sendAdapterEvent(BusAdapterOut(), IOConfigFBMultiAdapter::scmEventINITID, paECET);
+          sendOutputEvent(scmEventINDID, paECET);
+        } else {
+          // Send confirmation of deInit
+          BusAdapterIn().var_QO = QO();
+          sendAdapterEvent(BusAdapterIn(), IOConfigFBMultiAdapter::scmEventINITOID, paECET);
+        }
+      }
+    } else if (BusAdapterOut().INITO() == paEIID) {
+      // Forward confirmation of initialization
+      BusAdapterIn().var_QO = func_AND(BusAdapterOut().var_QO, QO());
+      sendAdapterEvent(BusAdapterIn(), IOConfigFBMultiAdapter::scmEventINITOID, paECET);
+    }
+
+    if (scmEventMAPID == paEIID) {
+      if (mInitialized) {
+        // Drop all existing handles
+        getController().dropSlaveHandles(mIndex);
+
+        if (true == QI()) {
+          initHandles();
+        }
+
+        QO() = true_BOOL;
+      } else {
+        QO() = false_BOOL;
+      }
+
+      sendOutputEvent(scmEventMAPOID, paECET);
+    }
+  }
+
+  void IOConfigHandlerFBMultiSlave::initHandle(IODeviceController::HandleDescriptor &paHandleDescriptor) {
+    mMaster->initHandle(paHandleDescriptor);
+  }
+
+  const char *IOConfigHandlerFBMultiSlave::handleInitEvent() {
+    // Get master by id
+    mMaster = IOConfigFBMultiMaster::getMasterById(static_cast<CIEC_UINT::TValueType>(BusAdapterIn().var_MasterId));
+    if (nullptr == mMaster) {
+      return scmMasterNotFound;
+    }
+    mIndex = static_cast<CIEC_UINT::TValueType>(BusAdapterIn().var_Index);
+
+    // Default parameters
+    for (size_t i = 0; i < mSlaveConfigurationIONum; i++) {
+      bool isSet = true;
+
+      CIEC_ANY *ptr = getDI(mSlaveConfigurationIO[i]);
+      if (CIEC_ANY::e_UINT == ptr->getDataTypeID()) {
+        isSet = static_cast<CIEC_UINT::TValueType>(*static_cast<CIEC_UINT *>(ptr)) > 0 ? true : false;
+      } else {
+        DEVLOG_WARNING("[IOConfigHandlerFBMultiSlave] Unable to handle data type %d. Skip slave configuration\n",
+                       ptr->getDataTypeID());
+        continue;
+      }
+
+      if (!mSlaveConfigurationIOIsDefault[i] && !isSet) {
+        mSlaveConfigurationIOIsDefault[i] = true;
+      }
+
+      if (mSlaveConfigurationIOIsDefault[i]) {
+        ptr->setValue(*BusAdapterIn().getDeviceConfigPin(BusAdapterIn().cmSlaveConfigurationIO[i]));
+      }
+    }
+
+    IODeviceMultiController &controller = getController();
+
+    if(!createSlaveHandler()) {
+      DEVLOG_ERROR("[IOConfigHandlerFBMultiSlave] Create Slave handler failed\n");
+      return "[IOConfigHandlerFBMultiSlave] Create Slave handler failed";
+    }
+
+    // Perform slave initialization
+    const char *const error = init();
+    if (error != nullptr) {
+      return error;
+    }
+    controller.dropSlaveHandles(mIndex);
+    if (true == QI()) {
+      initHandles();
+    }
+
+    DEVLOG_DEBUG("[IOConfigHandlerFBMultiSlave] Initialized slave at position %d\n", mIndex);
+
+    return nullptr;
+  }
+
+}

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -10,6 +10,8 @@
 # Contributors:
 #    Martin Erich Jobst
 #      - initial API and implementation and/or initial documentation
+#    Sichuan Qunyuan Technology Co., Ltd.
+#      - add ethercat module
 #############################################################################
 
 add_subdirectory(ads)
@@ -18,6 +20,7 @@ add_subdirectory(conmeleon_c1)
 add_subdirectory(convert)
 add_subdirectory(eliteboard)
 add_subdirectory(embrick)
+add_subdirectory(ethercat)
 add_subdirectory(gpiochip)
 add_subdirectory(i2c_dev)
 add_subdirectory(IEC61131-3)

--- a/modules/ethercat/CMakeLists.txt
+++ b/modules/ethercat/CMakeLists.txt
@@ -1,0 +1,67 @@
+# *******************************************************************************
+# Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+# *******************************************************************************/
+
+if (NOT LINUX)
+    return()
+endif ()
+
+option(FORTE_MODULE_ETHERCAT "Support for the modular ethercat system" OFF)
+
+if (NOT FORTE_MODULE_ETHERCAT)
+    return()
+endif ()
+
+# ############################################################################
+# ethercat FBs
+# ############################################################################
+
+add_library(forte-ethercat         
+            handler/bus.h
+            handler/bus.cpp
+            slave/slave.h
+            slave/slave.cpp
+            slave/handle.h
+            slave/handle.cpp
+            slave/ec_device.h
+            slave/ec_device.cpp
+            slave/ec_module.h
+            slave/ec_module.cpp
+            slave/model/ec_model.h
+            slave/model/ec_model.cpp
+            utils/EsiFileParser.h
+            utils/EsiFileParser.cpp
+            types/ECBusAdapter.h
+            types/ECBusAdapter.cpp
+            types/ECSlave.h
+            types/ECSlave.cpp
+            types/ECModule.h
+            types/ECModule.cpp
+            types/ECCoupler.h
+            types/ECCoupler.cpp
+            types/GEN_ECCoupler_fbt.h
+            types/GEN_ECCoupler_fbt.cpp
+            types/GEN_ECSlave_fbt.h
+            types/GEN_ECSlave_fbt.cpp
+            types/GEN_ECModule_fbt.h
+            types/GEN_ECModule_fbt.cpp
+            types/ECMaster.h
+            types/ECMaster.cpp
+            structs/ECSlaveConfig.h
+            structs/ECSlaveConfig.cpp
+            structs/ECModuleConfig.h
+            structs/ECModuleConfig.cpp
+)
+target_link_libraries(forte-ethercat PUBLIC forte-core)
+target_link_libraries(forte-ethercat PRIVATE ethercat tinyxml)
+target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-ethercat,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-ethercat>>)
+install(TARGETS forte-ethercat EXPORT forte-export FILE_SET HEADERS)

--- a/modules/ethercat/handler/bus.cpp
+++ b/modules/ethercat/handler/bus.cpp
@@ -1,0 +1,357 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+// #include <sched.h>
+#include <sys/mman.h>
+#include <fmt/base.h>
+#include "forte/timerha.h"
+#include "forte/io/mapper/io_mapper.h"
+#include "bus.h"
+#include "../slave/ec_device.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  namespace {
+    const char *const scmECMasterRequestFailed = "Request master failed.";
+    const char *const scmECCreateDomainFailed = "Master create domain failed.";
+    const char *const scmECConfigSlaveFailed = "Master config slave failed.";
+    const char *const scmECConfigSlavePdoFailed = "Master config slave pdoes failed.";
+    const char *const scmECRegisterPdoEntryFailed = "Master register pdo entries failed.";
+    const char *const scmECMasterActivateFailed = "Master activate failed.";
+    const char *const scmECGetDomainProcessDataFailed = "Master get domain process data failed.";
+
+  }
+
+  ECBusHandler::ECBusHandler(CDeviceExecution &paDeviceExecution) :
+    IODeviceMultiController(paDeviceExecution),
+    mECMaster(nullptr),
+    mECDomain(nullptr),
+    mECDomainPd(nullptr),
+    mInitializedFlag(false),
+    mLoopPreparedFlag(false),
+    mEnableFlag(false),
+    mIsShuttingDown(false){
+  }
+
+  void ECBusHandler::setConfig(struct IODeviceController::Config *paConfig) {
+    if(isAlive()) {
+      DEVLOG_ERROR("ethercat[BusHandler]: Cannot change configuration while running.\n");
+      return;
+    }
+
+    this->mConfig = *static_cast<Config *>(paConfig);
+  }
+
+  void ECBusHandler::addSlave(ECSlaveHandler *slave) {
+    if(slave != 0) {
+      mDevices.push_back(slave);
+    }
+  }
+
+  ECSlaveHandler* ECBusHandler::getSlave(size_t paSlaveIndex) {
+    for(ECSlaveHandler *handler : mDevices) {
+      if(handler == nullptr) {
+        continue;
+      }
+      if(handler->mSlaveIndex == paSlaveIndex) {
+        return handler;
+      }
+    }
+    return nullptr;
+  }
+
+  void ECBusHandler::addSlaveHandle(size_t paSlaveIndex, std::unique_ptr<forte::io::IOHandle> paHandle) {
+    ECSlaveHandler *slave = getSlave(paSlaveIndex);
+    if(slave == nullptr) {
+      return;
+    }
+
+    slave->addHandle((ECSlaveHandle*)paHandle.release());
+  }
+
+  void ECBusHandler::dropSlaveHandles(size_t paSlaveIndex) {
+    ECSlaveHandler *slave = getSlave(paSlaveIndex);
+    if(slave == nullptr) {
+      return;
+    }
+
+    slave->dropHandles();
+  }
+
+  bool ECBusHandler::isSlaveAvailable(size_t paSlaveIndex) {
+    return getSlave(paSlaveIndex) != nullptr;
+  }
+
+  bool ECBusHandler::checkSlaveType(size_t paSlaveIndex, int paSlaveType) {
+    ECSlaveHandler *slave = getSlave(paSlaveIndex);
+    if(slave == nullptr) {
+      return false;
+    }
+
+    return slave->mSlaveType == paSlaveType;
+  }
+
+  const char *ECBusHandler::init() {
+    mInitializedFlag = false;
+
+    mECMaster = ecrt_request_master(mConfig.mECMasterId);
+    if(mECMaster == nullptr) {
+      DEVLOG_ERROR("ethercat[BusHandler]: %s(Master ID: %u).\n", scmECMasterRequestFailed, mConfig.mECMasterId);
+      return scmECMasterRequestFailed;
+    }
+
+    mECDomain = ecrt_master_create_domain(mECMaster);
+    if(mECDomain == nullptr) {
+      DEVLOG_ERROR("ethercat[BusHandler]: %s(Master ID: %u).\n", scmECCreateDomainFailed, mConfig.mECMasterId);
+      return scmECCreateDomainFailed;
+    }
+
+    mInitializedFlag = true;
+
+    return 0;
+  }
+
+  void ECBusHandler::deInit() {
+    DEVLOG_INFO("ECBusHandler deInit!\n");
+    mIsShuttingDown = true;
+    if(mDevices.empty() && mECMaster == nullptr) {
+      return;
+    }
+
+    if(mECMaster != nullptr) {
+      ecrt_release_master(mECMaster);
+      mECMaster = nullptr;
+    }
+
+    mECDomain = nullptr;
+    mECDomainPd = nullptr;
+
+    for(ECSlaveHandler *it : mDevices) {
+      delete it;
+    }
+
+    mDevices.clear();
+  }
+
+  forte::io::IOHandle *ECBusHandler::createIOHandle(IODeviceController::HandleDescriptor &paHandleDescriptor) {
+    HandleDescriptor &desc = static_cast<HandleDescriptor &>(paHandleDescriptor);
+    ECSlaveHandler *slave = getSlave(desc.mSlaveIndex);
+    // Remove stale mapper entry left by prior session before creating a new handle with same ID.
+    forte::io::IOMapper::getInstance().deregisterHandle(desc.mId);
+    if(slave == nullptr) {
+      return nullptr;
+    }
+
+    switch (desc.mByteLength){
+      case 1:
+        return new ECSlaveHandle(this, desc.mDirection, CIEC_ANY::EDataTypeID::e_BYTE, desc.mOffset, desc.mId, slave);
+      case 2:
+        return new ECSlaveHandle(this, desc.mDirection, CIEC_ANY::EDataTypeID::e_WORD, desc.mOffset, desc.mId, slave);
+      case 4:
+        return new ECSlaveHandle(this, desc.mDirection, CIEC_ANY::EDataTypeID::e_DWORD, desc.mOffset, desc.mId, slave);
+      case 8:
+        return new ECSlaveHandle(this, desc.mDirection, CIEC_ANY::EDataTypeID::e_LWORD, desc.mOffset, desc.mId, slave);
+      default:
+        DEVLOG_ERROR("ethercat[BusHandler]: Unsupported handle byte length %u at slave %zu offset %u.\n",
+                     static_cast<unsigned int>(desc.mByteLength),
+                     desc.mSlaveIndex,
+                     static_cast<unsigned int>(desc.mOffset));
+        break;
+    }
+
+    return nullptr;
+  }
+
+  void ECBusHandler::prepareLoop() {
+    mLoopPreparedFlag = false;
+
+    for(size_t i = 0; i < mDevices.size(); ++i) {
+      ECSlaveHandler *handler = mDevices[i];
+      if(handler->mSlaveType == ECSlaveHandler::SlaveType::ECModule) {
+        continue;
+      }
+
+      ECDeviceHandler *deviceHandler = static_cast<ECDeviceHandler *>(handler);
+      ECDeviceModel &deviceModel = deviceHandler->mECDeviceModel;
+
+      ec_slave_config_t *sc = ecrt_master_slave_config(
+        mECMaster,
+        deviceModel.mAlias,
+        deviceModel.mPosition,
+        deviceModel.mVendorId,
+        deviceModel.mProductCode);
+      
+      if(sc == nullptr) {
+        DEVLOG_ERROR("ethercat[BusHandler]: %s(Master ID: %u),Slave Position:%u.\n",
+          scmECConfigSlaveFailed,
+          mConfig.mECMasterId,
+          deviceModel.mPosition);
+        return;
+      }
+
+      if(deviceModel.mSyncList.size() > 0) {
+        ec_sync_info_t *syncInfo = deviceModel.getSyncs();
+        if(ecrt_slave_config_pdos(sc, EC_END, syncInfo)) {
+          DEVLOG_ERROR("ethercat[BusHandler]: %s(Master ID: %u),Slave Position:%u.\n"
+                       ,scmECConfigSlavePdoFailed
+                       ,mConfig.mECMasterId
+                       ,deviceModel.mPosition);
+          return;
+        }
+      }
+
+      if(deviceModel.mEntryRegList.size() > 0) {
+        ec_pdo_entry_reg_t *reg = deviceModel.getDomainRegs();
+        if(ecrt_domain_reg_pdo_entry_list(mECDomain, reg)) {
+          DEVLOG_ERROR("ethercat[BusHandler]: %s(Master ID: %u),Slave Position:%u.\n"
+                       ,scmECRegisterPdoEntryFailed
+                       ,mConfig.mECMasterId
+                       ,deviceModel.mPosition);
+          return;
+        } else {
+          DEVLOG_INFO("ethercat[BusHandler]: PDO entries registered. Offsets:\n");
+          for(size_t i = 0; i < deviceModel.mEntryRegList.size(); i++) {
+            if(deviceModel.mEntryRegList[i].mOffset) {
+              DEVLOG_INFO("ethercat[BusHandler]: [%zu] 0x%04X:%u → offset=%u\n"
+                          ,i
+                          ,deviceModel.mEntryRegList[i].mIndex
+                          ,deviceModel.mEntryRegList[i].mSubIndex
+                          ,*deviceModel.mEntryRegList[i].mOffset);
+            }
+          }
+        }
+      }
+
+      DEVLOG_INFO("ethercat[BusHandler]: Configured slave - Alias: %u, Position: %u, VendorId: 0x%08X, ProductCode: 0x%08X\n"
+                  ,deviceModel.mAlias, deviceModel.mPosition, deviceModel.mVendorId, deviceModel.mProductCode);
+      
+      const int activateRet = ecrt_master_activate(mECMaster);
+      if(activateRet) {
+        DEVLOG_ERROR("ethercat[BusHandler]: %s(Master ID: %u).\n", scmECMasterActivateFailed, mConfig.mECMasterId);
+        return;
+      }
+
+      mECDomainPd = ecrt_domain_data(mECDomain);
+      if(mECDomainPd == nullptr) {
+        DEVLOG_ERROR("ethercat[BusHandler]: %s(Master ID: %u).\n", scmECGetDomainProcessDataFailed, mConfig.mECMasterId);
+        return;
+      }
+
+      // struct sched_param param = {};
+      // param.sched_priority = sched_get_priority_max(SCHED_FIFO);
+      // if(sched_setscheduler(0, SCHED_FIFO, &param)) {
+      //   DEVLOG_WARNING("ethercat[BusHandler]: sched_setscheduler failed:%s,(Master ID: %u)\n", strerror(errno), mConfig.mECMasterId);
+      // }
+
+      // if(mlockall(MCL_CURRENT | MCL_FUTURE) == -1) {
+      //   DEVLOG_WARNING("ethercat[BusHandler]: Failed to lock memory: %s,(Master ID: %u)\n", strerror(errno), mConfig.mECMasterId);
+      // }
+
+      ec_master_state_t ms;
+      ecrt_master_state(mECMaster, &ms);
+      DEVLOG_INFO("ethercat[BusHandler]: Initial state - Slave responding: %u, AL States: 0x%02x\n", ms.slaves_responding, ms.al_states);
+
+      size_t domainSize = ecrt_domain_size(mECDomain);
+      DEVLOG_INFO("ethercat[BusHandler]: Domain size: %zu bytes\n", domainSize);
+
+      DEVLOG_INFO("ethercat[BusHandler]: Master activated successfullly.\n");
+
+      mLoopPreparedFlag = true;
+    }
+  }
+
+  void ECBusHandler::runLoop() {
+    if(!mInitializedFlag){
+      return;
+    }
+
+    while(isAlive()) {
+      // Wait until MasterFB enabled.
+      while(!mEnableFlag && isAlive()) {
+        sleepThread(1000);
+      }
+
+      if(!mLoopPreparedFlag) {
+        DEVLOG_INFO("ethercat[BusHandler]: All slaves initialized. prepareLoop...\n");
+        prepareLoop();
+        // Check if prepareLoop executed successfully.
+        if(!mLoopPreparedFlag) {
+          DEVLOG_INFO("ethercat[BusHandler]: PrepareLoop failed.\n");
+          return;
+        }
+
+        //If executed here, then prepareLoop executed successfully.
+        clock_gettime(CLOCK_MONOTONIC, &mWakeupTime);
+        mWakeupTime.tv_nsec += static_cast<long>(mConfig.mUpdateInterval) * PERIOD_NS; // µs → ns (PERIOD_NS = 1000)
+        while(mWakeupTime.tv_nsec >= NSEC_PER_SEC) {
+          mWakeupTime.tv_nsec -= NSEC_PER_SEC;
+          mWakeupTime.tv_sec++;
+        }
+        DEVLOG_INFO("ethercat[BusHandler]: PrepareLoop completed, starting cyclic communication...\n");
+      }
+
+      int ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &mWakeupTime, NULL);
+      if(ret) {
+        mError = "ethercat[BusHandler]: clock_nanosleep() failed";
+        DEVLOG_ERROR("%s: %s.\n", mError,strerror(ret));
+        break;
+      }
+
+      // Check if cycle is still enabled before executing
+      if(!mEnableFlag) {
+        // Update wakeup time even when paused to avoid time drif
+        mWakeupTime.tv_nsec += static_cast<long>(mConfig.mUpdateInterval) * PERIOD_NS;
+        while(mWakeupTime.tv_nsec >= NSEC_PER_SEC) {
+          mWakeupTime.tv_nsec -= NSEC_PER_SEC;
+          mWakeupTime.tv_sec++;
+        }
+        continue;
+      }
+
+      ecrt_master_receive(mECMaster);
+      ecrt_domain_process(mECDomain);
+
+      for(ECSlaveHandler *handler : mDevices) {
+        // Update the slave with domain data.
+        handler->update(mECDomainPd);
+      }
+
+      // Queue domain data for sending.
+      ecrt_domain_queue(mECDomain);
+      // Send process data to slaves.
+      ecrt_master_send(mECMaster);
+
+      // Calculate next wakeup time (same cycle as mUpdateInterval µs).
+      mWakeupTime.tv_nsec += static_cast<long>(mConfig.mUpdateInterval) * PERIOD_NS;
+      while(mWakeupTime.tv_nsec >= NSEC_PER_SEC) {
+        mWakeupTime.tv_nsec -= NSEC_PER_SEC;
+        mWakeupTime.tv_sec++;
+      }
+    }
+
+  }
+
+  void ECBusHandler::enableECCycle(bool paEnableFlag) {
+    mEnableFlag = paEnableFlag;
+
+    if(paEnableFlag && mLoopPreparedFlag) {
+      clock_gettime(CLOCK_MONOTONIC, &mWakeupTime);
+      mWakeupTime.tv_nsec += static_cast<long>(mConfig.mUpdateInterval) * PERIOD_NS;
+      while(mWakeupTime.tv_nsec >= NSEC_PER_SEC) {
+        mWakeupTime.tv_nsec -= NSEC_PER_SEC;
+        mWakeupTime.tv_sec++;
+      }
+      DEVLOG_INFO("[ECBusHandler]: EtherCAT cycle resumed.\n");
+    }
+  }
+}

--- a/modules/ethercat/handler/bus.cpp
+++ b/modules/ethercat/handler/bus.cpp
@@ -13,7 +13,6 @@
 
 // #include <sched.h>
 #include <sys/mman.h>
-#include <fmt/base.h>
 #include "forte/timerha.h"
 #include "forte/io/mapper/io_mapper.h"
 #include "bus.h"

--- a/modules/ethercat/handler/bus.h
+++ b/modules/ethercat/handler/bus.h
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <ecrt.h>
+#include "../slave/slave.h"
+#include <forte/io/device/io_controller_multi.h>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class ECSlaveHandler;
+
+  class ECBusHandler : public forte::io::IODeviceMultiController {
+
+    public:
+      explicit ECBusHandler(CDeviceExecution &paDeviceExecution);
+
+      struct Config : IODeviceController::Config {
+        unsigned int mECMasterId;
+        unsigned int mUpdateInterval;
+      };
+
+      class HandleDescriptor : public IODeviceMultiController::HandleDescriptor {
+        public:
+          uint8_t mOffset;
+          uint8_t mByteLength;
+
+          HandleDescriptor(std::string const &paId,
+                           forte::io::IOMapper::Direction paDirection,
+                           size_t paSlaveIndex,
+                           uint8_t paOffset,
+                           uint8_t paByteLength) : 
+              IODeviceMultiController::HandleDescriptor(paId, paDirection, paSlaveIndex),
+              mOffset(paOffset),
+              mByteLength(paByteLength){
+          }
+      };
+
+      void setConfig(struct IODeviceController::Config *paConfig) override;
+
+      void addSlave(ECSlaveHandler *slave);
+      ECSlaveHandler *getSlave(size_t paSlaveIndex);
+
+      void addSlaveHandle(size_t paSlaveIndex, std::unique_ptr<forte::io::IOHandle> paHandle) override;
+      void dropSlaveHandles(size_t paSlaveIndex) override;
+
+      void enableECCycle(bool paEnableFlag);
+      bool isShuttingDown() const {
+        return mIsShuttingDown;
+      }
+
+    protected:
+      const char* init() override;
+      void deInit() override;
+
+      forte::io::IOHandle *createIOHandle(IODeviceController::HandleDescriptor &paHandleDescriptor) override;
+
+      void prepareLoop();
+      void runLoop() override;
+
+      // Config
+      struct  Config mConfig;
+      
+      // Devices
+      std::vector<ECSlaveHandler *> mDevices;
+      
+    private:
+      bool isSlaveAvailable(size_t paSlaveIndex) override;
+      bool checkSlaveType(size_t paSlaveIndex, int paSlaveType);
+      
+      ec_master_t *mECMaster;
+      ec_domain_t *mECDomain;
+      uint8_t *mECDomainPd;
+
+      struct timespec mWakeupTime;
+      static const long PERIOD_NS = 1000L;      // 1us in nanoseconds
+      static const long NSEC_PER_SEC = 1000000000L;
+
+      bool mInitializedFlag;
+      bool mLoopPreparedFlag;
+      bool mEnableFlag;
+      bool mIsShuttingDown;
+  };
+
+}

--- a/modules/ethercat/slave/ec_device.cpp
+++ b/modules/ethercat/slave/ec_device.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ec_device.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  ECDeviceHandler::ECDeviceHandler(ECBusHandler *paBus, 
+                                   ECSlaveHandler::SlaveType paSlaveType, 
+                                   size_t paSlaveIndex) : 
+      ECSlaveHandler(paBus, paSlaveType, paSlaveIndex) {
+  }
+
+  void ECDeviceHandler::setConfig(struct ECSlaveHandler::Config *paConfig) {
+    mConfig = *static_cast<Config *>(paConfig);
+
+    mECDeviceModel.mAlias = mConfig.mAlias;
+    mECDeviceModel.mPosition = mConfig.mPosition;
+    mECDeviceModel.mVendorId = mConfig.mVendorId;
+    mECDeviceModel.mProductCode = mConfig.mProductCode;
+  }
+}

--- a/modules/ethercat/slave/ec_device.h
+++ b/modules/ethercat/slave/ec_device.h
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "slave.h"
+#include "model/ec_model.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class ECDeviceHandler : public ECSlaveHandler {
+    
+    public:
+      struct Config : ECSlaveHandler::Config {
+        uint16_t mAlias;
+        uint16_t mPosition;
+        uint32_t mVendorId;
+        uint32_t mProductCode;
+      };
+
+      ECDeviceModel mECDeviceModel;
+
+      void setConfig(struct ECSlaveHandler::Config *paConfig) override;
+
+      ECDeviceHandler(ECBusHandler *paBus, ECSlaveHandler::SlaveType paSlaveType, size_t paSlaveIndex);
+
+    protected:
+      struct Config mConfig;
+  };
+}

--- a/modules/ethercat/slave/ec_module.cpp
+++ b/modules/ethercat/slave/ec_module.cpp
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ec_module.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  ECModuleHandler::ECModuleHandler(ECBusHandler *paBus, 
+                                   size_t paSlaveIndex) : 
+      ECSlaveHandler(paBus, SlaveType::ECModule, paSlaveIndex) {
+  }
+
+  void ECModuleHandler::setConfig(struct ECSlaveHandler::Config *paConfig) {
+    mConfig = *static_cast<Config *>(paConfig);
+  }
+}

--- a/modules/ethercat/slave/ec_module.h
+++ b/modules/ethercat/slave/ec_module.h
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "slave.h"
+#include "ec_device.h"
+#include <cstdint>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class ECModuleHandler : public ECSlaveHandler {
+    
+    public:
+      struct Config : ECSlaveHandler::Config {
+        uint32_t mModuleIdent;
+        uint16_t mSlot;
+      };
+
+      void setConfig(struct ECSlaveHandler::Config *paConfig) override;
+
+      ECModuleHandler(ECBusHandler *paBus, size_t paSlaveIndex);
+
+      uint32_t moduleIdent() const {
+        return mConfig.mModuleIdent;
+      }
+
+      uint16_t slot() const {
+        return mConfig.mSlot;
+      }
+
+    protected:
+      ECModuleHandler *mDeviceHandler;
+      struct Config mConfig;
+  };
+}

--- a/modules/ethercat/slave/handle.cpp
+++ b/modules/ethercat/slave/handle.cpp
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "handle.h"
+#include "slave.h"
+#include "forte/datatypes/forte_byte.h"
+#include "forte/datatypes/forte_word.h"
+#include "forte/datatypes/forte_dword.h"
+#include "forte/datatypes/forte_lword.h"
+#include "forte/io/mapper/io_mapper.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  ECSlaveHandle::ECSlaveHandle(forte::io::IODeviceController *paController,
+                                forte::io::IOMapper::Direction paDirection,
+                                CIEC_ANY::EDataTypeID paType,
+                                uint8_t paOffset,
+                                const std::string &paHandleId,
+                                ECSlaveHandler *paSlave) :
+      IOHandle(paController, paDirection, paType),
+      mOffset(paOffset),
+      mSlave(paSlave),
+      mECDomainDataOffset(0),
+      mUpdateMutex(&mSlave->mUpdateMutex),
+      mHandleId(paHandleId) {
+    if(paDirection == forte::io::IOMapper::In){
+      mBuffer = mSlave->mUpdateRecvImage;
+    } else if(paDirection == forte::io::IOMapper::Out) {
+      mBuffer = mSlave->mUpdateSendImage;
+    }
+
+    switch (paType) {
+      case CIEC_ANY::EDataTypeID::e_BYTE:
+        mByteLength = 1;
+        break;
+      case CIEC_ANY::EDataTypeID::e_WORD:
+        mByteLength = 2;
+        break;
+      case CIEC_ANY::EDataTypeID::e_DWORD:
+        mByteLength = 4;
+        break;
+      case CIEC_ANY::EDataTypeID::e_LWORD:
+        mByteLength = 8;
+        break;
+      default:
+        break;
+    }
+
+  }
+
+  ECSlaveHandle::~ECSlaveHandle() = default;
+
+  void ECSlaveHandle::syncDomainData(uint8_t *paECDomainData) {
+    uint8_t *ecDomainData = paECDomainData + mECDomainDataOffset;
+    if(isInput()) {
+      memcpy(mBuffer + mOffset, ecDomainData, mByteLength);
+    } else if(isOutput()) {
+      memcpy(ecDomainData, mBuffer + mOffset, mByteLength);
+    }
+  }
+
+  void ECSlaveHandle::set(const CIEC_ANY &paValue) {
+    switch (mType) {
+      case CIEC_ANY::EDataTypeID::e_BYTE: {
+        uint8_t value = static_cast<const CIEC_BYTE &>(paValue);
+        memcpy(mBuffer + mOffset, &value, sizeof(uint8_t));
+      }
+      break;
+      case CIEC_ANY::EDataTypeID::e_WORD: {
+        uint16_t value = static_cast<const CIEC_WORD &>(paValue);
+        uint16_t littleEndValue = hostToLittleEndian(value);
+        memcpy(mBuffer + mOffset, &littleEndValue, sizeof(uint16_t));
+      }
+      break;
+      case CIEC_ANY::EDataTypeID::e_DWORD: {
+        uint32_t value = static_cast<const CIEC_DWORD &>(paValue);
+        uint32_t littleEndValue = hostToLittleEndian(value);
+        memcpy(mBuffer + mOffset, &littleEndValue, sizeof(uint32_t));
+      }
+      break;
+      case CIEC_ANY::EDataTypeID::e_LWORD: {
+        uint64_t value = static_cast<const CIEC_LWORD &>(paValue);
+        uint64_t littleEndValue = hostToLittleEndian(value);
+        memcpy(mBuffer + mOffset, &littleEndValue, sizeof(uint64_t));
+      }
+      break;
+      default:
+        DEVLOG_ERROR("ethercat[ECSlaveHandle]:Unsupported data type for set.\n");
+      break;
+    }
+  }
+
+  void ECSlaveHandle::get(CIEC_ANY &paValue) {
+    switch (mType){
+      case CIEC_ANY::EDataTypeID::e_BYTE:
+        static_cast<CIEC_BYTE &>(paValue) = getByteValue(mBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_WORD:
+        static_cast<CIEC_WORD &>(paValue) = getWordValue(mBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_DWORD:
+        static_cast<CIEC_DWORD &>(paValue) = getDWordValue(mBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_LWORD:
+        static_cast<CIEC_LWORD &>(paValue) = getLWordValue(mBuffer);
+        break;
+      default:
+        DEVLOG_ERROR("ethercat[ECSlaveHandle]:Unsupported data type for get.\n");
+        break;
+    }
+  }
+
+  bool ECSlaveHandle::equal(unsigned char *paOldBuffer) {
+    bool result = false;
+
+    switch (mType){
+      case CIEC_ANY::EDataTypeID::e_BYTE:
+        result = getByteValue(mBuffer) == getByteValue(paOldBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_WORD:
+        result = getWordValue(mBuffer) == getWordValue(paOldBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_DWORD:
+        result = getDWordValue(mBuffer) == getDWordValue(paOldBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_LWORD:
+        result = getLWordValue(mBuffer) == getLWordValue(paOldBuffer);
+        break;
+      default:
+        result = false;
+        DEVLOG_ERROR("ethercat(ECSlaveHandle):Unsupported type for equal.\n");
+        break;
+    }
+
+    return result;
+  }
+
+  const CIEC_BYTE ECSlaveHandle::getByteValue(const unsigned char* paBuffer){
+    uint8_t *p = (uint8_t*)(paBuffer + mOffset);
+    return CIEC_BYTE(*p);
+  }
+
+  const CIEC_WORD ECSlaveHandle::getWordValue(const unsigned char* paBuffer){
+    uint16_t value;
+    memcpy(&value, paBuffer + mOffset, sizeof(uint16_t));
+    uint16_t hostValue = littleEndianToHost(value);   
+    return CIEC_WORD(hostValue);
+  }
+
+  const CIEC_DWORD ECSlaveHandle::getDWordValue(const unsigned char* paBuffer){
+    uint32_t value;
+    memcpy(&value, paBuffer + mOffset, sizeof(uint32_t));
+    uint32_t hostValue = littleEndianToHost(value);  
+    return CIEC_DWORD(hostValue);
+  }
+
+  const CIEC_LWORD ECSlaveHandle::getLWordValue(const unsigned char* paBuffer){
+    uint64_t value;
+    memcpy(&value, paBuffer + mOffset, sizeof(uint64_t));
+    uint64_t hostValue = littleEndianToHost(value);
+    return CIEC_LWORD(hostValue);
+  }
+
+  void ECSlaveHandle::onObserver(forte::io::IOObserver *paObserver) {
+    reset();
+    IOHandle::onObserver(paObserver);
+  }
+
+  void ECSlaveHandle::dropObserver() {
+    IOHandle::dropObserver();
+    reset();
+  }
+}

--- a/modules/ethercat/slave/handle.h
+++ b/modules/ethercat/slave/handle.h
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/io/mapper/io_handle.h"
+#include "forte/arch/forte_sync.h"
+#include "endian.h"
+#include <string>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class ECSlaveHandler;
+
+  class ECSlaveHandle : public forte::io::IOHandle {
+    public:
+			friend class ECSlaveHandler;
+			
+      ECSlaveHandle(forte::io::IODeviceController *paController,
+                    forte::io::IOMapper::Direction paDirection,
+                    CIEC_ANY::EDataTypeID type,
+                    uint8_t paOffset,
+                    const std::string &paHandleId,
+                    ECSlaveHandler *paSlave);
+      ~ECSlaveHandle() override;
+
+      const std::string &handleId() const {
+        return mHandleId;
+      }
+
+      /** Domain byte offset for EtherCAT registration (EsiFileParser / ECDeviceModel). */
+      unsigned int *ecDomainOffsetPtr() {
+        return &mECDomainDataOffset;
+      }
+
+      void set(const CIEC_ANY &) override;
+      void get(CIEC_ANY &) override;
+      bool equal(unsigned char *);
+
+    protected:
+			static constexpr bool IS_LITTLE_ENDIAN = __BYTE_ORDER == __LITTLE_ENDIAN;	
+
+			template<typename T>
+			static T hostLeEndianSwap(T value) {
+				if constexpr (!IS_LITTLE_ENDIAN) {
+					if constexpr (sizeof(T) == 2) {
+						return static_cast<T>(__builtin_bswap16(static_cast<uint16_t>(value)));
+					} else if constexpr (sizeof(T) == 4) {
+						return static_cast<T>(__builtin_bswap32(static_cast<uint32_t>(value)));
+					} else if constexpr (sizeof(T) == 8) {
+						return static_cast<T>(__builtin_bswap64(static_cast<uint64_t>(value)));
+					}
+				}
+
+				return value;
+			}
+
+			template<typename T>
+			static T hostToLittleEndian(T value) {
+				return hostLeEndianSwap(value);
+			}
+
+			template<typename T>
+			static T littleEndianToHost(T value) {
+				return hostLeEndianSwap(value);
+			}
+
+			const CIEC_BYTE getByteValue(const unsigned char *paBuffer);
+			const CIEC_WORD getWordValue(const unsigned char *paBuffer);
+			const CIEC_DWORD getDWordValue(const unsigned char *paBuffer);
+			const CIEC_LWORD getLWordValue(const unsigned char *paBuffer);
+        
+      virtual void reset() {}
+      void onObserver(forte::io::IOObserver *paObserver) override;
+      void dropObserver() override;
+			void syncDomainData(uint8_t *paECDomainData);
+
+      unsigned char *mBuffer;
+      const uint8_t mOffset;
+
+      unsigned int mECDomainDataOffset;
+      ECSlaveHandler *mSlave;
+			arch::CSyncObject *mUpdateMutex;
+
+			size_t mByteLength;
+      std::string mHandleId;
+  };
+}

--- a/modules/ethercat/slave/model/ec_model.cpp
+++ b/modules/ethercat/slave/model/ec_model.cpp
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ec_model.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  PdoEntry::PdoEntry(uint16_t paPdoIndex, uint16_t paIndex, uint8_t paSubIndex, uint8_t paBitLength) :
+    mPdoIndex(paPdoIndex),mIndex(paIndex),mSubIndex(paSubIndex),mBitLength(paBitLength) {
+  }
+
+  Pdo::Pdo(uint16_t paIndex, SyncDir paSyncDir) :
+    mIndex(paIndex), mSyncDir(paSyncDir) {
+  }
+
+  Sync::Sync(uint8_t paIndex, SyncDir paSyncDir) :
+    mIndex(paIndex), mSyncDir(paSyncDir) {
+  }
+
+  EntryReg::EntryReg(uint16_t paAlias, uint16_t paPosition, uint32_t paVendorId, uint32_t paProductCode, uint16_t paIndex, uint8_t paSubIndex, unsigned int *paOffset) :
+    mAlias(paAlias), mPosition(paPosition), mVendorId(paVendorId), mProductCode(paProductCode), mIndex(paIndex), mSubIndex(paSubIndex), mOffset(paOffset) {
+  }
+
+  ECDeviceModel::ECDeviceModel(uint16_t paAlias, uint16_t paPosition, uint32_t paVendorId, uint32_t paProductCode, uint32_t paSlotIndexInc, uint32_t paSlotPdoInc) :
+    mAlias(paAlias), mPosition(paPosition), mVendorId(paVendorId), mProductCode(paProductCode), mSlotIndexInc(paSlotIndexInc), mSlotPdoInc(paSlotPdoInc),
+    cachedSyncs(nullptr), cachedRxPdoSize(0), cachedTxPdoSize(0), cachedDomainRegs(nullptr) {
+  }
+
+  ECDeviceModel::~ECDeviceModel() {
+    cleanupSync();
+    cleanupDomainReg();
+  }
+
+  void ECDeviceModel::addSync(uint8_t paIndex, SyncDir paSyncDir) {
+    Sync sync {paIndex, paSyncDir};
+    mSyncList.push_back(sync);
+  }
+
+  void ECDeviceModel::addPdo(uint16_t paIndex, SyncDir paSyncDir) {
+    Pdo pdo {paIndex, paSyncDir};
+    mPdoList.push_back(pdo);
+  }
+
+  void ECDeviceModel::addPdoEntry(uint16_t paPdoIndex, uint16_t paIndex, uint8_t paSubIndex, uint8_t paBitlength) {
+    PdoEntry entry {paPdoIndex, paIndex, paSubIndex, paBitlength};
+    mPdoEntryList.push_back(entry);
+  }
+
+  void ECDeviceModel::addEntryReg(uint16_t paIndex, uint8_t paSubIndex, unsigned int *paOffset) {
+    EntryReg reg {mAlias, mPosition, mVendorId, mProductCode, paIndex, paSubIndex, paOffset};
+    mEntryRegList.push_back(reg);
+  }
+
+  void ECDeviceModel::cleanupSync() {
+    if(cachedSyncs != nullptr) {
+      if(cachedSyncs[0].pdos != nullptr) {
+        for(unsigned int i = 0; i < cachedRxPdoSize; i++) {
+          if(cachedSyncs[0].pdos[i].entries != nullptr) {
+            delete[] cachedSyncs[0].pdos[i].entries;
+          }
+        }
+
+        delete[] cachedSyncs[0].pdos;
+      }
+
+      if(cachedSyncs[1].pdos != nullptr) {
+        for(unsigned int i = 0; i < cachedTxPdoSize; i++) {
+          if(cachedSyncs[1].pdos[i].entries != nullptr) {
+            delete[] cachedSyncs[1].pdos[i].entries;
+          }
+        }
+
+        delete[] cachedSyncs[1].pdos;
+      }
+
+      delete[] cachedSyncs;
+      cachedSyncs = nullptr;
+      cachedRxPdoSize = 0;
+      cachedTxPdoSize = 0;
+    }
+  }
+
+  void ECDeviceModel::cleanupDomainReg() {
+    if(cachedDomainRegs != nullptr) {
+      delete[] cachedDomainRegs;
+      cachedDomainRegs = nullptr;
+    }
+  }
+
+  void ECDeviceModel::getPdoSize(unsigned int &paRxPdoSize, unsigned int &paTxPdoSize) {
+    for(int i = 0; i < mPdoList.size(); i++) {
+      if(mPdoList[i].mSyncDir == SyncDir::Out) {
+        paRxPdoSize++;
+      } else {
+        paTxPdoSize++;
+      }
+    }
+  }
+
+  void ECDeviceModel::getPdoEntrySize(uint16_t paPdoIndex, unsigned int &paPdoEntrySize) {
+    for(int i = 0; i < mPdoEntryList.size(); i++) {
+      if(mPdoEntryList[i].mPdoIndex == paPdoIndex) {
+        paPdoEntrySize++;
+      }
+    }
+  }
+
+  ec_pdo_entry_reg_t* ECDeviceModel::getDomainRegs(){
+    cleanupDomainReg();
+    
+    ec_pdo_entry_reg_t* regs = new ec_pdo_entry_reg_t[mEntryRegList.size() + 1];
+    
+    for(size_t i = 0; i < mEntryRegList.size(); i++){
+        regs[i] = {
+          mEntryRegList[i].mAlias,
+          mEntryRegList[i].mPosition,
+          mEntryRegList[i].mVendorId,
+          mEntryRegList[i].mProductCode,
+          mEntryRegList[i].mIndex,
+          mEntryRegList[i].mSubIndex,
+          mEntryRegList[i].mOffset,
+          nullptr  // bit_position
+        };
+    }
+    
+    regs[mEntryRegList.size()] = {};
+    
+    cachedDomainRegs = regs;
+    return regs;
+  }
+
+  ec_sync_info_t* ECDeviceModel::getSyncs(){
+    // Clean up previously cached syncs if any
+    cleanupSync();
+    
+    ec_sync_info_t* syncInfos = new ec_sync_info_t[3];
+    syncInfos[0] = {2, EC_DIR_OUTPUT, 0, nullptr, EC_WD_DEFAULT};
+    syncInfos[1] = {3, EC_DIR_INPUT, 0, nullptr, EC_WD_DEFAULT};
+    syncInfos[2] = {0xff};
+
+    unsigned int rxPdoSize = 0;
+    unsigned int txPdoSize = 0;
+    getPdoSize(rxPdoSize, txPdoSize);
+    
+    // Cache the sizes for later cleanup
+    cachedRxPdoSize = rxPdoSize;
+    cachedTxPdoSize = txPdoSize;
+   
+    // Build RxPDO (OUTPUT direction - from master to slave)
+    if(rxPdoSize > 0){
+        ec_pdo_info_t* rxPdoes = new ec_pdo_info_t[rxPdoSize];
+        int pdoIdx = 0;  // Use separate index for PDO array
+        for(int i = 0; i < mPdoList.size(); i++){
+            if(mPdoList[i].mSyncDir == SyncDir::Out){
+                uint16_t pdoIndex = mPdoList[i].mIndex;
+                unsigned int pdoEntrySize = 0;
+                getPdoEntrySize(pdoIndex, pdoEntrySize);
+                
+                ec_pdo_entry_info_t* entries = new ec_pdo_entry_info_t[pdoEntrySize];
+                int entryIdx = 0;
+                for(int j = 0; j < mPdoEntryList.size(); j++){
+                    if(mPdoEntryList[j].mPdoIndex == pdoIndex){
+                        entries[entryIdx] = {mPdoEntryList[j].mIndex, mPdoEntryList[j].mSubIndex, mPdoEntryList[j].mBitLength};
+                        entryIdx++;
+                    }                 
+                }
+                rxPdoes[pdoIdx] = {mPdoList[i].mIndex, pdoEntrySize, entries};
+                pdoIdx++;
+            }     
+        }
+        syncInfos[0].n_pdos = rxPdoSize; 
+        syncInfos[0].pdos = rxPdoes;
+    }
+
+    // Build TxPDO (INPUT direction - from slave to master)
+    if(txPdoSize > 0){
+        ec_pdo_info_t* txPdoes = new ec_pdo_info_t[txPdoSize];
+        int pdoIdx = 0;  // Use separate index for PDO array
+        for(int i = 0; i < mPdoList.size(); i++){
+            if(mPdoList[i].mSyncDir == SyncDir::In){
+                uint16_t pdoIndex = mPdoList[i].mIndex;
+                unsigned int pdoEntrySize = 0;
+                getPdoEntrySize(pdoIndex, pdoEntrySize);
+                
+                ec_pdo_entry_info_t* entries = new ec_pdo_entry_info_t[pdoEntrySize];
+                int entryIdx = 0;
+                for(int j = 0; j < mPdoEntryList.size(); j++){
+                    if(mPdoEntryList[j].mPdoIndex == pdoIndex){
+                        entries[entryIdx] = {mPdoEntryList[j].mIndex, mPdoEntryList[j].mSubIndex, mPdoEntryList[j].mBitLength};
+                        entryIdx++;
+                    }                 
+                }
+                txPdoes[pdoIdx] = {mPdoList[i].mIndex, pdoEntrySize, entries};
+                pdoIdx++;
+            }
+        }
+        syncInfos[1].n_pdos = txPdoSize;
+        syncInfos[1].pdos = txPdoes;
+    }
+
+    // Cache the pointer for later cleanup
+    cachedSyncs = syncInfos;
+    return syncInfos;
+  }
+  
+}

--- a/modules/ethercat/slave/model/ec_model.h
+++ b/modules/ethercat/slave/model/ec_model.h
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "ecrt.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  typedef enum {In, Out} SyncDir;
+
+  struct PdoEntry {
+    uint16_t mPdoIndex;
+    uint16_t mIndex;
+    uint8_t mSubIndex;
+    uint8_t mBitLength;
+
+    PdoEntry() = default;
+    PdoEntry(uint16_t paPdoIndex, uint16_t paIndex, uint8_t paSubIndex, uint8_t paBitLength);
+  };
+
+  struct Pdo {
+    uint16_t mIndex;
+    SyncDir mSyncDir;
+
+    Pdo() = default;
+    Pdo(uint16_t paIndex, SyncDir paDir);
+  };
+
+  struct Sync {
+    uint8_t mIndex;
+    SyncDir mSyncDir;
+
+    Sync() = default;
+    Sync(uint8_t paIndex, SyncDir paDir);
+  };
+
+  struct EntryReg {
+    uint16_t mAlias;
+    uint16_t mPosition;
+    uint32_t mVendorId;
+    uint32_t mProductCode;
+    uint16_t mIndex;
+    uint8_t mSubIndex;
+    unsigned int* mOffset;
+
+    EntryReg() = default;
+    EntryReg(uint16_t paAlias, uint16_t paPosition, uint32_t paVendorId, uint32_t paProductCode, uint16_t paIndex, uint8_t paSubIndex, unsigned int *paOffset);
+  };
+
+  struct ECDeviceModel {
+    uint16_t mAlias;
+    uint16_t mPosition;
+    uint32_t mVendorId;
+    uint32_t mProductCode;
+
+    uint32_t mSlotIndexInc;
+    uint32_t mSlotPdoInc;
+
+    std::vector<Sync> mSyncList;
+    std::vector<Pdo> mPdoList;
+    std::vector<PdoEntry> mPdoEntryList;
+    std::vector<EntryReg> mEntryRegList;
+
+    ECDeviceModel() = default;
+    ECDeviceModel(uint16_t paAlias, uint16_t paPosition, uint32_t paVendorId, uint32_t paProductCode, uint32_t paSlotIndexInc, uint32_t paSlotPdoInc);
+    ~ECDeviceModel();
+
+    void addSync(uint8_t paSyncIndex, SyncDir paDir);
+    void addPdo(uint16_t paPdoIndex,  SyncDir paDir);
+    void addPdoEntry(uint16_t paPdoIndex, uint16_t paEntryIndex, uint8_t paSubIndex, uint8_t paBitLength);
+    void addEntryReg(uint16_t paIndex, uint8_t paSubIndex, unsigned int *paOffset);
+
+    ec_sync_info_t *getSyncs();
+    ec_pdo_entry_reg_t *getDomainRegs();
+
+    void cleanupSync();
+    void cleanupDomainReg();
+
+    void getPdoSize(unsigned int &paRxPdoSize, unsigned int &paTxPdoSize);
+    void getPdoEntrySize(uint16_t paPdoIndex, unsigned int &paPdoEntrySize);
+
+  private:
+    ec_sync_info_t *cachedSyncs = nullptr;
+    unsigned int cachedRxPdoSize = 0;
+    unsigned int cachedTxPdoSize = 0;
+
+    ec_pdo_entry_reg_t *cachedDomainRegs = nullptr;
+  };
+}

--- a/modules/ethercat/slave/slave.cpp
+++ b/modules/ethercat/slave/slave.cpp
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "slave.h"
+#include "../handler/bus.h"
+#include "forte/io/mapper/io_mapper.h"
+#include "forte/util/criticalregion.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  ECSlaveHandler::ECSlaveHandler(ECBusHandler *paBus,
+                                 SlaveType paSlaveType,
+                                 size_t paSlaveIndex) : 
+      mDelegate(nullptr),
+      mSlaveIndex(paSlaveIndex),
+      mSlaveType(paSlaveType),
+      mBus(paBus),
+      mUpdateSendImage(nullptr),
+      mUpdateRecvImage(nullptr),
+      mUpdateRecvImageOld(nullptr),
+      mDataSendLength(0),
+      mDataRecvLength(0),
+      mStatus(NotInitialized),
+      mOldStatus(NotInitialized) {
+  }
+
+  ECSlaveHandler::~ECSlaveHandler() {
+    dropHandles();
+
+    delete[] mUpdateSendImage;
+    delete[] mUpdateRecvImage;
+    delete[] mUpdateRecvImageOld;
+
+    if (mDelegate != nullptr) {
+      if(mBus != nullptr && mBus->isShuttingDown()) {
+        mDelegate = nullptr;
+        return;
+      }
+      mDelegate->onSlaveDestroy();
+    }
+  }
+
+  void ECSlaveHandler::initBuffer(uint16_t paDataSendLength, uint16_t paDataRecvLength) {
+    mDataSendLength = paDataSendLength;
+    mDataRecvLength = paDataRecvLength;
+
+    mUpdateSendImage = new unsigned char[mDataSendLength];
+    mUpdateRecvImage = new unsigned char[mDataRecvLength];
+    mUpdateRecvImageOld = new unsigned char[mDataRecvLength];
+
+    memset(mUpdateSendImage, 0, mDataSendLength);
+    memset(mUpdateRecvImage, 0, mDataRecvLength);
+    memset(mUpdateRecvImageOld, 0, mDataRecvLength);
+  }
+
+  void ECSlaveHandler::update(uint8_t *paECDomainData) {
+    util::CCriticalRegion critialRegion(mHandleMutex);
+
+    for(ECSlaveHandle *handle : mInputs) {
+      handle->syncDomainData(paECDomainData);
+      if(handle->hasObserver() && !handle->equal(mUpdateRecvImageOld)){
+        handle->onChange();
+      }
+    }
+
+    memcpy(mUpdateRecvImageOld, mUpdateRecvImage, mDataRecvLength);
+
+    for(ECSlaveHandle *handle : mOutputs) {
+      handle->syncDomainData(paECDomainData);
+    }
+  }
+
+  void ECSlaveHandler::dropHandles() {
+    util::CCriticalRegion criticalRegion(mHandleMutex);
+    forte::io::IOMapper &mapper = forte::io::IOMapper::getInstance();
+
+    if(mBus != nullptr && mBus->isShuttingDown()) {
+      mInputs.clear();
+      mOutputs.clear();
+      return;
+    }
+
+    for(ECSlaveHandle *it : mInputs) {
+      mapper.deregisterHandle(it->handleId());
+      delete it;
+    }
+
+    for(ECSlaveHandle *it : mOutputs) {
+      mapper.deregisterHandle(it->handleId());
+      delete it;
+    }
+
+    mInputs.clear();
+    mOutputs.clear();
+  }
+
+  void ECSlaveHandler::addHandle(std::vector<ECSlaveHandle *> &paList, ECSlaveHandle *paHandle) {
+    util::CCriticalRegion criticalRegion(mHandleMutex);
+    paList.push_back(paHandle);
+
+    //TODO Maybe send indication event after connecting
+  }
+
+  ECSlaveHandle *ECSlaveHandler::getHandle(std::vector<ECSlaveHandle *> &paList, size_t paIndex) {
+    if(paList.size() <= paIndex) {
+      return nullptr;
+    }
+    return paList[paIndex];
+  }
+}

--- a/modules/ethercat/slave/slave.h
+++ b/modules/ethercat/slave/slave.h
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "handle.h"
+#include "forte/io/mapper/io_mapper.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+	class ECBusHandler;
+
+	class ECSlaveHandler {
+		
+		public:
+			friend class ECBusHandler;
+
+      enum SlaveStatus {
+        NotInitialized = 0,
+        Error = 1,
+        OK = 2
+      };
+
+      enum SlaveType {
+        ECSlave = 0,
+        ECCoupler = 1,
+        ECModule = 2
+      };
+
+      struct Config{
+      };
+
+      class Delegate {
+        public:
+          virtual void onSlaveStatus(SlaveStatus paStatus, SlaveStatus paOldStatus) = 0;
+          virtual void onSlaveDestroy() = 0;
+      };
+
+      virtual void setConfig(Config* paConfig) = 0;
+      Delegate *mDelegate;
+
+      size_t index() const {
+        return mSlaveIndex;
+      }
+
+      const SlaveType mSlaveType;
+
+      uint16_t dataSendLength() const {
+        return mDataSendLength;
+      }
+
+      uint16_t dataRecvLength() const {
+        return mDataRecvLength;
+      }
+
+      void update(uint8_t *paECDomianPd);
+
+      ECSlaveHandle *getInputHandle(size_t paIndex) {
+        return getHandle(mInputs, paIndex);
+      }
+
+      ECSlaveHandle *getOutputHandle(size_t paIndex) {
+        return getHandle(mOutputs, paIndex);
+      }
+
+      void addHandle(ECSlaveHandle *paHandle) {
+        switch (paHandle->getDirection()){
+          case forte::io::IOMapper::In: addHandle(mInputs, paHandle); break;
+          case forte::io::IOMapper::Out: addHandle(mOutputs, paHandle); break;
+          default: break;
+        }
+      }
+
+      void dropHandles();
+
+      unsigned char *mUpdateSendImage;
+      unsigned char *mUpdateRecvImage;
+      arch::CSyncObject mUpdateMutex;
+
+      void initBuffer(uint16_t paDataSendLength, uint16_t paDataRecvLength);
+
+    protected:
+      size_t mSlaveIndex;
+      
+      ECSlaveHandler(ECBusHandler *paBus, SlaveType paSlaveType, size_t paSlaveIndex);
+      virtual ~ECSlaveHandler();
+
+      ECBusHandler *mBus;
+
+      uint16_t mDataSendLength;
+      uint16_t mDataRecvLength;
+      SlaveStatus mStatus;
+      SlaveStatus mOldStatus;
+      unsigned char *mUpdateRecvImageOld;
+
+      arch::CSyncObject mHandleMutex;
+      std::vector<ECSlaveHandle *> mInputs;
+      std::vector<ECSlaveHandle *> mOutputs;
+      void addHandle(std::vector<ECSlaveHandle *> &paList, ECSlaveHandle *paHandle);
+      ECSlaveHandle *getHandle(std::vector<ECSlaveHandle *> &paList, size_t paIndex);
+
+    private:
+      //! declared but undefined copy constructor as we don't want Slaves to be directly copied.
+      ECSlaveHandler(const ECSlaveHandler &);
+      
+	};
+}

--- a/modules/ethercat/structs/ECModuleConfig.cpp
+++ b/modules/ethercat/structs/ECModuleConfig.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ECModuleConfig.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  StringId CIEC_ECModuleConfig::getStructTypeNameID() const {
+    return "ECModuleConfig"_STRID;
+  }
+
+  const StringId CIEC_ECModuleConfig::scmElementNames[] = {"ModuleIdent"_STRID, "Slot"_STRID};
+
+  DEFINE_FIRMWARE_DATATYPE(ECModuleConfig, "ECModuleConfig"_STRID);
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/structs/ECModuleConfig.h
+++ b/modules/ethercat/structs/ECModuleConfig.h
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/datatypes/forte_struct.h"
+#include "forte/datatypes/forte_udint.h"
+#include "forte/datatypes/forte_uint.h"
+#include "forte/typelib.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class CIEC_ECModuleConfig : public CIEC_STRUCT {
+      DECLARE_FIRMWARE_DATATYPE(ECModuleConfig);
+
+    public:
+      CIEC_UDINT ModuleIdent;
+      CIEC_UINT Slot;
+
+      CIEC_ECModuleConfig() = default;
+
+      size_t getStructSize() const override {
+        return 2;
+      }
+
+      const StringId *elementNames() const override {
+        return scmElementNames;
+      }
+
+      StringId getStructTypeNameID() const override;
+
+      CIEC_ANY *getMember(size_t paMemberIndex) override {
+        switch (paMemberIndex) {
+          case 0: return &ModuleIdent;
+          case 1: return &Slot;
+        }
+        return nullptr;
+      }
+
+      const CIEC_ANY *getMember(size_t paMemberIndex) const override {
+        switch (paMemberIndex) {
+          case 0: return &ModuleIdent;
+          case 1: return &Slot;
+        }
+        return nullptr;
+      }
+
+    private:
+      static const StringId scmElementNames[];
+  };
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/structs/ECSlaveConfig.cpp
+++ b/modules/ethercat/structs/ECSlaveConfig.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ECSlaveConfig.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  StringId CIEC_ECSlaveConfig::getStructTypeNameID() const {
+    return "ECSlaveConfig"_STRID;
+  }
+
+  const StringId CIEC_ECSlaveConfig::scmElementNames[] = {"Alias"_STRID, "Position"_STRID, "VendorId"_STRID, "ProductCode"_STRID};
+
+  DEFINE_FIRMWARE_DATATYPE(ECSlaveConfig, "ECSlaveConfig"_STRID);
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/structs/ECSlaveConfig.h
+++ b/modules/ethercat/structs/ECSlaveConfig.h
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/datatypes/forte_struct.h"
+#include "forte/datatypes/forte_uint.h"
+#include "forte/datatypes/forte_udint.h"
+#include "forte/typelib.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class CIEC_ECSlaveConfig : public CIEC_STRUCT {
+      DECLARE_FIRMWARE_DATATYPE(ECSlaveConfig);
+
+    public:
+      CIEC_UINT Alias;
+      CIEC_UINT Position;
+      CIEC_UDINT VendorId;
+      CIEC_UDINT ProductCode;
+
+      CIEC_ECSlaveConfig() = default;
+
+      size_t getStructSize() const override {
+        return 4;
+      }
+
+      const StringId *elementNames() const override {
+        return scmElementNames;
+      }
+
+      StringId getStructTypeNameID() const override;
+
+      CIEC_ANY *getMember(size_t paMemberIndex) override {
+        switch (paMemberIndex) {
+          case 0: return &Alias;
+          case 1: return &Position;
+          case 2: return &VendorId;
+          case 3: return &ProductCode;
+        }
+        return nullptr;
+      }
+
+      const CIEC_ANY *getMember(size_t paMemberIndex) const override {
+        switch (paMemberIndex) {
+          case 0: return &Alias;
+          case 1: return &Position;
+          case 2: return &VendorId;
+          case 3: return &ProductCode;
+        }
+        return nullptr;
+      }
+
+    private:
+      static const StringId scmElementNames[];
+  };
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/types/ECBusAdapter.cpp
+++ b/modules/ethercat/types/ECBusAdapter.cpp
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ECBusAdapter.h"
+
+#include <array>
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  namespace {
+    const forte::StringId cDataInputNames[] = {"QO"_STRID};
+    const forte::StringId cDataOutputNames[] = {"QI"_STRID, "MasterId"_STRID, "Index"_STRID};
+    const forte::StringId cEventInputNames[] = {"INITO"_STRID};
+    const forte::StringId cEventInputTypeIds[] = {"EInit"_STRID};
+    const forte::StringId cEventOutputNames[] = {"INIT"_STRID};
+    const forte::StringId cEventOutputTypeIds[] = {"EInit"_STRID};
+
+    const SFBInterfaceSpec scmFBInterfaceSpecSocket = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = cEventInputTypeIds,
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = cEventOutputTypeIds,
+        .mDINames = cDataInputNames,
+        .mDONames = cDataOutputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const SFBInterfaceSpec scmFBInterfaceSpecPlug = {
+        .mEINames = cEventOutputNames,
+        .mEITypeNames = cEventOutputTypeIds,
+        .mEONames = cEventInputNames,
+        .mEOTypeNames = cEventInputTypeIds,
+        .mDINames = cDataOutputNames,
+        .mDONames = cDataInputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const auto scmSlaveConfigurationIO = std::array<const TForteUInt8, 0>{};
+  } // namespace
+
+  DEFINE_ADAPTER_TYPE(FORTE_ECBusAdapter, "eclipse4diac::io::ethercat::ECBusAdapter"_STRID)
+
+  FORTE_ECBusAdapter::FORTE_ECBusAdapter(CFBContainer &paContainer,
+                                         const SFBInterfaceSpec &paInterfaceSpec,
+                                         const forte::StringId paInstanceNameId,
+                                         TForteUInt8 paParentAdapterlistID) :
+      IOConfigFBMultiAdapter(
+          scmSlaveConfigurationIO, paContainer, paInterfaceSpec, paInstanceNameId, paParentAdapterlistID) {
+  }
+
+  void FORTE_ECBusAdapter::setInitialValues() {
+  }
+
+  FORTE_ECBusAdapter_Plug::FORTE_ECBusAdapter_Plug(forte::StringId paInstanceNameId,
+                                                   CFBContainer &paContainer,
+                                                   TForteUInt8 paParentAdapterlistID) :
+      FORTE_ECBusAdapter(paContainer, scmFBInterfaceSpecPlug, paInstanceNameId, paParentAdapterlistID),
+      conn_INITO(*this, 0),
+      conn_QI(nullptr),
+      conn_MasterId(nullptr),
+      conn_MasterIndex(nullptr),
+      conn_QO(*this, 0, var_QO) {
+  }
+
+  void FORTE_ECBusAdapter_Plug::readInputData(TEventID paEIID) {
+    if (paEIID == scmEventINITID) {
+      readData(0, var_QI, conn_QI);
+      readData(1, var_MasterId, conn_MasterId);
+      readData(2, var_Index, conn_MasterIndex);
+      if (getPeer() != nullptr) {
+        getSocket()->var_QI = var_QI;
+        getSocket()->var_MasterId = var_MasterId;
+        getSocket()->var_Index = var_Index;
+      }
+    }
+  }
+
+  void FORTE_ECBusAdapter_Plug::writeOutputData(TEventID paEIID) {
+    if (paEIID == scmEventINITOID) {
+      writeData(scmFBInterfaceSpecPlug.getNumDIs() + 0, var_QO, conn_QO);
+    }
+  }
+
+  CEventConnection *FORTE_ECBusAdapter_Plug::getEOConUnchecked(TPortId paEONum) {
+    return (paEONum == 0) ? &conn_INITO : nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECBusAdapter_Plug::getDI(TPortId paDINum) {
+    switch (paDINum) {
+      case 0: return &var_QI; break;
+      case 1: return &var_MasterId; break;
+      case 2: return &var_Index; break;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_ECBusAdapter_Plug::getDIConUnchecked(TPortId paDINum) {
+    switch (paDINum) {
+      case 0: return &conn_QI; break;
+      case 1: return &conn_MasterId; break;
+      case 2: return &conn_MasterIndex; break;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_ECBusAdapter_Plug::getDOConUnchecked(TPortId paDONum) {
+    return (paDONum == 0) ? &conn_QO : nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECBusAdapter_Plug::getDO(TPortId paDONum) {
+    return (paDONum == 0) ? &var_QO : nullptr;
+  }
+
+  FORTE_ECBusAdapter_Socket *FORTE_ECBusAdapter_Plug::getSocket() {
+    return static_cast<FORTE_ECBusAdapter_Socket *>(getPeer());
+  }
+
+  FORTE_ECBusAdapter_Socket::FORTE_ECBusAdapter_Socket(forte::StringId paInstanceNameId,
+                                                       CFBContainer &paContainer,
+                                                       TForteUInt8 paParentAdapterlistID) :
+      FORTE_ECBusAdapter(paContainer, scmFBInterfaceSpecSocket, paInstanceNameId, paParentAdapterlistID),
+      conn_QO(nullptr),
+      conn_INIT(*this, 0),
+      conn_QI(*this, 0, var_QI),
+      conn_MasterId(*this, 1, var_MasterId),
+      conn_MasterIndex(*this, 2, var_Index) {
+  }
+
+  void FORTE_ECBusAdapter_Socket::readInputData(TEventID paEIID) {
+    if (paEIID == scmEventINITOID) {
+      readData(0, var_QO, conn_QO);
+      if (getPeer() != nullptr) {
+        getPlug()->var_QO = var_QO;
+      }
+    }
+  }
+
+  void FORTE_ECBusAdapter_Socket::writeOutputData(TEventID paEIID) {
+    if (paEIID == scmEventINITID) {
+      writeData(scmFBInterfaceSpecSocket.getNumDIs() + 0, var_QI, conn_QI);
+      writeData(scmFBInterfaceSpecSocket.getNumDIs() + 1, var_MasterId, conn_MasterId);
+      writeData(scmFBInterfaceSpecSocket.getNumDIs() + 2, var_Index, conn_MasterIndex);
+    }
+  }
+
+  CEventConnection *FORTE_ECBusAdapter_Socket::getEOConUnchecked(TPortId paEONum) {
+    return (paEONum == 0) ? &conn_INIT : nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECBusAdapter_Socket::getDI(TPortId paDINum) {
+    return (paDINum == 0) ? &var_QO : nullptr;
+  }
+
+  CDataConnection **FORTE_ECBusAdapter_Socket::getDIConUnchecked(TPortId paDINum) {
+    return (paDINum == 0) ? &conn_QO : nullptr;
+  }
+
+  CDataConnection *FORTE_ECBusAdapter_Socket::getDOConUnchecked(TPortId paDONum) {
+    switch (paDONum) {
+      case 0: return &conn_QI; break;
+      case 1: return &conn_MasterId; break;
+      case 2: return &conn_MasterIndex; break;
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECBusAdapter_Socket::getDO(TPortId paDONum) {
+    switch (paDONum) {
+      case 0: return &var_QI; break;
+      case 1: return &var_MasterId; break;
+      case 2: return &var_Index; break;
+    }
+    return nullptr;
+  }
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/types/ECBusAdapter.h
+++ b/modules/ethercat/types/ECBusAdapter.h
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/io/configFB/io_adapter_multi.h"
+#include "forte/datatypes/forte_uint.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECBusAdapter : public forte::io::IOConfigFBMultiAdapter {
+    DECLARE_ADAPTER_TYPE(FORTE_ECBusAdapter)
+
+    public:
+      static const TEventID scmEventINITOID = 0;
+      static const TEventID scmEventINITID = 0;
+
+      TEventID evt_INITO() {
+        return getParentAdapterListEventID() + scmEventINITOID;
+      }
+
+      TEventID evt_INIT() {
+        return getParentAdapterListEventID() + scmEventINITID;
+      }
+
+      ~FORTE_ECBusAdapter() override = default;
+
+      void setInitialValues() override;
+
+      CIEC_ANY *getDeviceConfigPin(int) override {
+        return nullptr;
+      }
+
+    protected:
+      FORTE_ECBusAdapter(CFBContainer &paContainer,
+                         const SFBInterfaceSpec &paInterfaceSpec,
+                         const forte::StringId paInstanceNameId,
+                         TForteUInt8 paParentAdapterlistID);
+  };
+
+  class FORTE_ECBusAdapter_Socket;
+
+  class FORTE_ECBusAdapter_Plug final : public FORTE_ECBusAdapter {
+    public:
+      FORTE_ECBusAdapter_Plug(forte::StringId paInstanceNameId,
+                              CFBContainer &paContainer,
+                              TForteUInt8 paParentAdapterlistID);
+      ~FORTE_ECBusAdapter_Plug() override = default;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+
+      CEventConnection conn_INITO;
+
+      CDataConnection *conn_QI;
+      CDataConnection *conn_MasterId;
+      CDataConnection *conn_MasterIndex;
+
+      COutDataConnection<CIEC_BOOL> conn_QO;
+
+    protected:
+      CEventConnection *getEOConUnchecked(TPortId paEONum) override;
+      CIEC_ANY *getDI(TPortId paDINum) override;
+      CDataConnection **getDIConUnchecked(TPortId paDINum) override;
+      CDataConnection *getDOConUnchecked(TPortId paDONum) override;
+      CIEC_ANY *getDO(TPortId paDONum) override;
+
+    private:
+      FORTE_ECBusAdapter_Socket *getSocket();
+  };
+
+  class FORTE_ECBusAdapter_Socket final : public FORTE_ECBusAdapter {
+    public:
+      FORTE_ECBusAdapter_Socket(forte::StringId paInstanceNameId,
+                                CFBContainer &paContainer,
+                                TForteUInt8 paParentAdapterlistID);
+      ~FORTE_ECBusAdapter_Socket() override = default;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+
+      CDataConnection *conn_QO;
+
+      CEventConnection conn_INIT;
+
+      COutDataConnection<CIEC_BOOL> conn_QI;
+      COutDataConnection<CIEC_UINT> conn_MasterId;
+      COutDataConnection<CIEC_UINT> conn_MasterIndex;
+
+    protected:
+      CEventConnection *getEOConUnchecked(TPortId paEONum) override;
+      CIEC_ANY *getDI(TPortId paDINum) override;
+      CDataConnection **getDIConUnchecked(TPortId paDINum) override;
+      CDataConnection *getDOConUnchecked(TPortId paDONum) override;
+      CIEC_ANY *getDO(TPortId paDONum) override;
+
+    private:
+      FORTE_ECBusAdapter_Plug *getPlug() {
+        return static_cast<FORTE_ECBusAdapter_Plug *>(getPeer());
+      }
+  };
+}

--- a/modules/ethercat/types/ECCoupler.cpp
+++ b/modules/ethercat/types/ECCoupler.cpp
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ECCoupler.h"
+
+#include "../handler/bus.h"
+#include "../slave/ec_device.h"
+#include "forte/iec61131_functions/func_AND.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  namespace {
+    const auto cCouplerPlugNames = std::array{"BusAdapterOut"_STRID, "ModuleAdapterOut"_STRID};
+  } // namespace
+
+  DEFINE_FIRMWARE_FB(FORTE_ECCoupler, "eclipse4diac::io::ethercat::ECCoupler"_STRID)
+
+  FORTE_ECCoupler::FORTE_ECCoupler(forte::StringId paInstanceNameId, CFBContainer &paContainer) :
+      FORTE_ECSlave(paInstanceNameId, paContainer, ECSlaveHandler::SlaveType::ECCoupler),
+      var_ModuleAdapterOut("ModuleAdapterOut"_STRID, *this, 1) {
+  }
+
+  bool FORTE_ECCoupler::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    if (!FORTE_ECSlave::createInterfaceSpec(paConfigString, paInterfaceSpec)) {
+      return false;
+    }
+    paInterfaceSpec.mPlugNames = cCouplerPlugNames;
+    return true;
+  }
+
+  void FORTE_ECCoupler::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    if (BusAdapterIn().INIT() == paEIID) {
+      if(BusAdapterIn().var_QI == true) {
+        if(var_ModuleAdapterOut.getAdapterBlock()->getPeer() != nullptr) {
+          var_ModuleAdapterOut->var_QI = true_BOOL;
+          var_ModuleAdapterOut->var_Index = CIEC_UINT((static_cast<TForteUInt16>(var_BusAdapterIn->var_Index) + 1) * 100);
+          var_ModuleAdapterOut->var_MasterId = var_BusAdapterIn->var_MasterId;
+          sendAdapterEvent(*var_ModuleAdapterOut, FORTE_ECBusAdapter::scmEventINITID, paECET);
+        }    
+      }
+    }
+  
+    FORTE_ECSlave::executeEvent(paEIID, paECET);
+  }
+
+  void FORTE_ECCoupler::forwardInitConfirmation(CEventChainExecutionThread *const paECET) {
+    CIEC_BOOL combinedQO = QO();
+    if(var_BusAdapterOut.getAdapterBlock()->getPeer() != nullptr) {
+      combinedQO = func_AND(combinedQO, var_BusAdapterOut->var_QO);
+    }
+    if(var_ModuleAdapterOut.getAdapterBlock()->getPeer() != nullptr) {
+      combinedQO = func_AND(combinedQO, var_ModuleAdapterOut->var_QO);
+    }
+    var_BusAdapterIn->var_QO = combinedQO;
+    sendAdapterEvent(*var_BusAdapterIn, forte::io::IOConfigFBMultiAdapter::scmEventINITOID, paECET);
+  }
+
+  forte::IPlugPin *FORTE_ECCoupler::getPlugPinUnchecked(size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_BusAdapterOut;
+      case 1: return &var_ModuleAdapterOut;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  bool FORTE_ECCoupler::createSlaveHandler() {  
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *handler = new ECDeviceHandler(&bus, ECSlaveHandler::SlaveType::ECCoupler, mIndex);
+    ECDeviceHandler::Config cfg{};
+    cfg.mAlias = static_cast<TForteUInt16>(Config().Alias);
+    cfg.mPosition = static_cast<TForteUInt16>(Config().Position);
+    cfg.mVendorId = static_cast<TForteUInt32>(Config().VendorId);
+    cfg.mProductCode = static_cast<TForteUInt32>(Config().ProductCode);
+    handler->setConfig(&cfg);
+    handler->mDelegate = this;
+    bus.addSlave(handler);
+    return true;
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/ECCoupler.h
+++ b/modules/ethercat/types/ECCoupler.h
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECSlave.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECCoupler : public FORTE_ECSlave {
+      DECLARE_FIRMWARE_FB(FORTE_ECCoupler)
+
+    public:
+      FORTE_ECCoupler(forte::StringId paInstanceNameId, CFBContainer &paContainer);
+      ~FORTE_ECCoupler() override = default;
+
+    protected:
+      bool createSlaveHandler() override;
+
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      forte::IPlugPin *getPlugPinUnchecked(size_t paIndex) override;
+      bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
+
+      void forwardInitConfirmation(CEventChainExecutionThread *const paECET);
+
+      forte::CPlugPin<FORTE_ECBusAdapter_Plug> var_ModuleAdapterOut;
+
+      FORTE_ECBusAdapter &ModuleAdapterOut() {
+        return (*static_cast<FORTE_ECBusAdapter *>(getPlugPinUnchecked(1)->getAdapterBlock()));
+      }
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/ECMaster.cpp
+++ b/modules/ethercat/types/ECMaster.cpp
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ECMaster.h"
+#include "../handler/bus.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  DEFINE_FIRMWARE_FB(FORTE_ECMaster, "eclipse4diac::io::ethercat::ECMaster"_STRID,
+                     "v2:SHA3-512:zdg7DeWvo5613AFG13T0n485ZdrDL9FBrnCW3_pjeBIh7Imn522te-wa85a-yODs2Hb5ClODMYi-r23BwH_ZiA==")
+
+  namespace {
+    const auto cDataInputNames = std::array{"QI"_STRID, "Enable"_STRID, "MasterIndex"_STRID, "UpdateInterval"_STRID};
+    const auto cDataOutputNames = std::array{"QO"_STRID, "STATUS"_STRID};
+    const auto cEventInputNames = std::array{"INIT"_STRID, "REQ"_STRID};
+    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
+    const auto cEventOutputNames = std::array{"INITO"_STRID, "CNF"_STRID, "IND"_STRID};
+    const auto cEventOutputTypeIds = std::array{"Event"_STRID, "Event"_STRID, "EVENT"_STRID};
+    const auto cPlugNameIds = std::array{"BusAdapterOut"_STRID};
+
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+      .mEINames = cEventInputNames,
+      .mEITypeNames = cEventInputTypeIds,
+      .mEONames = cEventOutputNames,
+      .mEOTypeNames = cEventOutputTypeIds,
+      .mDINames = cDataInputNames,
+      .mDONames = cDataOutputNames,
+      .mDIONames = {},
+      .mSocketNames = {},
+      .mPlugNames = cPlugNameIds,
+    };
+  }
+
+  FORTE_ECMaster::FORTE_ECMaster(const forte::StringId paInstanceNameId, CFBContainer &paContainer) :
+      IOConfigFBMultiMaster(paContainer, cFBInterfaceSpec, paInstanceNameId),
+      var_QI(0_BOOL),
+      var_Enable(0_BOOL),
+      var_MasterIndex(0_UINT),
+      var_UpdateInterval(0_TIME),
+      conn_INITO(*this, 0),
+      conn_CNF(*this, 1),
+      conn_IND(*this, 2),
+      conn_QI(nullptr),
+      conn_Enable(nullptr),
+      conn_MasterIndex(nullptr),
+      conn_UpdateInterval(nullptr),
+      conn_QO(*this, 0, var_QO),
+      conn_STATUS(*this, 1, var_STATUS),
+      var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0) {
+  };
+
+  void FORTE_ECMaster::setInitialValues() {
+    var_QI = 0_BOOL;
+    var_Enable = 0_BOOL;
+    var_MasterIndex = 0_UINT;
+    var_UpdateInterval.setFromMilliSeconds(1);
+    var_QO = 0_BOOL;
+    var_STATUS = u""_WSTRING;
+  }
+
+  void FORTE_ECMaster::readInputData(const TEventID paEIED) {
+    switch (paEIED){
+      case scmEventINITID:
+      case scmEventREQID:
+        readData(0, var_QI, conn_QI);
+        readData(1, var_Enable, conn_Enable);
+        readData(2, var_MasterIndex, conn_MasterIndex);
+        readData(3, var_UpdateInterval, conn_UpdateInterval);
+        break;
+      default:break;
+    }
+  }
+
+  void FORTE_ECMaster::writeOutputData(const TEventID paEIID) {
+    switch(paEIID) {
+      case scmEventIND:
+      case scmEventCNF:
+      case scmEventINITOID: {
+        writeData(cFBInterfaceSpec.getNumDIs() + 0, var_QO, conn_QO);
+        writeData(cFBInterfaceSpec.getNumDIs() + 1, var_STATUS, conn_STATUS);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_ECMaster::getDI(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QI;
+      case 1: return &var_Enable;
+      case 2: return &var_MasterIndex;
+      case 3: return &var_UpdateInterval;
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECMaster::getDO(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QO;
+      case 1: return &var_STATUS;
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_ECMaster::getEOConUnchecked(const TPortId paIndex) {
+    switch(paIndex) {
+      case 0: return &conn_INITO;
+      case 1: return &conn_CNF;
+      case 2: return &conn_IND;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_ECMaster::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QI;
+      case 1: return &conn_Enable;
+      case 2: return &conn_MasterIndex;
+      case 3: return &conn_UpdateInterval;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_ECMaster::getDOConUnchecked(const TPortId paIndex) {
+    switch(paIndex) {
+      case 0: return &conn_QO;
+      case 1: return &conn_STATUS;
+    }
+    return nullptr;
+  }
+
+  forte::IPlugPin *FORTE_ECMaster::getPlugPinUnchecked(size_t paIndex) {
+    return (paIndex == 0) ? &var_BusAdapterOut : nullptr;
+  }
+
+  forte::io::IODeviceController *FORTE_ECMaster::createDeviceController(CDeviceExecution &paDeviceExecution) {
+    return new ECBusHandler(paDeviceExecution);
+  }
+
+  void FORTE_ECMaster::setConfig() {
+    ECBusHandler::Config config;
+    config.mECMasterId = var_MasterIndex.operator TForteUInt16();
+    config.mUpdateInterval = static_cast<unsigned int>(var_UpdateInterval.getInMicroSeconds());
+    DEVLOG_INFO("ECMasterId is:%d, and UpdateInterval is: %d\n", config.mECMasterId, config.mUpdateInterval);
+    getDeviceController()->setConfig(&config);
+  }
+
+  void FORTE_ECMaster::onStartup(CEventChainExecutionThread *const paECET) {
+    var_BusAdapterOut->var_Index = 0_UINT;
+    IOConfigFBMultiMaster::onStartup(paECET);
+  }
+
+  void FORTE_ECMaster::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    if (paEIID == scmEventREQID) {
+      // Align with legacy EtherCAT behavior: REQ toggles cyclic bus execution.
+      readInputData(paEIID);
+      auto *bus = static_cast<ECBusHandler *>(getDeviceController());
+      if (bus != nullptr) {
+        bus->enableECCycle(var_Enable);
+      }
+      sendOutputEvent(scmEventCNF, paECET);
+    }
+    IOConfigFBMultiMaster::executeEvent(paEIID, paECET);
+  }
+      
+}

--- a/modules/ethercat/types/ECMaster.h
+++ b/modules/ethercat/types/ECMaster.h
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/io/configFB/io_master_multi.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_uint.h"
+#include "forte/datatypes/forte_udint.h"
+#include "forte/datatypes/forte_wstring.h"
+#include "forte/datatypes/forte_time.h"
+#include "ECBusAdapter.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECMaster final : public forte::io::IOConfigFBMultiMaster {
+      DECLARE_FIRMWARE_FB(FORTE_ECMaster)
+    
+    private:
+      static const TEventID scmEventINITID = 0;
+      static const TEventID scmEventREQID = 1;
+      static const TEventID scmEventINITO = 0;
+      static const TEventID scmEventCNF = 1;
+      static const TEventID scmEventIND = 2;
+      static const int scmBusAdapterOutAdpNum = 0;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    protected:
+      forte::io::IODeviceController *createDeviceController(CDeviceExecution &paDeviceExecution) override;
+
+      void setConfig() override;
+
+      void onStartup(CEventChainExecutionThread *const paECET) override;
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+    public:
+      FORTE_ECMaster(forte::StringId paInstanceNameId, CFBContainer &paContainer);
+
+      CIEC_BOOL var_QI;
+      CIEC_BOOL var_Enable;
+      CIEC_UINT var_MasterIndex;
+      CIEC_TIME var_UpdateInterval;
+
+      CIEC_BOOL var_QO;
+      CIEC_WSTRING var_STATUS;
+
+      CEventConnection conn_INITO;
+      CEventConnection conn_IND;
+      CEventConnection conn_CNF;
+
+      CDataConnection *conn_QI;
+      CDataConnection *conn_Enable;
+      CDataConnection *conn_MasterIndex;
+      CDataConnection *conn_UpdateInterval;
+
+      COutDataConnection<CIEC_BOOL> conn_QO;
+      COutDataConnection<CIEC_WSTRING> conn_STATUS;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+
+      forte::CPlugPin<FORTE_ECBusAdapter_Plug> var_BusAdapterOut;
+
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+      forte::IPlugPin *getPlugPinUnchecked(size_t) override;
+
+      void evt_INIT(const CIEC_BOOL &paQI,
+                    const CIEC_BOOL &paEnable,
+                    const CIEC_UINT &paMasterIndex,
+                    const CIEC_TIME &paUpdateInterval,
+                    CAnyBitOutputParameter<CIEC_BOOL> paQO,
+                    COutputParameter<CIEC_WSTRING> paSTATUS) {
+        COutputGuard guard_paQO(paQO);
+        COutputGuard guard_paSTATUS(paSTATUS);
+        var_QI = paQI;
+        var_Enable = paEnable;
+        var_MasterIndex = paMasterIndex;
+        var_UpdateInterval = paUpdateInterval;
+        receiveInputEvent(scmEventINITID, nullptr);
+        *paQO = var_QO;
+        *paSTATUS = var_STATUS;
+      }
+
+      void operator()(const CIEC_BOOL &paQI,
+                      const CIEC_BOOL &paEnable,
+                      const CIEC_UINT &paMasterIndex,
+                      const CIEC_TIME &paUpdateInterval,
+                      CAnyBitOutputParameter<CIEC_BOOL> paQO,
+                      COutputParameter<CIEC_WSTRING> paSTATUS) {
+        evt_INIT(paQI, paEnable, paMasterIndex, paUpdateInterval, paQO, paSTATUS);
+      }
+  };
+}

--- a/modules/ethercat/types/ECModule.cpp
+++ b/modules/ethercat/types/ECModule.cpp
@@ -1,0 +1,258 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ECModule.h"
+
+#include "../handler/bus.h"
+#include "../slave/ec_device.h"
+#include "../utils/EsiFileParser.h"
+#include "forte/iec61131_functions/func_AND.h"
+#include "forte/util/string_utils.h"
+
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  namespace {
+    const auto cSocketNameIds = std::array{"ModuleAdapterIn"_STRID};
+    const auto cPlugNameIds = std::array{"ModuleAdapterOut"_STRID};
+    const auto cEventInputNameIds = std::array{"MAP"_STRID};
+    const auto cEventOutputNameIds = std::array{"MAPO"_STRID, "IND"_STRID};
+    const auto cEventInputTypeIds = std::array{"Event"_STRID};
+    const auto cEventOutputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
+  } // namespace
+
+  DEFINE_GENERIC_FIRMWARE_FB(FORTE_ECModule, "eclipse4diac::io::ethercat::GEN_ECModule"_STRID)
+
+  const TForteUInt8 FORTE_ECModule::scmSlaveConfigurationIO[] = {};
+  const TForteUInt8 FORTE_ECModule::scmSlaveConfigurationIONum = 0;
+
+  FORTE_ECModule::FORTE_ECModule(const forte::StringId paInstanceNameId, CFBContainer &paContainer) :
+      CGenFunctionBlock<forte::io::IOConfigHandlerFBMultiSlave>(paContainer,
+                                           paInstanceNameId,
+                                           scmSlaveConfigurationIO,
+                                           scmSlaveConfigurationIONum,
+                                           static_cast<int>(ECSlaveHandler::SlaveType::ECModule)),
+      conn_MAPO(*this, 0),
+      conn_IND(*this, 1),
+      conn_QI(nullptr),
+      conn_Config(nullptr),
+      conn_QO(*this, 0, var_QO),
+      conn_STATUS(*this, 1, var_STATUS),    
+      var_ModuleAdapterIn("ModuleAdapterIn"_STRID, *this, 0),
+      var_ModuleAdapterOut("ModuleAdapterOut"_STRID, *this, 1) {
+  }
+
+  FORTE_ECModule::~FORTE_ECModule() {
+    const size_t numDIs = getFBInterfaceSpec().getNumDIs();
+    const size_t genOffset = getGenDIOffset();
+    const size_t safeGenDINums = (numDIs > genOffset) ? (numDIs - genOffset) : 0;
+    for (size_t i = 0; i < safeGenDINums && mGenDIs; ++i) {
+      delete mGenDIs[i];
+    }
+  }
+
+  void FORTE_ECModule::readInputData(const TEventID paEIID) {
+    if (paEIID == scmEventMAPID) {
+      readData(0, var_QI, conn_QI);
+      readData(1, var_Config, conn_Config);
+      for (TPortId i = 0; i < static_cast<TPortId>(getGenDINums()); ++i) {
+        readData(static_cast<TPortId>(i + getGenDIOffset()), *mGenDIs[i], mGenDIConns[i]);
+      }
+    }
+  }
+
+  void FORTE_ECModule::writeOutputData(const TEventID paEIID) {
+    const size_t numDIs = getFBInterfaceSpec().getNumDIs();
+    switch (paEIID) {
+      case scmEventMAPOID: writeData(numDIs + 0, var_QO, conn_QO); break;
+      case scmEventINDID:
+        writeData(numDIs + 0, var_QO, conn_QO);
+        writeData(numDIs + 1, var_STATUS, conn_STATUS);
+        break;
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_ECModule::getDI(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QI;
+      case 1: return &var_Config;
+      default: return mGenDIs[paIndex - getGenDIOffset()];
+    }
+  }
+
+  CIEC_ANY *FORTE_ECModule::getDO(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QO;
+      case 1: return &var_STATUS;
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_ECModule::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_MAPO;
+      case 1: return &conn_IND;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_ECModule::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QI;
+      case 1: return &conn_Config;
+      default: return CGenFunctionBlock<forte::io::IOConfigHandlerFBMultiSlave>::getDIConUnchecked(paIndex);
+    }
+  }
+
+  CDataConnection *FORTE_ECModule::getDOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QO;
+      case 1: return &conn_STATUS;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  forte::IPlugPin *FORTE_ECModule::getPlugPinUnchecked(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_ModuleAdapterOut;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  forte::ISocketPin *FORTE_ECModule::getSocketPinUnchecked(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_ModuleAdapterIn;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  void FORTE_ECModule::createGenInputData() {
+    const size_t n = getGenDINums();
+    mGenDIs = std::make_unique<CIEC_ANY *[]>(n);
+    for (size_t i = 0; i < n; ++i) {
+      mGenDIs[i] = new CIEC_WSTRING();
+    }
+  }
+
+  bool FORTE_ECModule::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    std::string tempstring(paConfigString);
+    const char *sParamA = nullptr;
+    const char *sParamB = nullptr;
+    const size_t firstUnderscore = tempstring.find('_');
+    const size_t secondUnderscore =
+        tempstring.find('_', firstUnderscore == std::string::npos ? 0 : firstUnderscore + 1);
+    if (firstUnderscore != std::string::npos && secondUnderscore != std::string::npos &&
+        firstUnderscore + 1 < tempstring.size() && secondUnderscore + 1 < tempstring.size()) {
+      tempstring[secondUnderscore] = '\0';
+      sParamA = &(tempstring[firstUnderscore + 1]);
+      sParamB = &(tempstring[secondUnderscore + 1]);
+    }
+    if (sParamB == nullptr) {
+      return false;
+    }
+
+    configureDIDOs(sParamA, sParamB, paInterfaceSpec);
+    paInterfaceSpec.mEINames = cEventInputNameIds;
+    paInterfaceSpec.mEITypeNames = cEventInputTypeIds;
+    paInterfaceSpec.mEONames = cEventOutputNameIds;
+    paInterfaceSpec.mEOTypeNames = cEventOutputTypeIds;
+    paInterfaceSpec.mSocketNames = cSocketNameIds;
+    paInterfaceSpec.mPlugNames = cPlugNameIds;
+    return true;
+  }
+
+  void FORTE_ECModule::configureDIDOs(const char *paDIConfigString,
+                                      const char *paDOConfigString,
+                                      SFBInterfaceSpec &paInterfaceSpec) {
+    mDiNames.clear();
+    mDoNames.clear();
+    mDiNames.emplace_back("QI"_STRID);
+    mDiNames.emplace_back("Config"_STRID);
+    mNumInPdus = static_cast<size_t>(util::strtol(paDIConfigString, nullptr, 10));
+    mNumOutPdus = static_cast<size_t>(util::strtol(paDOConfigString, nullptr, 10));
+    generateGenericInterfacePointNameArray("IN_", mDiNames, mNumInPdus);
+    generateGenericInterfacePointNameArray("OUT_", mDiNames, mNumOutPdus);
+    mDoNames.emplace_back("QO"_STRID);
+    mDoNames.emplace_back("STATUS"_STRID);
+    paInterfaceSpec.mDINames = mDiNames;
+    paInterfaceSpec.mDONames = mDoNames;
+  }
+
+  bool FORTE_ECModule::createSlaveHandler() {
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *handler = new ECModuleHandler(&bus, mIndex);
+    ECModuleHandler::Config cfg{};
+    cfg.mModuleIdent = static_cast<TForteUInt32>(Config().ModuleIdent);
+    cfg.mSlot = static_cast<TForteUInt16>(Config().Slot);
+    handler->setConfig(&cfg);
+    handler->mDelegate = this;
+    bus.addSlave(handler);
+    return true;
+  }
+
+  const char *FORTE_ECModule::init() {
+    const auto moduleIdent = static_cast<TForteUInt32>(Config().ModuleIdent);
+    std::string errMsg;
+    if (!EsiFileParser::getInstance().loadModule(moduleIdent, errMsg)) {
+      mLastError = errMsg;
+      return mLastError.c_str();
+    }
+    return nullptr;
+  }
+
+  void FORTE_ECModule::deInit() {
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    ECSlaveHandler *slave = bus.getSlave(mIndex);
+    if (slave != nullptr && slave->mDelegate == this) {
+      slave->mDelegate = nullptr;
+    }
+  }
+
+  void FORTE_ECModule::initHandles() {
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *module = static_cast<ECModuleHandler *>(bus.getSlave(mIndex));
+    if (nullptr == module) {
+      return;
+    }
+    ECSlaveHandler *parent = bus.getSlave(mIndex / 100 - 1);
+    auto *device = static_cast<ECDeviceHandler *>(parent);
+    if (nullptr == device) {
+      return;
+    }
+    EsiFileParser::getInstance().initModuleIOHandles(module->moduleIdent(), device, module, *this);
+  }
+
+  void FORTE_ECModule::onSlaveStatus(ECSlaveHandler::SlaveStatus paStatus, ECSlaveHandler::SlaveStatus) {
+    switch (paStatus) {
+      case ECSlaveHandler::OK: STATUS() = scmOK; break;
+      case ECSlaveHandler::Error: STATUS() = u"Error"_WSTRING; break;
+      case ECSlaveHandler::NotInitialized: STATUS() = u"NotInitialized"_WSTRING; break;
+      default: STATUS() = u"Unknown"_WSTRING; break;
+    }
+    sendOutputEvent(scmEventINDID, getEventChainExecutor());
+  }
+
+  void FORTE_ECModule::onSlaveDestroy() {
+    deInit();
+    QO() = false_BOOL;
+    STATUS() = u"Slave destroyed"_WSTRING;
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/ECModule.h
+++ b/modules/ethercat/types/ECModule.h
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECBusAdapter.h"
+#include "../structs/ECModuleConfig.h"
+#include "../slave/slave.h"
+#include "forte/adapter.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_wstring.h"
+#include "forte/io/configFB/io_slave_multi_handler.h"
+#include "forte/genfb.h"
+#include <string>
+
+namespace forte::eclipse4diac::io::ethercat {
+  class EsiFileParser;
+
+  class FORTE_ECModule : public CGenFunctionBlock<forte::io::IOConfigHandlerFBMultiSlave>, public ECSlaveHandler::Delegate {
+      DECLARE_GENERIC_FIRMWARE_FB(FORTE_ECModule)
+
+    public:
+      FORTE_ECModule(forte::StringId paInstanceNameId, CFBContainer &paContainer);
+      ~FORTE_ECModule() override;
+
+      void onSlaveStatus(ECSlaveHandler::SlaveStatus paStatus, ECSlaveHandler::SlaveStatus paOldStatus) override;
+      void onSlaveDestroy() override;
+
+      size_t numInMappings() const {
+        return mNumInPdus;
+      }
+
+      CIEC_ECModuleConfig &Config() {
+        return var_Config;
+      }
+
+    protected:
+      bool createSlaveHandler() override;
+      const char *init() override;
+      void deInit() override;
+      void initHandles() override;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      //void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      size_t getGenDIOffset() override {
+        return 2;
+      }
+
+      size_t getGenDOOffset() override {
+        return 2;
+      }
+
+      FORTE_ECBusAdapter &ModuleAdapterOut() {
+        return (*static_cast<FORTE_ECBusAdapter *>(getPlugPinUnchecked(0)->getAdapterBlock()));
+      }
+
+      FORTE_ECBusAdapter &ModuleAdapterIn() {
+        return (*static_cast<FORTE_ECBusAdapter *>(getSocketPinUnchecked(0)->getAdapterBlock()));
+      }
+
+      void createGenInputData() override;
+
+      CIEC_ANY *getDI(TPortId paIndex) override;
+      CIEC_ANY *getDO(TPortId paIndex) override;
+
+      CEventConnection *getEOConUnchecked(TPortId paIndex) override;
+      CDataConnection **getDIConUnchecked(TPortId paIndex) override;
+      CDataConnection *getDOConUnchecked(TPortId paIndex) override;
+
+      forte::IPlugPin *getPlugPinUnchecked(size_t paIndex) override;
+      forte::ISocketPin *getSocketPinUnchecked(size_t paIndex) override;
+
+      CIEC_BOOL var_QI;
+      CIEC_ECModuleConfig var_Config;
+      CIEC_BOOL var_QO;
+      CIEC_WSTRING var_STATUS;
+
+      CEventConnection conn_MAPO;
+      CEventConnection conn_IND;
+
+      CDataConnection *conn_QI;
+      CDataConnection *conn_Config;
+
+      COutDataConnection<CIEC_BOOL> conn_QO;
+      COutDataConnection<CIEC_WSTRING> conn_STATUS;
+   
+      forte::CSocketPin<FORTE_ECBusAdapter_Socket> var_ModuleAdapterIn;
+      forte::CPlugPin<FORTE_ECBusAdapter_Plug> var_ModuleAdapterOut;
+
+      std::unique_ptr<CIEC_ANY *[]> mGenDIs;
+
+    private:
+      friend class EsiFileParser;
+
+      std::vector<StringId> mDiNames;
+      std::vector<StringId> mDoNames;
+
+      size_t mNumInPdus{};
+      size_t mNumOutPdus{};
+      std::string mLastError;
+
+      static const TForteUInt8 scmSlaveConfigurationIO[];
+      static const TForteUInt8 scmSlaveConfigurationIONum;
+
+      bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
+
+      void configureDIDOs(const char *paDIConfigString, const char *paDOConfigString, SFBInterfaceSpec &paInterfaceSpec);
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/ECSlave.cpp
+++ b/modules/ethercat/types/ECSlave.cpp
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ECSlave.h"
+
+#include "../handler/bus.h"
+#include "../slave/ec_device.h"
+#include "../utils/EsiFileParser.h"
+#include "forte/util/string_utils.h"
+
+#include <string>
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  namespace {
+    const auto cSocketNameIds = std::array{"BusAdapterIn"_STRID};
+    const auto cPlugNameIds = std::array{"BusAdapterOut"_STRID};
+
+    const auto cEventInputNameIds = std::array{"MAP"_STRID};
+    const auto cEventOutputNameIds = std::array{"MAPO"_STRID, "IND"_STRID};
+
+    const auto cEventInputTypeIds = std::array{"Event"_STRID};
+    const auto cEventOutputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
+  } // namespace
+
+  DEFINE_GENERIC_FIRMWARE_FB(FORTE_ECSlave, "eclipse4diac::io::ethercat::GEN_ECSlave"_STRID)
+
+  const TForteUInt8 FORTE_ECSlave::scmSlaveConfigurationIO[] = {};
+  const TForteUInt8 FORTE_ECSlave::scmSlaveConfigurationIONum = 0;
+
+  FORTE_ECSlave::FORTE_ECSlave(const forte::StringId paInstanceNameId,
+                               CFBContainer &paContainer,
+                               ECSlaveHandler::SlaveType paSlaveType) :
+      CGenFunctionBlock<forte::io::IOConfigHandlerFBMultiSlave>(paContainer,
+                                           paInstanceNameId,
+                                           scmSlaveConfigurationIO,
+                                           scmSlaveConfigurationIONum,
+                                           static_cast<int>(paSlaveType)),
+      conn_MAPO(*this, 0),
+      conn_IND(*this, 1),
+      conn_QI(nullptr),
+      conn_Config(nullptr),
+      conn_QO(*this, 0, var_QO),
+      conn_STATUS(*this, 1, var_STATUS),
+      var_BusAdapterIn("BusAdapterIn"_STRID, *this, 0),
+      var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0) {
+  }
+
+  FORTE_ECSlave::~FORTE_ECSlave() {
+    const size_t numDIs = getFBInterfaceSpec().getNumDIs();
+    const size_t genOffset = getGenDIOffset();
+    const size_t safeGenDINums = (numDIs > genOffset) ? (numDIs - genOffset) : 0;
+    for (size_t i = 0; i < safeGenDINums && mGenDIs; ++i) {
+      delete mGenDIs[i];
+    }
+  }
+
+  void FORTE_ECSlave::readInputData(const TEventID paEIID) {
+    if (paEIID == scmEventMAPID) {
+      readData(0, var_QI, conn_QI);
+      readData(1, var_Config, conn_Config);
+      for (TPortId i = 0; i < static_cast<TPortId>(getGenDINums()); ++i) {
+        readData(static_cast<TPortId>(i + getGenDIOffset()), *mGenDIs[i], mGenDIConns[i]);
+      }
+    }
+  }
+
+  void FORTE_ECSlave::writeOutputData(const TEventID paEIID) {
+    const size_t numDIs = getFBInterfaceSpec().getNumDIs();
+    switch (paEIID) {
+      case scmEventMAPOID: {
+        writeData(numDIs + 0, var_QO, conn_QO);
+        break;
+      }
+      case scmEventINDID: {
+        writeData(numDIs + 0, var_QO, conn_QO);
+        writeData(numDIs + 1, var_STATUS, conn_STATUS);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_ECSlave::getDI(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QI;
+      case 1: return &var_Config;
+      default: return mGenDIs[paIndex - getGenDIOffset()];
+    }
+  }
+
+  CIEC_ANY *FORTE_ECSlave::getDO(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QO;
+      case 1: return &var_STATUS;
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_ECSlave::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_MAPO;
+      case 1: return &conn_IND;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_ECSlave::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QI;
+      case 1: return &conn_Config;
+      default: return CGenFunctionBlock<forte::io::IOConfigHandlerFBMultiSlave>::getDIConUnchecked(paIndex);
+    }
+  }
+
+  CDataConnection *FORTE_ECSlave::getDOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QO;
+      case 1: return &conn_STATUS;
+    }
+    return nullptr;
+  }
+
+  forte::IPlugPin *FORTE_ECSlave::getPlugPinUnchecked(const size_t paIndex) {
+    return (paIndex == 0) ? &var_BusAdapterOut : nullptr;
+  }
+
+  forte::ISocketPin *FORTE_ECSlave::getSocketPinUnchecked(const size_t paIndex) {
+    return (paIndex == 0) ? &var_BusAdapterIn : nullptr;
+  }
+
+  void FORTE_ECSlave::createGenInputData() {
+    const size_t n = getGenDINums();
+    mGenDIs = std::make_unique<CIEC_ANY *[]>(n);
+    for (size_t i = 0; i < n; ++i) {
+      mGenDIs[i] = new CIEC_WSTRING();
+    }
+  }
+
+  bool FORTE_ECSlave::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    std::string tempstring(paConfigString);
+    const char *sParamA = nullptr;
+    const char *sParamB = nullptr;
+
+    const size_t firstUnderscore = tempstring.find('_');
+    const size_t secondUnderscore = tempstring.find('_', firstUnderscore == std::string::npos ? 0 : firstUnderscore + 1);
+    if (firstUnderscore != std::string::npos && secondUnderscore != std::string::npos &&
+        firstUnderscore + 1 < tempstring.size() && secondUnderscore + 1 < tempstring.size()) {
+      tempstring[secondUnderscore] = '\0';
+      sParamA = &(tempstring[firstUnderscore + 1]);
+      sParamB = &(tempstring[secondUnderscore + 1]);
+    }
+
+    if (sParamB == nullptr) {
+      return false;
+    }
+
+    configureDIDOs(sParamA, sParamB, paInterfaceSpec);
+
+    paInterfaceSpec.mEINames = cEventInputNameIds;
+    paInterfaceSpec.mEITypeNames = cEventInputTypeIds;
+    paInterfaceSpec.mEONames = cEventOutputNameIds;
+    paInterfaceSpec.mEOTypeNames = cEventOutputTypeIds;
+    paInterfaceSpec.mSocketNames = cSocketNameIds;
+    paInterfaceSpec.mPlugNames = cPlugNameIds;
+    return true;
+  }
+
+  void FORTE_ECSlave::configureDIDOs(const char *paDIConfigString,
+                                     const char *paDOConfigString,
+                                     SFBInterfaceSpec &paInterfaceSpec) {
+    mDiNames.clear();
+    mDoNames.clear();
+
+    mDiNames.emplace_back("QI"_STRID);
+    mDiNames.emplace_back("Config"_STRID);
+
+    mNumInPdus = static_cast<size_t>(util::strtol(paDIConfigString, nullptr, 10));
+    mNumOutPdus = static_cast<size_t>(util::strtol(paDOConfigString, nullptr, 10));
+
+    generateGenericInterfacePointNameArray("IN_", mDiNames, mNumInPdus);
+    generateGenericInterfacePointNameArray("OUT_", mDiNames, mNumOutPdus);
+
+    mDoNames.emplace_back("QO"_STRID);
+    mDoNames.emplace_back("STATUS"_STRID);
+
+    paInterfaceSpec.mDINames = mDiNames;
+    paInterfaceSpec.mDONames = mDoNames;
+  }
+
+  bool FORTE_ECSlave::createSlaveHandler() {
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *handler = new ECDeviceHandler(&bus, ECSlaveHandler::SlaveType::ECSlave, mIndex);
+    ECDeviceHandler::Config cfg{};
+    cfg.mAlias = static_cast<TForteUInt16>(Config().Alias);
+    cfg.mPosition = static_cast<TForteUInt16>(Config().Position);
+    cfg.mVendorId = static_cast<TForteUInt32>(Config().VendorId);
+    cfg.mProductCode = static_cast<TForteUInt32>(Config().ProductCode);
+    handler->setConfig(&cfg);
+    handler->mDelegate = this;
+    bus.addSlave(handler);
+    return true;
+  }
+
+  const char *FORTE_ECSlave::init() {
+    const auto productCode = static_cast<TForteUInt32>(Config().ProductCode);
+    std::string errMsg;
+    if (!EsiFileParser::getInstance().loadDevice(productCode, errMsg)) {
+      mLastError = errMsg;
+      return mLastError.c_str();
+    }
+    return nullptr;
+  }
+
+  void FORTE_ECSlave::deInit() { 
+    auto &bus = *static_cast<ECBusHandler *>(&getController()); 
+    ECSlaveHandler *slave = bus.getSlave(mIndex);
+    if (slave != nullptr && slave->mDelegate == this) {
+      slave->mDelegate = nullptr;
+    }
+  }
+
+  void FORTE_ECSlave::initHandles() {
+    if (!QI()) {
+      return;
+    }
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *device = static_cast<ECDeviceHandler *>(bus.getSlave(mIndex));
+    if (nullptr == device) {
+      return;
+    }
+    EsiFileParser::getInstance().initDeviceIOHandles(static_cast<TForteUInt32>(Config().ProductCode), device, *this);
+  }
+
+  void FORTE_ECSlave::onSlaveStatus(ECSlaveHandler::SlaveStatus paStatus, ECSlaveHandler::SlaveStatus) {
+    switch (paStatus) {
+      case ECSlaveHandler::OK: STATUS() = scmOK; break;
+      case ECSlaveHandler::Error: STATUS() = u"Error"_WSTRING; break;
+      case ECSlaveHandler::NotInitialized: STATUS() = u"NotInitialized"_WSTRING; break;
+      default: STATUS() = u"Unknown"_WSTRING; break;
+    }
+    sendOutputEvent(scmEventINDID, getEventChainExecutor());
+  }
+
+  void FORTE_ECSlave::onSlaveDestroy() {
+    deInit();
+    QO() = false_BOOL;
+    STATUS() = u"Slave destroyed"_WSTRING;
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/types/ECSlave.h
+++ b/modules/ethercat/types/ECSlave.h
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECBusAdapter.h"
+#include "../structs/ECSlaveConfig.h"
+#include "../slave/slave.h"
+#include "forte/adapter.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_wstring.h"
+#include "forte/io/configFB/io_slave_multi_handler.h"
+#include "forte/genfb.h"
+#include <string>
+
+namespace forte::eclipse4diac::io::ethercat {
+  class EsiFileParser;
+
+  class FORTE_ECSlave : public CGenFunctionBlock<forte::io::IOConfigHandlerFBMultiSlave>, public ECSlaveHandler::Delegate {
+      DECLARE_GENERIC_FIRMWARE_FB(FORTE_ECSlave)
+
+    public:
+      FORTE_ECSlave(forte::StringId paInstanceNameId,
+                    CFBContainer &paContainer,
+                    ECSlaveHandler::SlaveType paSlaveType = ECSlaveHandler::SlaveType::ECSlave);
+      ~FORTE_ECSlave() override;
+
+      void onSlaveStatus(ECSlaveHandler::SlaveStatus paStatus, ECSlaveHandler::SlaveStatus paOldStatus) override;
+      void onSlaveDestroy() override;
+
+      CIEC_ECSlaveConfig &Config() {
+        return var_Config;
+      }
+
+      size_t numInMappings() const {
+        return mNumInPdus;
+      }
+
+      size_t numOutMappings() const {
+        return mNumOutPdus;
+      }
+
+    protected:
+      virtual bool createSlaveHandler() override;
+      const char *init() override;
+      void deInit() override;
+      void initHandles() override;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+
+      size_t getGenDIOffset() override {
+        return 2;
+      }
+
+      size_t getGenDOOffset() override {
+        return 2;
+      }
+
+      void createGenInputData() override;
+
+      CIEC_ANY *getDI(TPortId paIndex) override;
+      CIEC_ANY *getDO(TPortId paIndex) override;
+
+      CEventConnection *getEOConUnchecked(TPortId paIndex) override;
+      CDataConnection **getDIConUnchecked(TPortId paIndex) override;
+      CDataConnection *getDOConUnchecked(TPortId paIndex) override;
+
+      forte::IPlugPin *getPlugPinUnchecked(size_t paIndex) override;
+      forte::ISocketPin *getSocketPinUnchecked(size_t paIndex) override;
+
+      CIEC_BOOL var_QI;
+      CIEC_ECSlaveConfig var_Config;
+      CIEC_BOOL var_QO;
+      CIEC_WSTRING var_STATUS;
+
+      CEventConnection conn_MAPO;
+      CEventConnection conn_IND;
+
+      CDataConnection *conn_QI;
+      CDataConnection *conn_Config;
+
+      COutDataConnection<CIEC_BOOL> conn_QO;
+      COutDataConnection<CIEC_WSTRING> conn_STATUS;
+
+      forte::CSocketPin<FORTE_ECBusAdapter_Socket> var_BusAdapterIn;
+      forte::CPlugPin<FORTE_ECBusAdapter_Plug> var_BusAdapterOut;
+
+      std::unique_ptr<CIEC_ANY *[]> mGenDIs;
+
+    protected:
+      static const TForteUInt8 scmSlaveConfigurationIO[];
+      static const TForteUInt8 scmSlaveConfigurationIONum;
+
+      bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
+      void configureDIDOs(const char *paDIConfigString, const char *paDOConfigString, SFBInterfaceSpec &paInterfaceSpec);
+
+      std::vector<StringId> mDiNames;
+      std::vector<StringId> mDoNames;
+
+      size_t mNumInPdus{};
+      size_t mNumOutPdus{};
+      std::string mLastError;
+
+    private:
+      friend class EsiFileParser;
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/types/GEN_ECCoupler_fbt.cpp
+++ b/modules/ethercat/types/GEN_ECCoupler_fbt.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "GEN_ECCoupler_fbt.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_ECCoupler, "eclipse4diac::io::ethercat::GEN_ECCoupler"_STRID)
+
+  GEN_ECCoupler::GEN_ECCoupler(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      FORTE_ECCoupler(paInstanceNameId, paContainer) {
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECCoupler_fbt.h
+++ b/modules/ethercat/types/GEN_ECCoupler_fbt.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECCoupler.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class GEN_ECCoupler : public FORTE_ECCoupler {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_ECCoupler)
+
+    public:
+      GEN_ECCoupler(const StringId paInstanceNameId, CFBContainer &paContainer);
+      ~GEN_ECCoupler() override = default;
+
+      template<typename... Args>
+      void evt_MAP(Args &&...paArgs) {
+        writeInputArguments(std::forward<Args>(paArgs)...);
+        receiveInputEvent(scmEventMAPID, nullptr);
+        readOutputArguments(std::forward<Args>(paArgs)...);
+      }
+
+      template<typename ...Args>
+        void operator()(Args &&...paArgs) {
+        evt_INIT(std::forward<Args>(paArgs)...);
+      }
+  };
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECModule_fbt.cpp
+++ b/modules/ethercat/types/GEN_ECModule_fbt.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "GEN_ECModule_fbt.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_ECModule, "eclipse4diac::io::ethercat::GEN_ECModule"_STRID)
+
+  GEN_ECModule::GEN_ECModule(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      FORTE_ECModule(paInstanceNameId, paContainer) {
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECModule_fbt.h
+++ b/modules/ethercat/types/GEN_ECModule_fbt.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECModule.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class GEN_ECModule : public FORTE_ECModule {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_ECModule)
+
+    public:
+      GEN_ECModule(const StringId paInstanceNameId, CFBContainer &paContainer);
+      ~GEN_ECModule() override = default;
+
+      template<typename... Args>
+      void evt_MAP(Args &&...paArgs) {
+        writeInputArguments(std::forward<Args>(paArgs)...);
+        receiveInputEvent(scmEventMAPID, nullptr);
+        readOutputArguments(std::forward<Args>(paArgs)...);
+      }
+
+      template<typename ...Args>
+        void operator()(Args &&...paArgs) {
+        evt_INIT(std::forward<Args>(paArgs)...);
+      }
+  };
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECSlave_fbt.cpp
+++ b/modules/ethercat/types/GEN_ECSlave_fbt.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "GEN_ECSlave_fbt.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_ECSlave, "eclipse4diac::io::ethercat::GEN_ECSlave"_STRID)
+
+  GEN_ECSlave::GEN_ECSlave(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      FORTE_ECSlave(paInstanceNameId, paContainer) {
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECSlave_fbt.h
+++ b/modules/ethercat/types/GEN_ECSlave_fbt.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECSlave.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class GEN_ECSlave : public FORTE_ECSlave {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_ECSlave)
+
+    public:
+      GEN_ECSlave(const StringId paInstanceNameId, CFBContainer &paContainer);
+      ~GEN_ECSlave() override = default;
+
+      template<typename... Args>
+      void evt_MAP(Args &&...paArgs) {
+        writeInputArguments(std::forward<Args>(paArgs)...);
+        receiveInputEvent(scmEventMAPID, nullptr);
+        readOutputArguments(std::forward<Args>(paArgs)...);
+      }
+
+      template<typename ...Args>
+        void operator()(Args &&...paArgs) {
+        evt_INIT(std::forward<Args>(paArgs)...);
+      }
+  };
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/utils/EsiFileParser.cpp
+++ b/modules/ethercat/utils/EsiFileParser.cpp
@@ -1,0 +1,488 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "EsiFileParser.h"
+
+#include "../handler/bus.h"
+#include "../types/ECModule.h"
+#include "../types/ECSlave.h"
+#include "forte/util/string_utils.h"
+
+#include <filesystem>
+#include <string>
+#include <cstring>
+#include <tinyxml.h>
+#include <unistd.h>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  namespace {
+    
+    void applyVendorModulePdoEntryIndexCorrection(const std::string &paVendorName, uint16_t &paEntryIndex) {
+      if (paVendorName == "SiChuan Odot Automation System Co.,Ltd.") {
+        paEntryIndex = static_cast<uint16_t>(paEntryIndex + 1U);
+      } else if (paVendorName == "Inovance") {
+        paEntryIndex = static_cast<uint16_t>(paEntryIndex - 1U);
+      }     
+    }
+
+  } // namespace
+
+  DEFINE_SINGLETON(EsiFileParser)
+
+  std::map<uint32_t, std::string> EsiFileParser::scmEsiFilePathMap;
+  std::map<std::string, TiXmlDocument *> EsiFileParser::scmEsiFileDocMap;
+  std::map<uint32_t, TiXmlElement *> EsiFileParser::scmDeviceOrModuleMap;
+  std::map<uint32_t, std::string> EsiFileParser::scmVendorMap;
+
+  EsiFileParser::EsiFileParser() {
+    init();
+  }
+
+  EsiFileParser::~EsiFileParser() {
+    for (auto &[_, doc] : scmEsiFileDocMap) {
+      delete doc;
+    }
+  }
+
+  uint32_t EsiFileParser::parseEcNumber(const char *paText) {
+    if (nullptr == paText) {
+      return 0;
+    }
+    if (strlen(paText) > 2 && paText[0] == '#' && (paText[1] == 'x' || paText[1] == 'X')) {
+      return static_cast<uint32_t>(util::strtoul(paText + 2, nullptr, 16));
+    }
+    if (strlen(paText) > 2 && paText[0] == '0' && (paText[1] == 'x' || paText[1] == 'X')) {
+      return static_cast<uint32_t>(util::strtoul(paText + 2, nullptr, 16));
+    }
+    return static_cast<uint32_t>(util::strtoul(paText, nullptr, 10));
+  }
+
+  void EsiFileParser::init() {
+    char exePath[4096];
+    const ssize_t len = readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
+    if (len <= 0) {
+      return;
+    }
+    exePath[len] = '\0';
+    char *lastSlash = strrchr(exePath, '/');
+    if (nullptr == lastSlash) {
+      return;
+    }
+    *lastSlash = '\0';
+    const std::string esiFolder = std::string(exePath) + "/devices/";
+    if (!std::filesystem::exists(esiFolder)) {
+      DEVLOG_WARNING("ethercat[EsiFileParser]: ESI folder not found: %s\n", esiFolder.c_str());
+      return;
+    }
+
+    for (const auto &entry : std::filesystem::directory_iterator(esiFolder)) {
+      if (!entry.is_regular_file()) {
+        continue;
+      }
+      const std::string extension = entry.path().extension().string();
+      if (!(extension == ".xml" || extension == ".XML")) {
+        continue;
+      }
+      const std::string filePath = entry.path().string();
+      auto *doc = new TiXmlDocument(filePath.c_str());
+      if (!doc->LoadFile()) {
+        delete doc;
+        continue;
+      }
+      auto *root = doc->RootElement();
+      if (nullptr == root) {
+        delete doc;
+        continue;
+      }
+      auto *descriptions = root->FirstChildElement("Descriptions");
+      if (nullptr == descriptions) {
+        delete doc;
+        continue;
+      }
+      std::string vendorName;
+      if (auto *vendor = root->FirstChildElement("Vendor")) {
+        if (auto *name = vendor->FirstChildElement("Name"); name && name->GetText()) {
+          vendorName = name->GetText();
+        }
+      }
+      scmEsiFileDocMap[filePath] = doc;
+      if (auto *devices = descriptions->FirstChildElement("Devices")) {
+        for (auto *device = devices->FirstChildElement("Device"); device != nullptr;
+             device = device->NextSiblingElement("Device")) {
+          if (auto *type = device->FirstChildElement("Type")) {
+            const char *pc = type->Attribute("ProductCode");
+            if (pc) {
+              const uint32_t key = parseEcNumber(pc);
+              scmEsiFilePathMap[key] = filePath;
+              scmVendorMap[key] = vendorName;
+            }
+          }
+        }
+      }
+      if (auto *modules = descriptions->FirstChildElement("Modules")) {
+        for (auto *module = modules->FirstChildElement("Module"); module != nullptr;
+             module = module->NextSiblingElement("Module")) {
+          if (auto *type = module->FirstChildElement("Type")) {
+            const char *mi = type->Attribute("ModuleIdent");
+            if (mi) {
+              const uint32_t key = parseEcNumber(mi);
+              scmEsiFilePathMap[key] = filePath;
+              scmVendorMap[key] = vendorName;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  bool EsiFileParser::loadEsiFileByKey(uint32_t paKey, std::string &paErrMsg) {
+    auto it = scmEsiFilePathMap.find(paKey);
+    if (it == scmEsiFilePathMap.end()) {
+      paErrMsg = std::string("No ESI file for key ") + std::to_string(paKey);
+      return false;
+    }
+    return scmEsiFileDocMap.find(it->second) != scmEsiFileDocMap.end();
+  }
+
+  bool EsiFileParser::getDeviceFromDocByProductCode(TiXmlDocument *paDocument,
+                                                     uint32_t paProductCode,
+                                                     TiXmlElement *&paDeviceElement,
+                                                     std::string &paErrMsg) {
+    if (nullptr == paDocument || nullptr == paDocument->RootElement()) {
+      paErrMsg = "Invalid ESI XML root";
+      return false;
+    }
+    if (auto cached = scmDeviceOrModuleMap.find(paProductCode); cached != scmDeviceOrModuleMap.end()) {
+      paDeviceElement = cached->second;
+      return true;
+    }
+    auto *descriptions = paDocument->RootElement()->FirstChildElement("Descriptions");
+    auto *devices = descriptions ? descriptions->FirstChildElement("Devices") : nullptr;
+    if (nullptr == devices) {
+      paErrMsg = "No Devices section in ESI";
+      return false;
+    }
+    for (auto *device = devices->FirstChildElement("Device"); device; device = device->NextSiblingElement("Device")) {
+      auto *type = device->FirstChildElement("Type");
+      if (!type) {
+        continue;
+      }
+      const char *pc = type->Attribute("ProductCode");
+      if (pc && parseEcNumber(pc) == paProductCode) {
+        scmDeviceOrModuleMap[paProductCode] = device;
+        paDeviceElement = device;
+        return true;
+      }
+    }
+    paErrMsg = std::string("Device ProductCode ") + std::to_string(paProductCode) + " not found in ESI";
+    return false;
+  }
+
+  bool EsiFileParser::getModuleFromDocByIdentity(TiXmlDocument *paDocument,
+                                                 uint32_t paModuleIdent,
+                                                 TiXmlElement *&paModuleElement,
+                                                 std::string &paErrMsg) {
+    if (nullptr == paDocument || nullptr == paDocument->RootElement()) {
+      paErrMsg = "Invalid ESI XML root";
+      return false;
+    }
+    if (auto cached = scmDeviceOrModuleMap.find(paModuleIdent); cached != scmDeviceOrModuleMap.end()) {
+      paModuleElement = cached->second;
+      return true;
+    }
+    auto *descriptions = paDocument->RootElement()->FirstChildElement("Descriptions");
+    auto *modules = descriptions ? descriptions->FirstChildElement("Modules") : nullptr;
+    if (nullptr == modules) {
+      paErrMsg = "No Modules section in ESI";
+      return false;
+    }
+    for (auto *module = modules->FirstChildElement("Module"); module; module = module->NextSiblingElement("Module")) {
+      auto *type = module->FirstChildElement("Type");
+      if (!type) {
+        continue;
+      }
+      const char *mi = type->Attribute("ModuleIdent");
+      if (mi && parseEcNumber(mi) == paModuleIdent) {
+        scmDeviceOrModuleMap[paModuleIdent] = module;
+        paModuleElement = module;
+        return true;
+      }
+    }
+    paErrMsg = std::string("ModuleIdent ") + std::to_string(paModuleIdent) + " not found in ESI";
+    return false;
+  }
+
+  bool EsiFileParser::loadDevice(uint32_t paProductCode, std::string &paErrMsg) {
+    if (!loadEsiFileByKey(paProductCode, paErrMsg)) {
+      return false;
+    }
+    TiXmlElement *deviceElement = nullptr;
+    return getDeviceFromDocByProductCode(scmEsiFileDocMap[scmEsiFilePathMap[paProductCode]],
+                                         paProductCode,
+                                         deviceElement,
+                                         paErrMsg);
+  }
+
+  bool EsiFileParser::loadModule(uint32_t paModuleIdent, std::string &paErrMsg) {
+    if (!loadEsiFileByKey(paModuleIdent, paErrMsg)) {
+      return false;
+    }
+    TiXmlElement *moduleElement = nullptr;
+    return getModuleFromDocByIdentity(scmEsiFileDocMap[scmEsiFilePathMap[paModuleIdent]],
+                                      paModuleIdent,
+                                      moduleElement,
+                                      paErrMsg);
+  }
+
+  void EsiFileParser::getPdoSizeInfo(TiXmlElement *paElement,
+                                     FORTE_ECSlave &paSlave,
+                                     uint16_t &paRcvBufferSize,
+                                     uint16_t &paSendBufferSize) {
+    int inputIndex = 0;
+    for (auto *tx = paElement->FirstChildElement("TxPdo"); tx; tx = tx->NextSiblingElement("TxPdo")) {
+      if (!tx->Attribute("Sm")) {
+        continue;
+      }
+      for (auto *entry = tx->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const auto *idVar = static_cast<const CIEC_WSTRING *>(paSlave.getDI(2 + inputIndex++));
+        if (!idVar->getValue() || idVar->getValue()[0] == '\0') {
+          continue;
+        }
+        const char *bitLen = entry->FirstChildElement("BitLen")->GetText();
+        paRcvBufferSize += static_cast<uint16_t>(util::strtoul(bitLen, nullptr, 10));
+      }
+    }
+
+    inputIndex = static_cast<int>(paSlave.numInMappings());
+    for (auto *rx = paElement->FirstChildElement("RxPdo"); rx; rx = rx->NextSiblingElement("RxPdo")) {
+      if (!rx->Attribute("Sm")) {
+        continue;
+      }
+      for (auto *entry = rx->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const auto *idVar = static_cast<const CIEC_WSTRING *>(paSlave.getDI(2 + inputIndex++));
+        if (!idVar->getValue() || idVar->getValue()[0] == '\0') {
+          continue;
+        }
+        const char *bitLen = entry->FirstChildElement("BitLen")->GetText();
+        paSendBufferSize += static_cast<uint16_t>(util::strtoul(bitLen, nullptr, 10));
+      }
+    }
+    paRcvBufferSize /= 8;
+    paSendBufferSize /= 8;
+  }
+
+  void EsiFileParser::getPdoSizeInfo(TiXmlElement *paElement,
+                                     FORTE_ECModule &paSlave,
+                                     uint16_t &paRcvBufferSize,
+                                     uint16_t &paSendBufferSize) {
+    int inputIndex = 0;
+    for (auto *tx = paElement->FirstChildElement("TxPdo"); tx; tx = tx->NextSiblingElement("TxPdo")) {
+      if (!tx->Attribute("Sm")) {
+        continue;
+      }
+      for (auto *entry = tx->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const auto *idVar = static_cast<const CIEC_WSTRING *>(paSlave.getDI(2 + inputIndex++));
+        if (!idVar->getValue() || idVar->getValue()[0] == '\0') {
+          continue;
+        }
+        const char *bitLen = entry->FirstChildElement("BitLen")->GetText();
+        paRcvBufferSize += static_cast<uint16_t>(util::strtoul(bitLen, nullptr, 10));
+      }
+    }
+
+    inputIndex = static_cast<int>(paSlave.numInMappings());
+    for (auto *rx = paElement->FirstChildElement("RxPdo"); rx; rx = rx->NextSiblingElement("RxPdo")) {
+      if (!rx->Attribute("Sm")) {
+        continue;
+      }
+      for (auto *entry = rx->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const auto *idVar = static_cast<const CIEC_WSTRING *>(paSlave.getDI(2 + inputIndex++));
+        if (!idVar->getValue() || idVar->getValue()[0] == '\0') {
+          continue;
+        }
+        const char *bitLen = entry->FirstChildElement("BitLen")->GetText();
+        paSendBufferSize += static_cast<uint16_t>(util::strtoul(bitLen, nullptr, 10));
+      }
+    }
+    paRcvBufferSize /= 8;
+    paSendBufferSize /= 8;
+  }
+
+  void EsiFileParser::parseDevicePdo(const std::string &paPdoType,
+                                     TiXmlElement *paElement,
+                                     ECDeviceHandler *paDeviceHandler,
+                                     FORTE_ECSlave &paSlave) {
+    const SyncDir dir = (paPdoType == "RxPdo") ? SyncDir::Out : SyncDir::In;
+    int diIndex = (dir == SyncDir::In) ? 2 : 2 + static_cast<int>(paSlave.numInMappings());
+    int handleIndex = 0;
+    int entryIndexInInterface = 0;
+    int offset = 0;
+    for (auto *pdoElement = paElement->FirstChildElement(paPdoType.c_str()); pdoElement; pdoElement = pdoElement->NextSiblingElement(paPdoType.c_str())) {
+      if (!pdoElement->Attribute("Sm")) {
+        continue;
+      }
+      const char *indexStr = pdoElement->FirstChildElement("Index")->GetText();
+      const uint16_t pdoIndex = static_cast<uint16_t>(parseEcNumber(indexStr));
+      paDeviceHandler->mECDeviceModel.addPdo(pdoIndex, dir);
+
+      for (auto *entry = pdoElement->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const char *entryIndexText = entry->FirstChildElement("Index")->GetText();
+        const uint16_t entryIndex = static_cast<uint16_t>(parseEcNumber(entryIndexText));
+        const uint8_t subIndex =
+            static_cast<uint8_t>(util::strtoul(entry->FirstChildElement("SubIndex")->GetText(), nullptr, 10));
+        const uint8_t bitLen =
+            static_cast<uint8_t>(util::strtoul(entry->FirstChildElement("BitLen")->GetText(), nullptr, 10));
+        paDeviceHandler->mECDeviceModel.addPdoEntry(pdoIndex, entryIndex, subIndex, bitLen);
+
+        auto *idVar = static_cast<CIEC_WSTRING *>(paSlave.getDI(diIndex + entryIndexInInterface++));
+        const char *idText = idVar->getValue();
+        if (nullptr == idText || idText[0] == '\0') {
+          continue;
+        }
+
+        std::string handleId{idText};
+        ECBusHandler::HandleDescriptor desc(handleId,
+                                            dir == SyncDir::In ? forte::io::IOMapper::Direction::In
+                                                               : forte::io::IOMapper::Direction::Out,
+                                            paDeviceHandler->index(),
+                                            static_cast<uint8_t>(offset),
+                                            static_cast<uint8_t>(bitLen / 8));
+        paSlave.initHandle(desc);
+        offset += bitLen / 8;
+
+        ECSlaveHandle *handle = (dir == SyncDir::In) ? paDeviceHandler->getInputHandle(handleIndex)
+                                                      : paDeviceHandler->getOutputHandle(handleIndex);
+        if (handle) {
+          paDeviceHandler->mECDeviceModel.addEntryReg(entryIndex, subIndex, handle->ecDomainOffsetPtr());
+        }
+        handleIndex++;
+      }
+    }
+  }
+
+  void EsiFileParser::parseModulePdo(const std::string &paPdoType,
+                                     TiXmlElement *paElement,
+                                     ECDeviceHandler *paDeviceHandler,
+                                     ECModuleHandler *paModuleHandler,
+                                     FORTE_ECModule &paSlave) {
+    std::string vendorName;
+    if (auto vit = scmVendorMap.find(paModuleHandler->moduleIdent()); vit != scmVendorMap.end()) {
+      vendorName = vit->second;
+    }
+
+    const SyncDir dir = (paPdoType == "RxPdo") ? SyncDir::Out : SyncDir::In;
+    int diIndex = (dir == SyncDir::In) ? 2 : 2 + static_cast<int>(paSlave.numInMappings());
+    int handleIndex = 0;
+    int entryIndexInInterface = 0;
+    int offset = 0;
+    for (auto *pdoElement = paElement->FirstChildElement(paPdoType.c_str()); pdoElement; pdoElement = pdoElement->NextSiblingElement(paPdoType.c_str())) {
+      if (!pdoElement->Attribute("Sm")) {
+        continue;
+      }
+      uint16_t pdoIndex = static_cast<uint16_t>(parseEcNumber(pdoElement->FirstChildElement("Index")->GetText()));
+      pdoIndex = static_cast<uint16_t>(pdoIndex + paDeviceHandler->mECDeviceModel.mSlotPdoInc * paModuleHandler->slot());
+      paDeviceHandler->mECDeviceModel.addPdo(pdoIndex, dir);
+
+      for (auto *entry = pdoElement->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const char *entryIndexText = entry->FirstChildElement("Index")->GetText();
+        uint16_t entryIndex = static_cast<uint16_t>(parseEcNumber(entryIndexText));
+        const uint8_t subIndex =
+            static_cast<uint8_t>(util::strtoul(entry->FirstChildElement("SubIndex")->GetText(), nullptr, 10));
+        const uint8_t bitLen =
+            static_cast<uint8_t>(util::strtoul(entry->FirstChildElement("BitLen")->GetText(), nullptr, 10));
+        applyVendorModulePdoEntryIndexCorrection(vendorName, entryIndex);
+        entryIndex =
+            static_cast<uint16_t>(entryIndex + paDeviceHandler->mECDeviceModel.mSlotIndexInc * paModuleHandler->slot());
+        paDeviceHandler->mECDeviceModel.addPdoEntry(pdoIndex, entryIndex, subIndex, bitLen);
+
+        auto *idVar = static_cast<CIEC_WSTRING *>(paSlave.getDI(diIndex + entryIndexInInterface++));
+        const char *idText = idVar->getValue();
+        if (nullptr == idText || idText[0] == '\0') {
+          continue;
+        }
+
+        std::string handleId{idText};
+        ECBusHandler::HandleDescriptor desc(handleId,
+                                            dir == SyncDir::In ? forte::io::IOMapper::Direction::In
+                                                               : forte::io::IOMapper::Direction::Out,
+                                            paModuleHandler->index(),
+                                            static_cast<uint8_t>(offset),
+                                            static_cast<uint8_t>(bitLen / 8));
+        paSlave.initHandle(desc);
+        offset += bitLen / 8;
+
+        ECSlaveHandle *handle = (dir == SyncDir::In) ? paModuleHandler->getInputHandle(handleIndex)
+                                                      : paModuleHandler->getOutputHandle(handleIndex);
+        if (handle) {
+          paDeviceHandler->mECDeviceModel.addEntryReg(entryIndex, subIndex, handle->ecDomainOffsetPtr());
+        }
+        handleIndex++;
+      }
+    }
+  }
+
+  void EsiFileParser::initDeviceIOHandles(uint32_t paProductCode, ECDeviceHandler *paDeviceHandler, FORTE_ECSlave &paSlave) {
+    auto it = scmDeviceOrModuleMap.find(paProductCode);
+    if (it == scmDeviceOrModuleMap.end()) {
+      return;
+    }
+    TiXmlElement *deviceElement = it->second;
+    if (paDeviceHandler->mSlaveType == ECSlaveHandler::SlaveType::ECCoupler) {
+      if (auto *slots = deviceElement->FirstChildElement("Slots")) {
+        paDeviceHandler->mECDeviceModel.mSlotIndexInc =
+            static_cast<uint32_t>(util::strtoul(slots->Attribute("SlotIndexIncrement"), nullptr, 10));
+        paDeviceHandler->mECDeviceModel.mSlotPdoInc =
+            static_cast<uint32_t>(util::strtoul(slots->Attribute("SlotPdoIncrement"), nullptr, 10));
+      }
+    }
+
+    uint8_t smIndex = 0;
+    for (auto *sm = deviceElement->FirstChildElement("Sm"); sm; sm = sm->NextSiblingElement("Sm")) {
+      if (!sm->GetText()) {
+        smIndex++;
+        continue;
+      }
+      const std::string smText = sm->GetText();
+      if (smText == "Outputs" || smText == "Inputs") {
+        paDeviceHandler->mECDeviceModel.addSync(smIndex, smText == "Outputs" ? SyncDir::Out : SyncDir::In);
+      }
+      smIndex++;
+    }
+
+    uint16_t recvSize = 0;
+    uint16_t sendSize = 0;
+    getPdoSizeInfo(deviceElement, paSlave, recvSize, sendSize);
+    paDeviceHandler->initBuffer(sendSize, recvSize);
+    parseDevicePdo("TxPdo", deviceElement, paDeviceHandler, paSlave);
+    parseDevicePdo("RxPdo", deviceElement, paDeviceHandler, paSlave);
+  }
+
+  void EsiFileParser::initModuleIOHandles(uint32_t paModuleIdent,
+                                          ECDeviceHandler *paDeviceHandler,
+                                          ECModuleHandler *paModuleHandler,
+                                          FORTE_ECModule &paSlave) {
+    auto it = scmDeviceOrModuleMap.find(paModuleIdent);
+    if (it == scmDeviceOrModuleMap.end()) {
+      return;
+    }
+    TiXmlElement *moduleElement = it->second;
+    uint16_t recvSize = 0;
+    uint16_t sendSize = 0;
+    getPdoSizeInfo(moduleElement, paSlave, recvSize, sendSize);
+    paModuleHandler->initBuffer(sendSize, recvSize);
+    parseModulePdo("TxPdo", moduleElement, paDeviceHandler, paModuleHandler, paSlave);
+    parseModulePdo("RxPdo", moduleElement, paDeviceHandler, paModuleHandler, paSlave);
+  }
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/utils/EsiFileParser.h
+++ b/modules/ethercat/utils/EsiFileParser.h
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "../slave/ec_device.h"
+#include "../slave/ec_module.h"
+#include "forte/util/singlet.h"
+
+#include <map>
+#include <string>
+
+class TiXmlDocument;
+class TiXmlElement;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECSlave;
+  class FORTE_ECModule;
+
+  class EsiFileParser {
+      DECLARE_SINGLETON(EsiFileParser)
+
+    public:
+      bool loadDevice(uint32_t paProductCode, std::string &paErrMsg);
+      bool loadModule(uint32_t paModuleIdent, std::string &paErrMsg);
+
+      void initDeviceIOHandles(uint32_t paProductCode, ECDeviceHandler *paDeviceHandler, FORTE_ECSlave &paSlave);
+      void initModuleIOHandles(uint32_t paModuleIdent,
+                               ECDeviceHandler *paDeviceHandler,
+                               ECModuleHandler *paModuleHandler,
+                               FORTE_ECModule &paSlave);
+
+    private:
+      bool loadEsiFileByKey(uint32_t paKey, std::string &paErrMsg);
+      void init();
+
+      bool getDeviceFromDocByProductCode(TiXmlDocument *paDocument,
+                                         uint32_t paProductCode,
+                                         TiXmlElement *&paDeviceElement,
+                                         std::string &paErrMsg);
+      bool getModuleFromDocByIdentity(TiXmlDocument *paDocument,
+                                      uint32_t paModuleIdent,
+                                      TiXmlElement *&paModuleElement,
+                                      std::string &paErrMsg);
+
+      void parseDevicePdo(const std::string &paPdoType,
+                          TiXmlElement *paDeviceElement,
+                          ECDeviceHandler *paDeviceHandler,
+                          FORTE_ECSlave &paSlave);
+      void parseModulePdo(const std::string &paPdoType,
+                          TiXmlElement *paModuleElement,
+                          ECDeviceHandler *paDeviceHandler,
+                          ECModuleHandler *paModuleHandler,
+                          FORTE_ECModule &paSlave);
+
+      void getPdoSizeInfo(TiXmlElement *paElement,
+                          FORTE_ECSlave &paSlave,
+                          uint16_t &paRcvBufferSize,
+                          uint16_t &paSendBufferSize);
+
+      void getPdoSizeInfo(TiXmlElement *paElement,
+                          FORTE_ECModule &paSlave,
+                          uint16_t &paRcvBufferSize,
+                          uint16_t &paSendBufferSize);
+
+      static uint32_t parseEcNumber(const char *paText);
+
+      static std::map<uint32_t, std::string> scmEsiFilePathMap;
+      static std::map<std::string, TiXmlDocument *> scmEsiFileDocMap;
+      static std::map<uint32_t, TiXmlElement *> scmDeviceOrModuleMap;
+      static std::map<uint32_t, std::string> scmVendorMap;
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat
+


### PR DESCRIPTION
## Summary
- Add FORTE_MODULE_ETHERCAT for Linux with ECMaster, ECSlave, ECModule, and ECCoupler FBs
- Add ESI file parsing and IgH EtherCAT Master integration
- Add IOConfigHandlerFBMultiSlave for multi-slave IO handlers

## Related PRs
- eclipse-4diac/4diac-fbe#72
- eclipse-4diac/4diac-ide#2581

## Test plan
- [ ] Build forte with FORTE_MODULE_ETHERCAT=ON
- [ ] Verify EtherCAT master/slave FB deployment on Linux