### PR TITLE
Add core EtherCAT library integration (PR 1 of 3)

### DIFF
--- a/dependencies.spdx
+++ b/dependencies.spdx
@@ -52,3 +52,17 @@ FilesAnalyzed: false
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
+
+PackageName: ethercat
+SPDXID: SPDXRef-ethercat
+PackageComment: <text>IgH EtherCAT Master userspace library (libethercat, ecrt.h). FORTE links against the userspace API only; kernel modules are not bundled. Userspace library license: LGPL-2.1-only.</text>
+ExternalRef: PACKAGE-MANAGER purl pkg:gitlab/etherlab.org/ethercat@1.6.7
+PackageVersion: 1.6.7
+PackageSupplier: Organization: etherlab
+Relationship: SPDXRef-ethercat OPTIONAL_DEPENDENCY_OF SPDXRef-4diac-FORTE
+PackageDownloadLocation: https://gitlab.com/api/v4/projects/etherlab.org%2Fethercat/packages/generic/ethercat/1.6.7/ethercat-1.6.7.tar.bz2
+PackageChecksum: SHA256: 024e976a58eb527aacd86767e94a826fe937ca1741b133208e6c6e76f81ca062
+FilesAnalyzed: false
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -10,6 +10,8 @@
 # Contributors:
 #    Martin Erich Jobst
 #      - initial API and implementation and/or initial documentation
+#    Sichuan Qunyuan Technology Co., Ltd.
+#      - add ethercat module
 #############################################################################
 
 add_subdirectory(ads)
@@ -18,6 +20,7 @@ add_subdirectory(conmeleon_c1)
 add_subdirectory(convert)
 add_subdirectory(eliteboard)
 add_subdirectory(embrick)
+add_subdirectory(ethercat)
 add_subdirectory(gpiochip)
 add_subdirectory(i2c_dev)
 add_subdirectory(IEC61131-3)

--- a/modules/ethercat/CMakeLists.txt
+++ b/modules/ethercat/CMakeLists.txt
@@ -1,0 +1,43 @@
+# *******************************************************************************
+# Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+# *******************************************************************************/
+
+if (NOT LINUX)
+    return()
+endif ()
+
+option(FORTE_MODULE_ETHERCAT "Support for the modular ethercat system" OFF)
+
+if (NOT FORTE_MODULE_ETHERCAT)
+    return()
+endif ()
+
+# ############################################################################
+# EtherCAT core integration (IgH ecrt, bus handler, device layer)
+# ############################################################################
+
+add_library(forte-ethercat
+            handler/bus.h
+            handler/bus.cpp
+            device/bus_device_handler.h
+            device/bus_device_handler.cpp
+            device/handle.h
+            device/handle.cpp
+            device/ec_device.h
+            device/ec_device.cpp
+            device/model/ec_model.h
+            device/model/ec_model.cpp
+)
+target_link_libraries(forte-ethercat PUBLIC forte-core)
+target_link_libraries(forte-ethercat PRIVATE ethercat)
+target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-ethercat,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-ethercat>>)
+install(TARGETS forte-ethercat EXPORT forte-export FILE_SET HEADERS)

--- a/modules/ethercat/device/bus_device_handler.cpp
+++ b/modules/ethercat/device/bus_device_handler.cpp
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "bus_device_handler.h"
+#include "../handler/bus.h"
+#include "../device/ec_device.h"
+#include "forte/io/mapper/io_mapper.h"
+#include "forte/util/criticalregion.h"
+#include <algorithm>
+
+namespace forte::eclipse4diac::io::ethercat {
+  ECBusDeviceHandler::ECBusDeviceHandler(ECBusHandler *paBus,
+                                 DeviceType paDeviceType,
+                                 size_t paDeviceIndex) : 
+      mDelegate(nullptr),
+      mDeviceIndex(paDeviceIndex),
+      mDeviceType(paDeviceType),
+      mBus(paBus),
+      mDataSendLength(0),
+      mDataRecvLength(0),
+      mStatus(NotInitialized),
+      mOldStatus(NotInitialized) {
+  }
+
+  ECBusDeviceHandler::~ECBusDeviceHandler() {
+    dropHandles();
+
+    if (mDelegate != nullptr) {
+      if(mBus != nullptr && mBus->isShuttingDown()) {
+        mDelegate = nullptr;
+        return;
+      }
+      mDelegate->onDeviceDestroy();
+    }
+  }
+
+  void ECBusDeviceHandler::initBuffer(uint16_t paDataSendLength, uint16_t paDataRecvLength) {
+    mDataSendLength = paDataSendLength;
+    mDataRecvLength = paDataRecvLength;
+
+    mUpdateSendImage.assign(paDataSendLength, 0);
+    mUpdateRecvImage.assign(paDataRecvLength, 0);
+    mUpdateRecvImageOld.assign(paDataRecvLength, 0);
+  }
+
+  void ECBusDeviceHandler::update(uint8_t *paECDomainData) {
+    util::CCriticalRegion critialRegion(mHandleMutex);
+
+    for(ECDeviceHandle *handle : mInputs) {
+      handle->syncDomainData(paECDomainData);
+      if(handle->hasObserver() && !handle->equal(mUpdateRecvImageOld)){
+        handle->onChange();
+      }
+    }
+
+    std::copy(mUpdateRecvImage.begin(), mUpdateRecvImage.end(), mUpdateRecvImageOld.begin());
+
+    for(ECDeviceHandle *handle : mOutputs) {
+      handle->syncDomainData(paECDomainData);
+    }
+  }
+
+  void ECBusDeviceHandler::dropHandles() {
+    util::CCriticalRegion criticalRegion(mHandleMutex);
+    forte::io::IOMapper &mapper = forte::io::IOMapper::getInstance();
+
+    if(mBus != nullptr && mBus->isShuttingDown()) {
+      mInputs.clear();
+      mOutputs.clear();
+      return;
+    }
+
+    if(mBus != nullptr && mBus->isLoopPrepared()) {
+      ECDeviceHandler *device = mBus->getParentDevice(this);
+      if(device != nullptr) {
+        auto persistHandleOffset = [&](ECDeviceHandle *handle) {
+          for(EntryReg &reg : device->mECDeviceModel.mEntryRegList) {
+            if(reg.mOffset == &handle->mECDomainDataOffset) {
+              reg.mDomainOffset = handle->mECDomainDataOffset;
+              reg.mOffsetValid = true;
+            }
+          }
+        };
+        for(ECDeviceHandle *handle : mInputs) {
+          persistHandleOffset(handle);
+        }
+        for(ECDeviceHandle *handle : mOutputs) {
+          persistHandleOffset(handle);
+        }
+      }
+    }
+
+    for(ECDeviceHandle *it : mInputs) {
+      mapper.deregisterHandle(it->handleId());
+      delete it;
+    }
+
+    for(ECDeviceHandle *it : mOutputs) {
+      mapper.deregisterHandle(it->handleId());
+      delete it;
+    }
+
+    mInputs.clear();
+    mOutputs.clear();
+  }
+
+  void ECBusDeviceHandler::addHandle(std::vector<ECDeviceHandle *> &paList, ECDeviceHandle *paHandle) {
+    util::CCriticalRegion criticalRegion(mHandleMutex);
+    paList.push_back(paHandle);
+
+    //TODO Maybe send indication event after connecting
+  }
+
+  ECDeviceHandle *ECBusDeviceHandler::getHandle(std::vector<ECDeviceHandle *> &paList, size_t paIndex) {
+    if(paList.size() <= paIndex) {
+      return nullptr;
+    }
+    return paList[paIndex];
+  }
+}

--- a/modules/ethercat/device/bus_device_handler.h
+++ b/modules/ethercat/device/bus_device_handler.h
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "handle.h"
+#include "forte/io/mapper/io_mapper.h"
+#include <vector>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+	class ECBusHandler;
+
+	class ECBusDeviceHandler {
+		
+		public:
+			friend class ECBusHandler;
+
+      enum DeviceStatus {
+        NotInitialized = 0,
+        Error = 1,
+        OK = 2
+      };
+
+      enum DeviceType {
+        ECDevice = 0,
+        ECCoupler = 1,
+        ECModule = 2
+      };
+
+      struct Config{
+      };
+
+      class Delegate {
+        public:
+          virtual void onDeviceStatus(DeviceStatus paStatus, DeviceStatus paOldStatus) = 0;
+          virtual void onDeviceDestroy() = 0;
+      };
+
+      virtual void setConfig(Config* paConfig) = 0;
+      Delegate *mDelegate;
+
+      size_t index() const {
+        return mDeviceIndex;
+      }
+
+      const DeviceType mDeviceType;
+
+      uint16_t dataSendLength() const {
+        return mDataSendLength;
+      }
+
+      uint16_t dataRecvLength() const {
+        return mDataRecvLength;
+      }
+
+      void update(uint8_t *paECDomianPd);
+
+      ECDeviceHandle *getInputHandle(size_t paIndex) {
+        return getHandle(mInputs, paIndex);
+      }
+
+      ECDeviceHandle *getOutputHandle(size_t paIndex) {
+        return getHandle(mOutputs, paIndex);
+      }
+
+      void addHandle(ECDeviceHandle *paHandle) {
+        switch (paHandle->getDirection()){
+          case forte::io::IOMapper::In: addHandle(mInputs, paHandle); break;
+          case forte::io::IOMapper::Out: addHandle(mOutputs, paHandle); break;
+          default: break;
+        }
+      }
+
+      void dropHandles();
+
+      std::vector<unsigned char> mUpdateSendImage;
+      std::vector<unsigned char> mUpdateRecvImage;
+      arch::CSyncObject mUpdateMutex;
+
+      void initBuffer(uint16_t paDataSendLength, uint16_t paDataRecvLength);
+
+    protected:
+      size_t mDeviceIndex;
+      
+      ECBusDeviceHandler(ECBusHandler *paBus, DeviceType paDeviceType, size_t paDeviceIndex);
+      virtual ~ECBusDeviceHandler();
+
+      ECBusHandler *mBus;
+
+      uint16_t mDataSendLength;
+      uint16_t mDataRecvLength;
+      DeviceStatus mStatus;
+      DeviceStatus mOldStatus;
+      std::vector<unsigned char> mUpdateRecvImageOld;
+
+      arch::CSyncObject mHandleMutex;
+      std::vector<ECDeviceHandle *> mInputs;
+      std::vector<ECDeviceHandle *> mOutputs;
+      void addHandle(std::vector<ECDeviceHandle *> &paList, ECDeviceHandle *paHandle);
+      ECDeviceHandle *getHandle(std::vector<ECDeviceHandle *> &paList, size_t paIndex);
+
+    private:
+      //! declared but undefined copy constructor as we don't want devices to be directly copied.
+      ECBusDeviceHandler(const ECBusDeviceHandler &);
+      
+	};
+}

--- a/modules/ethercat/device/ec_device.cpp
+++ b/modules/ethercat/device/ec_device.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ec_device.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  ECDeviceHandler::ECDeviceHandler(ECBusHandler *paBus, 
+                                   ECBusDeviceHandler::DeviceType paDeviceType, 
+                                   size_t paDeviceIndex) : 
+      ECBusDeviceHandler(paBus, paDeviceType, paDeviceIndex) {
+  }
+
+  void ECDeviceHandler::setConfig(struct ECBusDeviceHandler::Config *paConfig) {
+    mConfig = *static_cast<Config *>(paConfig);
+
+    mECDeviceModel.mAlias = mConfig.mAlias;
+    mECDeviceModel.mPosition = mConfig.mPosition;
+    mECDeviceModel.mVendorId = mConfig.mVendorId;
+    mECDeviceModel.mProductCode = mConfig.mProductCode;
+  }
+}

--- a/modules/ethercat/device/ec_device.h
+++ b/modules/ethercat/device/ec_device.h
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "bus_device_handler.h"
+#include "model/ec_model.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class ECDeviceHandler : public ECBusDeviceHandler {
+    
+    public:
+      struct Config : ECBusDeviceHandler::Config {
+        uint16_t mAlias;
+        uint16_t mPosition;
+        uint32_t mVendorId;
+        uint32_t mProductCode;
+      };
+
+      ECDeviceModel mECDeviceModel;
+
+      void setConfig(struct ECBusDeviceHandler::Config *paConfig) override;
+
+      ECDeviceHandler(ECBusHandler *paBus, ECBusDeviceHandler::DeviceType paDeviceType, size_t paDeviceIndex);
+
+    protected:
+      struct Config mConfig;
+  };
+}

--- a/modules/ethercat/device/handle.cpp
+++ b/modules/ethercat/device/handle.cpp
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "handle.h"
+#include "bus_device_handler.h"
+#include "forte/datatypes/forte_byte.h"
+#include "forte/datatypes/forte_word.h"
+#include "forte/datatypes/forte_dword.h"
+#include "forte/datatypes/forte_lword.h"
+#include "forte/io/mapper/io_mapper.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  ECDeviceHandle::ECDeviceHandle(forte::io::IODeviceController *paController,
+                                forte::io::IOMapper::Direction paDirection,
+                                CIEC_ANY::EDataTypeID paType,
+                                uint8_t paOffset,
+                                const std::string &paHandleId,
+                                ECBusDeviceHandler &paDevice) :
+      IOHandle(paController, paDirection, paType),
+      mOffset(paOffset),
+      mECDomainDataOffset(0),
+      mDevice(paDevice),
+      mUpdateMutex(mDevice.mUpdateMutex),
+      mHandleId(paHandleId) {
+    if(paDirection == forte::io::IOMapper::In){
+      mBuffer = std::span<unsigned char>(mDevice.mUpdateRecvImage.data(), mDevice.mUpdateRecvImage.size());
+    } else if(paDirection == forte::io::IOMapper::Out) {
+      mBuffer = std::span<unsigned char>(mDevice.mUpdateSendImage.data(), mDevice.mUpdateSendImage.size());
+    }
+
+    switch (paType) {
+      case CIEC_ANY::EDataTypeID::e_BYTE:
+        mByteLength = 1;
+        break;
+      case CIEC_ANY::EDataTypeID::e_WORD:
+        mByteLength = 2;
+        break;
+      case CIEC_ANY::EDataTypeID::e_DWORD:
+        mByteLength = 4;
+        break;
+      case CIEC_ANY::EDataTypeID::e_LWORD:
+        mByteLength = 8;
+        break;
+      default:
+        break;
+    }
+
+  }
+
+  ECDeviceHandle::~ECDeviceHandle() = default;
+
+  void ECDeviceHandle::syncDomainData(uint8_t *paECDomainData) {
+    uint8_t *ecDomainData = paECDomainData + mECDomainDataOffset;
+    if(isInput()) {
+      memcpy(mBuffer.data() + mOffset, ecDomainData, mByteLength);
+    } else if(isOutput()) {
+      memcpy(ecDomainData, mBuffer.data() + mOffset, mByteLength);
+    }
+  }
+
+  void ECDeviceHandle::set(const CIEC_ANY &paValue) {
+    switch (mType) {
+      case CIEC_ANY::EDataTypeID::e_BYTE: {
+        uint8_t value = static_cast<const CIEC_BYTE &>(paValue);
+        memcpy(mBuffer.data() + mOffset, &value, sizeof(uint8_t));
+      }
+      break;
+      case CIEC_ANY::EDataTypeID::e_WORD: {
+        uint16_t value = static_cast<const CIEC_WORD &>(paValue);
+        uint16_t littleEndValue = hostToLittleEndian(value);
+        memcpy(mBuffer.data() + mOffset, &littleEndValue, sizeof(uint16_t));
+      }
+      break;
+      case CIEC_ANY::EDataTypeID::e_DWORD: {
+        uint32_t value = static_cast<const CIEC_DWORD &>(paValue);
+        uint32_t littleEndValue = hostToLittleEndian(value);
+        memcpy(mBuffer.data() + mOffset, &littleEndValue, sizeof(uint32_t));
+      }
+      break;
+      case CIEC_ANY::EDataTypeID::e_LWORD: {
+        uint64_t value = static_cast<const CIEC_LWORD &>(paValue);
+        uint64_t littleEndValue = hostToLittleEndian(value);
+        memcpy(mBuffer.data() + mOffset, &littleEndValue, sizeof(uint64_t));
+      }
+      break;
+      default:
+        DEVLOG_ERROR("ethercat[ECDeviceHandle]:Unsupported data type for set.\n");
+      break;
+    }
+  }
+
+  void ECDeviceHandle::get(CIEC_ANY &paValue) {
+    switch (mType){
+      case CIEC_ANY::EDataTypeID::e_BYTE:
+        static_cast<CIEC_BYTE &>(paValue) = getByteValue(mBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_WORD:
+        static_cast<CIEC_WORD &>(paValue) = getWordValue(mBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_DWORD:
+        static_cast<CIEC_DWORD &>(paValue) = getDWordValue(mBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_LWORD:
+        static_cast<CIEC_LWORD &>(paValue) = getLWordValue(mBuffer);
+        break;
+      default:
+        DEVLOG_ERROR("ethercat[ECDeviceHandle]:Unsupported data type for get.\n");
+        break;
+    }
+  }
+
+  bool ECDeviceHandle::equal(std::span<const unsigned char> paOldBuffer) {
+    bool result = false;
+
+    switch (mType){
+      case CIEC_ANY::EDataTypeID::e_BYTE:
+        result = getByteValue(mBuffer) == getByteValue(paOldBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_WORD:
+        result = getWordValue(mBuffer) == getWordValue(paOldBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_DWORD:
+        result = getDWordValue(mBuffer) == getDWordValue(paOldBuffer);
+        break;
+      case CIEC_ANY::EDataTypeID::e_LWORD:
+        result = getLWordValue(mBuffer) == getLWordValue(paOldBuffer);
+        break;
+      default:
+        result = false;
+        DEVLOG_ERROR("ethercat(ECDeviceHandle):Unsupported type for equal.\n");
+        break;
+    }
+
+    return result;
+  }
+
+  const CIEC_BYTE ECDeviceHandle::getByteValue(std::span<const unsigned char> paBuffer){
+    return CIEC_BYTE(paBuffer[mOffset]);
+  }
+
+  const CIEC_WORD ECDeviceHandle::getWordValue(std::span<const unsigned char> paBuffer){
+    uint16_t value;
+    memcpy(&value, paBuffer.data() + mOffset, sizeof(uint16_t));
+    uint16_t hostValue = littleEndianToHost(value);   
+    return CIEC_WORD(hostValue);
+  }
+
+  const CIEC_DWORD ECDeviceHandle::getDWordValue(std::span<const unsigned char> paBuffer){
+    uint32_t value;
+    memcpy(&value, paBuffer.data() + mOffset, sizeof(uint32_t));
+    uint32_t hostValue = littleEndianToHost(value);  
+    return CIEC_DWORD(hostValue);
+  }
+
+  const CIEC_LWORD ECDeviceHandle::getLWordValue(std::span<const unsigned char> paBuffer){
+    uint64_t value;
+    memcpy(&value, paBuffer.data() + mOffset, sizeof(uint64_t));
+    uint64_t hostValue = littleEndianToHost(value);
+    return CIEC_LWORD(hostValue);
+  }
+
+  void ECDeviceHandle::onObserver(forte::io::IOObserver *paObserver) {
+    reset();
+    IOHandle::onObserver(paObserver);
+  }
+
+  void ECDeviceHandle::dropObserver() {
+    IOHandle::dropObserver();
+    reset();
+  }
+}

--- a/modules/ethercat/device/handle.h
+++ b/modules/ethercat/device/handle.h
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/io/mapper/io_handle.h"
+#include "forte/arch/forte_sync.h"
+#include "endian.h"
+#include <span>
+#include <string>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class ECBusDeviceHandler;
+
+  class ECDeviceHandle : public forte::io::IOHandle {
+    public:
+			friend class ECBusDeviceHandler;
+			
+      ECDeviceHandle(forte::io::IODeviceController *paController,
+                    forte::io::IOMapper::Direction paDirection,
+                    CIEC_ANY::EDataTypeID type,
+                    uint8_t paOffset,
+                    const std::string &paHandleId,
+                    ECBusDeviceHandler &paDevice);
+      ~ECDeviceHandle() override;
+
+      const std::string &handleId() const {
+        return mHandleId;
+      }
+
+      /** Domain byte offset for EtherCAT registration (EsiFileParser / ECDeviceModel). */
+      unsigned int *ecDomainOffsetPtr() {
+        return &mECDomainDataOffset;
+      }
+
+      void set(const CIEC_ANY &) override;
+      void get(CIEC_ANY &) override;
+      bool equal(std::span<const unsigned char> paOldBuffer);
+
+    protected:
+			static constexpr bool IS_LITTLE_ENDIAN = __BYTE_ORDER == __LITTLE_ENDIAN;	
+
+			template<typename T>
+			static T hostLeEndianSwap(T value) {
+				if constexpr (!IS_LITTLE_ENDIAN) {
+					if constexpr (sizeof(T) == 2) {
+						return static_cast<T>(__builtin_bswap16(static_cast<uint16_t>(value)));
+					} else if constexpr (sizeof(T) == 4) {
+						return static_cast<T>(__builtin_bswap32(static_cast<uint32_t>(value)));
+					} else if constexpr (sizeof(T) == 8) {
+						return static_cast<T>(__builtin_bswap64(static_cast<uint64_t>(value)));
+					}
+				}
+
+				return value;
+			}
+
+			template<typename T>
+			static T hostToLittleEndian(T value) {
+				return hostLeEndianSwap(value);
+			}
+
+			template<typename T>
+			static T littleEndianToHost(T value) {
+				return hostLeEndianSwap(value);
+			}
+
+			const CIEC_BYTE getByteValue(std::span<const unsigned char> paBuffer);
+			const CIEC_WORD getWordValue(std::span<const unsigned char> paBuffer);
+			const CIEC_DWORD getDWordValue(std::span<const unsigned char> paBuffer);
+			const CIEC_LWORD getLWordValue(std::span<const unsigned char> paBuffer);
+        
+      virtual void reset() {}
+      void onObserver(forte::io::IOObserver *paObserver) override;
+      void dropObserver() override;
+			void syncDomainData(uint8_t *paECDomainData);
+
+      std::span<unsigned char> mBuffer;
+      const uint8_t mOffset;
+
+      unsigned int mECDomainDataOffset;
+      ECBusDeviceHandler &mDevice;
+      arch::CSyncObject &mUpdateMutex;
+
+			size_t mByteLength;
+      std::string mHandleId;
+  };
+}

--- a/modules/ethercat/device/model/ec_model.cpp
+++ b/modules/ethercat/device/model/ec_model.cpp
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#include "ec_model.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  PdoEntry::PdoEntry(uint16_t paPdoIndex, uint16_t paIndex, uint8_t paSubIndex, uint8_t paBitLength) :
+    mPdoIndex(paPdoIndex),mIndex(paIndex),mSubIndex(paSubIndex),mBitLength(paBitLength) {
+  }
+
+  Pdo::Pdo(uint16_t paIndex, SyncDir paSyncDir) :
+    mIndex(paIndex), mSyncDir(paSyncDir) {
+  }
+
+  Sync::Sync(uint8_t paIndex, SyncDir paSyncDir) :
+    mIndex(paIndex), mSyncDir(paSyncDir) {
+  }
+
+  EntryReg::EntryReg(uint16_t paAlias, uint16_t paPosition, uint32_t paVendorId, uint32_t paProductCode, uint16_t paIndex, uint8_t paSubIndex, unsigned int *paOffset) :
+    mAlias(paAlias), mPosition(paPosition), mVendorId(paVendorId), mProductCode(paProductCode), mIndex(paIndex), mSubIndex(paSubIndex), mOffset(paOffset),
+    mDomainOffset(0), mOffsetValid(false) {
+  }
+
+  ECDeviceModel::ECDeviceModel(uint16_t paAlias, uint16_t paPosition, uint32_t paVendorId, uint32_t paProductCode, uint32_t paSlotIndexInc, uint32_t paSlotPdoInc) :
+    mAlias(paAlias), mPosition(paPosition), mVendorId(paVendorId), mProductCode(paProductCode), mSlotIndexInc(paSlotIndexInc), mSlotPdoInc(paSlotPdoInc),
+    cachedSyncs(nullptr), cachedRxPdoSize(0), cachedTxPdoSize(0), cachedDomainRegs(nullptr) {
+  }
+
+  ECDeviceModel::~ECDeviceModel() {
+    cleanupSync();
+    cleanupDomainReg();
+  }
+
+  void ECDeviceModel::addSync(uint8_t paIndex, SyncDir paSyncDir) {
+    Sync sync {paIndex, paSyncDir};
+    mSyncList.push_back(sync);
+  }
+
+  void ECDeviceModel::addPdo(uint16_t paIndex, SyncDir paSyncDir) {
+    Pdo pdo {paIndex, paSyncDir};
+    mPdoList.push_back(pdo);
+  }
+
+  void ECDeviceModel::addPdoEntry(uint16_t paPdoIndex, uint16_t paIndex, uint8_t paSubIndex, uint8_t paBitlength) {
+    PdoEntry entry {paPdoIndex, paIndex, paSubIndex, paBitlength};
+    mPdoEntryList.push_back(entry);
+  }
+
+  void ECDeviceModel::addEntryReg(uint16_t paIndex, uint8_t paSubIndex, unsigned int *paOffset) {
+    EntryReg reg {mAlias, mPosition, mVendorId, mProductCode, paIndex, paSubIndex, paOffset};
+    mEntryRegList.push_back(reg);
+  }
+
+  EntryReg *ECDeviceModel::findEntryReg(uint16_t paIndex, uint8_t paSubIndex) {
+    for (EntryReg &reg : mEntryRegList) {
+      if (reg.mIndex == paIndex && reg.mSubIndex == paSubIndex) {
+        return &reg;
+      }
+    }
+    return nullptr;
+  }
+
+  void ECDeviceModel::restoreHandleDomainOffset(uint16_t paIndex, uint8_t paSubIndex, unsigned int *paHandleOffsetPtr) {
+    EntryReg *reg = findEntryReg(paIndex, paSubIndex);
+    if (reg == nullptr || !reg->mOffsetValid || paHandleOffsetPtr == nullptr) {
+      return;
+    }
+    *paHandleOffsetPtr = reg->mDomainOffset;
+    reg->mOffset = paHandleOffsetPtr;
+  }
+
+  void ECDeviceModel::cleanupSync() {
+    if(cachedSyncs != nullptr) {
+      if(cachedSyncs[0].pdos != nullptr) {
+        for(unsigned int i = 0; i < cachedRxPdoSize; i++) {
+          if(cachedSyncs[0].pdos[i].entries != nullptr) {
+            delete[] cachedSyncs[0].pdos[i].entries;
+          }
+        }
+
+        delete[] cachedSyncs[0].pdos;
+      }
+
+      if(cachedSyncs[1].pdos != nullptr) {
+        for(unsigned int i = 0; i < cachedTxPdoSize; i++) {
+          if(cachedSyncs[1].pdos[i].entries != nullptr) {
+            delete[] cachedSyncs[1].pdos[i].entries;
+          }
+        }
+
+        delete[] cachedSyncs[1].pdos;
+      }
+
+      delete[] cachedSyncs;
+      cachedSyncs = nullptr;
+      cachedRxPdoSize = 0;
+      cachedTxPdoSize = 0;
+    }
+  }
+
+  void ECDeviceModel::cleanupDomainReg() {
+    if(cachedDomainRegs != nullptr) {
+      delete[] cachedDomainRegs;
+      cachedDomainRegs = nullptr;
+    }
+  }
+
+  void ECDeviceModel::getPdoSize(unsigned int &paRxPdoSize, unsigned int &paTxPdoSize) {
+    for(int i = 0; i < mPdoList.size(); i++) {
+      if(mPdoList[i].mSyncDir == SyncDir::Out) {
+        paRxPdoSize++;
+      } else {
+        paTxPdoSize++;
+      }
+    }
+  }
+
+  void ECDeviceModel::getPdoEntrySize(uint16_t paPdoIndex, unsigned int &paPdoEntrySize) {
+    for(int i = 0; i < mPdoEntryList.size(); i++) {
+      if(mPdoEntryList[i].mPdoIndex == paPdoIndex) {
+        paPdoEntrySize++;
+      }
+    }
+  }
+
+  ec_pdo_entry_reg_t* ECDeviceModel::getDomainRegs(){
+    cleanupDomainReg();
+    
+    ec_pdo_entry_reg_t* regs = new ec_pdo_entry_reg_t[mEntryRegList.size() + 1];
+    
+    for(size_t i = 0; i < mEntryRegList.size(); i++){
+        regs[i] = {
+          mEntryRegList[i].mAlias,
+          mEntryRegList[i].mPosition,
+          mEntryRegList[i].mVendorId,
+          mEntryRegList[i].mProductCode,
+          mEntryRegList[i].mIndex,
+          mEntryRegList[i].mSubIndex,
+          mEntryRegList[i].mOffset,
+          nullptr  // bit_position
+        };
+    }
+    
+    regs[mEntryRegList.size()] = {};
+    
+    cachedDomainRegs = regs;
+    return regs;
+  }
+
+  ec_sync_info_t* ECDeviceModel::getSyncs(){
+    // Clean up previously cached syncs if any
+    cleanupSync();
+    
+    ec_sync_info_t* syncInfos = new ec_sync_info_t[3];
+    syncInfos[0] = {2, EC_DIR_OUTPUT, 0, nullptr, EC_WD_DEFAULT};
+    syncInfos[1] = {3, EC_DIR_INPUT, 0, nullptr, EC_WD_DEFAULT};
+    syncInfos[2] = {0xff};
+
+    unsigned int rxPdoSize = 0;
+    unsigned int txPdoSize = 0;
+    getPdoSize(rxPdoSize, txPdoSize);
+    
+    // Cache the sizes for later cleanup
+    cachedRxPdoSize = rxPdoSize;
+    cachedTxPdoSize = txPdoSize;
+   
+    // Build RxPDO (OUTPUT direction - from controller to device)
+    if(rxPdoSize > 0){
+        ec_pdo_info_t* rxPdoes = new ec_pdo_info_t[rxPdoSize];
+        int pdoIdx = 0;  // Use separate index for PDO array
+        for(int i = 0; i < mPdoList.size(); i++){
+            if(mPdoList[i].mSyncDir == SyncDir::Out){
+                uint16_t pdoIndex = mPdoList[i].mIndex;
+                unsigned int pdoEntrySize = 0;
+                getPdoEntrySize(pdoIndex, pdoEntrySize);
+                
+                ec_pdo_entry_info_t* entries = new ec_pdo_entry_info_t[pdoEntrySize];
+                int entryIdx = 0;
+                for(int j = 0; j < mPdoEntryList.size(); j++){
+                    if(mPdoEntryList[j].mPdoIndex == pdoIndex){
+                        entries[entryIdx] = {mPdoEntryList[j].mIndex, mPdoEntryList[j].mSubIndex, mPdoEntryList[j].mBitLength};
+                        entryIdx++;
+                    }                 
+                }
+                rxPdoes[pdoIdx] = {mPdoList[i].mIndex, pdoEntrySize, entries};
+                pdoIdx++;
+            }     
+        }
+        syncInfos[0].n_pdos = rxPdoSize; 
+        syncInfos[0].pdos = rxPdoes;
+    }
+
+    // Build TxPDO (INPUT direction - from device to controller)
+    if(txPdoSize > 0){
+        ec_pdo_info_t* txPdoes = new ec_pdo_info_t[txPdoSize];
+        int pdoIdx = 0;  // Use separate index for PDO array
+        for(int i = 0; i < mPdoList.size(); i++){
+            if(mPdoList[i].mSyncDir == SyncDir::In){
+                uint16_t pdoIndex = mPdoList[i].mIndex;
+                unsigned int pdoEntrySize = 0;
+                getPdoEntrySize(pdoIndex, pdoEntrySize);
+                
+                ec_pdo_entry_info_t* entries = new ec_pdo_entry_info_t[pdoEntrySize];
+                int entryIdx = 0;
+                for(int j = 0; j < mPdoEntryList.size(); j++){
+                    if(mPdoEntryList[j].mPdoIndex == pdoIndex){
+                        entries[entryIdx] = {mPdoEntryList[j].mIndex, mPdoEntryList[j].mSubIndex, mPdoEntryList[j].mBitLength};
+                        entryIdx++;
+                    }                 
+                }
+                txPdoes[pdoIdx] = {mPdoList[i].mIndex, pdoEntrySize, entries};
+                pdoIdx++;
+            }
+        }
+        syncInfos[1].n_pdos = txPdoSize;
+        syncInfos[1].pdos = txPdoes;
+    }
+
+    // Cache the pointer for later cleanup
+    cachedSyncs = syncInfos;
+    return syncInfos;
+  }
+  
+}

--- a/modules/ethercat/device/model/ec_model.h
+++ b/modules/ethercat/device/model/ec_model.h
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "ecrt.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  typedef enum {In, Out} SyncDir;
+
+  struct PdoEntry {
+    uint16_t mPdoIndex;
+    uint16_t mIndex;
+    uint8_t mSubIndex;
+    uint8_t mBitLength;
+
+    PdoEntry() = default;
+    PdoEntry(uint16_t paPdoIndex, uint16_t paIndex, uint8_t paSubIndex, uint8_t paBitLength);
+  };
+
+  struct Pdo {
+    uint16_t mIndex;
+    SyncDir mSyncDir;
+
+    Pdo() = default;
+    Pdo(uint16_t paIndex, SyncDir paDir);
+  };
+
+  struct Sync {
+    uint8_t mIndex;
+    SyncDir mSyncDir;
+
+    Sync() = default;
+    Sync(uint8_t paIndex, SyncDir paDir);
+  };
+
+  struct EntryReg {
+    uint16_t mAlias;
+    uint16_t mPosition;
+    uint32_t mVendorId;
+    uint32_t mProductCode;
+    uint16_t mIndex;
+    uint8_t mSubIndex;
+    unsigned int* mOffset;
+    unsigned int mDomainOffset;
+    bool mOffsetValid;
+
+    EntryReg() : mOffset(nullptr), mDomainOffset(0), mOffsetValid(false) {}
+    EntryReg(uint16_t paAlias, uint16_t paPosition, uint32_t paVendorId, uint32_t paProductCode, uint16_t paIndex, uint8_t paSubIndex, unsigned int *paOffset);
+  };
+
+  struct ECDeviceModel {
+    uint16_t mAlias;
+    uint16_t mPosition;
+    uint32_t mVendorId;
+    uint32_t mProductCode;
+
+    uint32_t mSlotIndexInc;
+    uint32_t mSlotPdoInc;
+
+    std::vector<Sync> mSyncList;
+    std::vector<Pdo> mPdoList;
+    std::vector<PdoEntry> mPdoEntryList;
+    std::vector<EntryReg> mEntryRegList;
+
+    ECDeviceModel() = default;
+    ECDeviceModel(uint16_t paAlias, uint16_t paPosition, uint32_t paVendorId, uint32_t paProductCode, uint32_t paSlotIndexInc, uint32_t paSlotPdoInc);
+    ~ECDeviceModel();
+
+    void addSync(uint8_t paSyncIndex, SyncDir paDir);
+    void addPdo(uint16_t paPdoIndex,  SyncDir paDir);
+    void addPdoEntry(uint16_t paPdoIndex, uint16_t paEntryIndex, uint8_t paSubIndex, uint8_t paBitLength);
+    void addEntryReg(uint16_t paIndex, uint8_t paSubIndex, unsigned int *paOffset);
+    EntryReg *findEntryReg(uint16_t paIndex, uint8_t paSubIndex);
+    void restoreHandleDomainOffset(uint16_t paIndex, uint8_t paSubIndex, unsigned int *paHandleOffsetPtr);
+
+    ec_sync_info_t *getSyncs();
+    ec_pdo_entry_reg_t *getDomainRegs();
+
+    void cleanupSync();
+    void cleanupDomainReg();
+
+    void getPdoSize(unsigned int &paRxPdoSize, unsigned int &paTxPdoSize);
+    void getPdoEntrySize(uint16_t paPdoIndex, unsigned int &paPdoEntrySize);
+
+  private:
+    ec_sync_info_t *cachedSyncs = nullptr;
+    unsigned int cachedRxPdoSize = 0;
+    unsigned int cachedTxPdoSize = 0;
+
+    ec_pdo_entry_reg_t *cachedDomainRegs = nullptr;
+  };
+}

--- a/modules/ethercat/handler/bus.cpp
+++ b/modules/ethercat/handler/bus.cpp
@@ -1,0 +1,360 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+// #include <sched.h>
+#include <sys/mman.h>
+#include "forte/timerha.h"
+#include "forte/io/mapper/io_mapper.h"
+#include "bus.h"
+#include "../device/ec_device.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  namespace {
+    const char *const scmECControllerRequestFailed = "Request controller failed.";
+    const char *const scmECCreateDomainFailed = "Controller create domain failed.";
+    const char *const scmECConfigDeviceFailed = "Controller config device failed.";
+    const char *const scmECConfigDevicePdoFailed = "Controller config device PDOs failed.";
+    const char *const scmECRegisterPdoEntryFailed = "Controller register PDO entries failed.";
+    const char *const scmECControllerActivateFailed = "Controller activate failed.";
+    const char *const scmECGetDomainProcessDataFailed = "Controller get domain process data failed.";
+
+  }
+
+  ECBusHandler::ECBusHandler(CDeviceExecution &paDeviceExecution) :
+    IODeviceMultiController(paDeviceExecution),
+    mECController(nullptr),
+    mECDomain(nullptr),
+    mECDomainPd(nullptr),
+    mInitializedFlag(false),
+    mLoopPreparedFlag(false),
+    mEnableFlag(false),
+    mIsShuttingDown(false){
+  }
+
+  void ECBusHandler::setConfig(struct IODeviceController::Config *paConfig) {
+    if(isAlive()) {
+      DEVLOG_ERROR("ethercat[BusHandler]: Cannot change configuration while running.\n");
+      return;
+    }
+
+    this->mConfig = *static_cast<Config *>(paConfig);
+  }
+
+  void ECBusHandler::addDevice(ECBusDeviceHandler *device) {
+    if(device != 0) {
+      mDevices.push_back(device);
+    }
+  }
+
+  ECBusDeviceHandler* ECBusHandler::getDevice(size_t paDeviceIndex) {
+    for(ECBusDeviceHandler *handler : mDevices) {
+      if(handler == nullptr) {
+        continue;
+      }
+      if(handler->mDeviceIndex == paDeviceIndex) {
+        return handler;
+      }
+    }
+    return nullptr;
+  }
+
+  void ECBusHandler::addSlaveHandle(size_t paDeviceIndex, std::unique_ptr<forte::io::IOHandle> paHandle) {
+    ECBusDeviceHandler *device = getDevice(paDeviceIndex);
+    if(device == nullptr) {
+      return;
+    }
+
+    device->addHandle(static_cast<ECDeviceHandle *>(paHandle.release()));
+  }
+
+  void ECBusHandler::dropSlaveHandles(size_t paDeviceIndex) {
+    ECBusDeviceHandler *device = getDevice(paDeviceIndex);
+    if(device == nullptr) {
+      return;
+    }
+
+    device->dropHandles();
+  }
+
+  ECDeviceHandler *ECBusHandler::getParentDevice(ECBusDeviceHandler *paDevice) {
+    if(paDevice == nullptr) {
+      return nullptr;
+    }
+    if(paDevice->mDeviceType == ECBusDeviceHandler::DeviceType::ECModule) {
+      return static_cast<ECDeviceHandler *>(getDevice(paDevice->mDeviceIndex / 100 - 1));
+    }
+    return static_cast<ECDeviceHandler *>(paDevice);
+  }
+
+  bool ECBusHandler::isSlaveAvailable(size_t paDeviceIndex) {
+    return getDevice(paDeviceIndex) != nullptr;
+  }
+
+  bool ECBusHandler::checkSlaveType(size_t paDeviceIndex, int paDeviceType) {
+    ECBusDeviceHandler *device = getDevice(paDeviceIndex);
+    if(device == nullptr) {
+      return false;
+    }
+
+    return device->mDeviceType == paDeviceType;
+  }
+
+  const char *ECBusHandler::init() {
+    mInitializedFlag = false;
+
+    mECController = ecrt_request_master(mConfig.mECControllerId);
+    if(mECController == nullptr) {
+      DEVLOG_ERROR("ethercat[BusHandler]: %s(Controller ID: %u).\n", scmECControllerRequestFailed, mConfig.mECControllerId);
+      return scmECControllerRequestFailed;
+    }
+
+    mECDomain = ecrt_master_create_domain(mECController);
+    if(mECDomain == nullptr) {
+      DEVLOG_ERROR("ethercat[BusHandler]: %s(Controller ID: %u).\n", scmECCreateDomainFailed, mConfig.mECControllerId);
+      return scmECCreateDomainFailed;
+    }
+
+    mInitializedFlag = true;
+
+    return 0;
+  }
+
+  void ECBusHandler::deInit() {
+    if (mIsShuttingDown) {
+      return;
+    }
+    mIsShuttingDown = true;
+    DEVLOG_INFO("ECBusHandler deInit!\n");
+    if(mDevices.empty() && mECController == nullptr) {
+      return;
+    }
+
+    if(mECController != nullptr) {
+      ecrt_release_master(mECController);
+      mECController = nullptr;
+    }
+
+    mECDomain = nullptr;
+    mECDomainPd = nullptr;
+
+    for(ECBusDeviceHandler *it : mDevices) {
+      delete it;
+    }
+
+    mDevices.clear();
+  }
+
+  forte::io::IOHandle *ECBusHandler::createIOHandle(IODeviceController::HandleDescriptor &paHandleDescriptor) {
+    HandleDescriptor &desc = static_cast<HandleDescriptor &>(paHandleDescriptor);
+    ECBusDeviceHandler *device = getDevice(desc.mSlaveIndex);
+    // Remove stale mapper entry left by prior session before creating a new handle with same ID.
+    forte::io::IOMapper::getInstance().deregisterHandle(desc.mId);
+    if(device == nullptr) {
+      return nullptr;
+    }
+
+    switch (desc.mByteLength){
+      case 1:
+        return new ECDeviceHandle(this, desc.mDirection, CIEC_ANY::EDataTypeID::e_BYTE, desc.mOffset, desc.mId, *device);
+      case 2:
+        return new ECDeviceHandle(this, desc.mDirection, CIEC_ANY::EDataTypeID::e_WORD, desc.mOffset, desc.mId, *device);
+      case 4:
+        return new ECDeviceHandle(this, desc.mDirection, CIEC_ANY::EDataTypeID::e_DWORD, desc.mOffset, desc.mId, *device);
+      case 8:
+        return new ECDeviceHandle(this, desc.mDirection, CIEC_ANY::EDataTypeID::e_LWORD, desc.mOffset, desc.mId, *device);
+      default:
+        DEVLOG_ERROR("ethercat[BusHandler]: Unsupported handle byte length %u at device %zu offset %u.\n",
+                     static_cast<unsigned int>(desc.mByteLength),
+                     desc.mSlaveIndex,
+                     static_cast<unsigned int>(desc.mOffset));
+        break;
+    }
+
+    return nullptr;
+  }
+
+  void ECBusHandler::prepareLoop() {
+    mLoopPreparedFlag = false;
+
+    for(size_t i = 0; i < mDevices.size(); ++i) {
+      ECBusDeviceHandler *handler = mDevices[i];
+      if(handler->mDeviceType == ECBusDeviceHandler::DeviceType::ECModule) {
+        continue;
+      }
+
+      ECDeviceHandler *deviceHandler = static_cast<ECDeviceHandler *>(handler);
+      ECDeviceModel &deviceModel = deviceHandler->mECDeviceModel;
+
+      ec_slave_config_t *sc = ecrt_master_slave_config(
+        mECController,
+        deviceModel.mAlias,
+        deviceModel.mPosition,
+        deviceModel.mVendorId,
+        deviceModel.mProductCode);
+      
+      if(sc == nullptr) {
+        DEVLOG_ERROR("ethercat[BusHandler]: %s(Controller ID: %u),Device position:%u.\n",
+          scmECConfigDeviceFailed,
+          mConfig.mECControllerId,
+          deviceModel.mPosition);
+        return;
+      }
+
+      if(deviceModel.mSyncList.size() > 0) {
+        ec_sync_info_t *syncInfo = deviceModel.getSyncs();
+        if(ecrt_slave_config_pdos(sc, EC_END, syncInfo)) {
+          DEVLOG_ERROR("ethercat[BusHandler]: %s(Controller ID: %u),Device position:%u.\n"
+                       ,scmECConfigDevicePdoFailed
+                       ,mConfig.mECControllerId
+                       ,deviceModel.mPosition);
+          return;
+        }
+      }
+
+      if(deviceModel.mEntryRegList.size() > 0) {
+        ec_pdo_entry_reg_t *reg = deviceModel.getDomainRegs();
+        if(ecrt_domain_reg_pdo_entry_list(mECDomain, reg)) {
+          DEVLOG_ERROR("ethercat[BusHandler]: %s(Controller ID: %u),Device position:%u.\n"
+                       ,scmECRegisterPdoEntryFailed
+                       ,mConfig.mECControllerId
+                       ,deviceModel.mPosition);
+          return;
+        } else {
+          DEVLOG_INFO("ethercat[BusHandler]: PDO entries registered. Offsets:\n");
+          for(size_t j = 0; j < deviceModel.mEntryRegList.size(); j++) {
+            if(deviceModel.mEntryRegList[j].mOffset) {
+              DEVLOG_INFO("ethercat[BusHandler]: [%zu] 0x%04X:%u → offset=%u\n"
+                          ,j
+                          ,deviceModel.mEntryRegList[j].mIndex
+                          ,deviceModel.mEntryRegList[j].mSubIndex
+                          ,*deviceModel.mEntryRegList[j].mOffset);
+            }
+          }
+        }
+      }
+
+      DEVLOG_INFO("ethercat[BusHandler]: Configured device - Alias: %u, Position: %u, VendorId: 0x%08X, ProductCode: 0x%08X\n"
+                  ,deviceModel.mAlias, deviceModel.mPosition, deviceModel.mVendorId, deviceModel.mProductCode);
+      
+      const int activateRet = ecrt_master_activate(mECController);
+      if(activateRet) {
+        DEVLOG_ERROR("ethercat[BusHandler]: %s(Controller ID: %u).\n", scmECControllerActivateFailed, mConfig.mECControllerId);
+        return;
+      }
+
+      mECDomainPd = ecrt_domain_data(mECDomain);
+      if(mECDomainPd == nullptr) {
+        DEVLOG_ERROR("ethercat[BusHandler]: %s(Controller ID: %u).\n", scmECGetDomainProcessDataFailed, mConfig.mECControllerId);
+        return;
+      }
+
+      ec_master_state_t ms;
+      ecrt_master_state(mECController, &ms);
+      DEVLOG_INFO("ethercat[BusHandler]: Initial state - Devices responding: %u, AL States: 0x%02x\n", ms.slaves_responding, ms.al_states);
+
+      size_t domainSize = ecrt_domain_size(mECDomain);
+      DEVLOG_INFO("ethercat[BusHandler]: Domain size: %zu bytes\n", domainSize);
+
+      DEVLOG_INFO("ethercat[BusHandler]: Controller activated successfully.\n");
+
+      mLoopPreparedFlag = true;
+    }
+  }
+
+  void ECBusHandler::runLoop() {
+    if(!mInitializedFlag){
+      return;
+    }
+
+    while(isAlive()) {
+      // Wait until Controller FB enabled.
+      while(!mEnableFlag && isAlive()) {
+        sleepThread(10);
+      }
+
+      if(!mLoopPreparedFlag) {
+        DEVLOG_INFO("ethercat[BusHandler]: All devices initialized. prepareLoop...\n");
+        prepareLoop();
+        // Check if prepareLoop executed successfully.
+        if(!mLoopPreparedFlag) {
+          DEVLOG_INFO("ethercat[BusHandler]: PrepareLoop failed.\n");
+          return;
+        }
+
+        //If executed here, then prepareLoop executed successfully.
+        clock_gettime(CLOCK_MONOTONIC, &mWakeupTime);
+        mWakeupTime.tv_nsec += static_cast<long>(mConfig.mUpdateInterval) * PERIOD_NS; // µs → ns (PERIOD_NS = 1000)
+        while(mWakeupTime.tv_nsec >= NSEC_PER_SEC) {
+          mWakeupTime.tv_nsec -= NSEC_PER_SEC;
+          mWakeupTime.tv_sec++;
+        }
+        DEVLOG_INFO("ethercat[BusHandler]: PrepareLoop completed, starting cyclic communication...\n");
+      }
+
+      int ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &mWakeupTime, NULL);
+      if(ret) {
+        mError = "ethercat[BusHandler]: clock_nanosleep() failed";
+        DEVLOG_ERROR("%s: %s.\n", mError,strerror(ret));
+        break;
+      }
+
+      // Check if cycle is still enabled before executing
+      if(!mEnableFlag) {
+        // Update wakeup time even when paused to avoid time drif
+        mWakeupTime.tv_nsec += static_cast<long>(mConfig.mUpdateInterval) * PERIOD_NS;
+        while(mWakeupTime.tv_nsec >= NSEC_PER_SEC) {
+          mWakeupTime.tv_nsec -= NSEC_PER_SEC;
+          mWakeupTime.tv_sec++;
+        }
+        continue;
+      }
+
+      ecrt_master_receive(mECController);
+      ecrt_domain_process(mECDomain);
+
+      for(ECBusDeviceHandler *handler : mDevices) {
+        // Update the device with domain data.
+        handler->update(mECDomainPd);
+      }
+
+      // Queue domain data for sending.
+      ecrt_domain_queue(mECDomain);
+      // Send process data to devices.
+      ecrt_master_send(mECController);
+
+      // Calculate next wakeup time (same cycle as mUpdateInterval µs).
+      mWakeupTime.tv_nsec += static_cast<long>(mConfig.mUpdateInterval) * PERIOD_NS;
+      while(mWakeupTime.tv_nsec >= NSEC_PER_SEC) {
+        mWakeupTime.tv_nsec -= NSEC_PER_SEC;
+        mWakeupTime.tv_sec++;
+      }
+    }
+
+  }
+
+  void ECBusHandler::enableECCycle(bool paEnableFlag) {
+    mEnableFlag = paEnableFlag;
+
+    if(paEnableFlag && mLoopPreparedFlag) {
+      clock_gettime(CLOCK_MONOTONIC, &mWakeupTime);
+      mWakeupTime.tv_nsec += static_cast<long>(mConfig.mUpdateInterval) * PERIOD_NS;
+      while(mWakeupTime.tv_nsec >= NSEC_PER_SEC) {
+        mWakeupTime.tv_nsec -= NSEC_PER_SEC;
+        mWakeupTime.tv_sec++;
+      }
+      DEVLOG_INFO("[ECBusHandler]: EtherCAT cycle resumed.\n");
+    }
+  }
+
+}

--- a/modules/ethercat/handler/bus.h
+++ b/modules/ethercat/handler/bus.h
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <ecrt.h>
+#include "../device/bus_device_handler.h"
+#include <forte/io/device/io_controller_multi.h>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class ECBusDeviceHandler;
+  class ECDeviceHandler;
+
+  class ECBusHandler : public forte::io::IODeviceMultiController {
+
+    public:
+      explicit ECBusHandler(CDeviceExecution &paDeviceExecution);
+
+      struct Config : IODeviceController::Config {
+        unsigned int mECControllerId;
+        unsigned int mUpdateInterval;
+      };
+
+      class HandleDescriptor : public IODeviceMultiController::HandleDescriptor {
+        public:
+          uint8_t mOffset;
+          uint8_t mByteLength;
+
+          HandleDescriptor(std::string const &paId,
+                           forte::io::IOMapper::Direction paDirection,
+                           size_t paDeviceIndex,
+                           uint8_t paOffset,
+                           uint8_t paByteLength) : 
+              IODeviceMultiController::HandleDescriptor(paId, paDirection, paDeviceIndex),
+              mOffset(paOffset),
+              mByteLength(paByteLength){
+          }
+      };
+
+      void setConfig(struct IODeviceController::Config *paConfig) override;
+
+      void addDevice(ECBusDeviceHandler *device);
+      ECBusDeviceHandler *getDevice(size_t paDeviceIndex);
+
+      void addSlaveHandle(size_t paDeviceIndex, std::unique_ptr<forte::io::IOHandle> paHandle) override;
+      void dropSlaveHandles(size_t paDeviceIndex) override;
+
+      void enableECCycle(bool paEnableFlag);
+      bool isLoopPrepared() const {
+        return mLoopPreparedFlag;
+      }
+      bool isShuttingDown() const {
+        return mIsShuttingDown;
+      }
+
+      ECDeviceHandler *getParentDevice(ECBusDeviceHandler *paDevice);
+
+    protected:
+      const char* init() override;
+      void deInit() override;
+
+      forte::io::IOHandle *createIOHandle(IODeviceController::HandleDescriptor &paHandleDescriptor) override;
+
+      void prepareLoop();
+      void runLoop() override;
+
+      // Config
+      struct  Config mConfig;
+      
+      // Devices
+      std::vector<ECBusDeviceHandler *> mDevices;
+      
+    private:
+      bool isSlaveAvailable(size_t paDeviceIndex) override;
+      bool checkSlaveType(size_t paDeviceIndex, int paDeviceType) override;
+      
+      ec_master_t *mECController;
+      ec_domain_t *mECDomain;
+      uint8_t *mECDomainPd;
+
+      struct timespec mWakeupTime;
+      static const long PERIOD_NS = 1000L;      // 1us in nanoseconds
+      static const long NSEC_PER_SEC = 1000000000L;
+
+      bool mInitializedFlag;
+      bool mLoopPreparedFlag;
+      bool mEnableFlag;
+      bool mIsShuttingDown;
+  };
+
+}


### PR DESCRIPTION
## Summary

First of three PRs split from #967 per maintainer feedback.

- Add `FORTE_MODULE_ETHERCAT` CMake option for Linux
- Add IgH EtherCAT Master userspace integration (bus handler, device layer)
- Update `dependencies.spdx` with IgH ethercat library entry for CQ process

**Review feedback addressed (force-pushed):**
- Renamed runtime layer from `slave/` to `device/` with controller/device terminology
- `ECBusDeviceHandler` / `ECDeviceHandle` replace former slave handler/handle names
- Process images use `std::vector<unsigned char>` (RAII) instead of manual `new[]`/`delete[]`
- Handle buffer views use `std::span<unsigned char>`
- `mUpdateMutex` and `mDevice` bound by reference in `ECDeviceHandle`

IgH API names (`ecrt_master_*`, `ecrt_slave_*`) and FORTE core IO base classes remain unchanged.

## Related PRs

- Closes #967 (superseded by this split series)
- eclipse-4diac/4diac-fbe#72 (build dependency recipes)
- eclipse-4diac/4diac-ide#2581 (ESI import, planned for PR 3)

## Planned follow-up PRs

2. IO function blocks (ECController, ECDevice, ECModule, ECCoupler)
3. ESI parsing and generic FB support

## Test plan

- [x] Build forte with `FORTE_MODULE_ETHERCAT=ON` on Linux (core-only module)
- [ ] Verify module links against IgH libethercat
- [ ] Confirm `dependencies.spdx` entry is sufficient for CQ