### PR TITLE
bugfix of timers

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/timers/E_PULSE_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_PULSE_fbt.h
@@ -1,33 +1,32 @@
 /*************************************************************************
- *** Copyright (c) 2023, 2024 HR Agrartechnik GmbH
+ *** Copyright (c) 2023 HR Agrartechnik GmbH
  *** This program and the accompanying materials are made available under the
  *** terms of the Eclipse Public License 2.0 which is available at
  *** http://www.eclipse.org/legal/epl-2.0.
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.2.0.202606092002!
  ***
  *** Name: E_PULSE
  *** Description: standard timer function block (pulse)
  *** Version:
- ***     1.0: 2023-08-21/Franz Hoepfinger - HR Agrartechnik GmbH - initial implementation as E_IMPULSE
- ***     1.0: 2024-03-05/Franz Hoepfinger - HR Agrartechnik GmbH - renamed to E_PULSE
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0.1: 2024-03-05/Franz Höpfinger - HR Agrartechnik GmbH - renamed to E_PULSE
+ ***     1.0: 2023-08-21/Franz Höpfinger - HR Agrartechnik GmbH - initial implementation as E_IMPULSE
  *************************************************************************/
 
 #pragma once
 
 #include "forte/cfb.h"
 #include "forte/typelib.h"
-#include "forte/datatypes/forte_time.h"
 #include "forte/datatypes/forte_bool.h"
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/datatypes/forte_time.h"
+#include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
 #include "forte/iec61499/events/E_SR_fbt.h"
 
@@ -36,9 +35,9 @@ namespace forte::iec61499::events::timers {
       DECLARE_FIRMWARE_FB(FORTE_E_PULSE)
 
     private:
+      static const TEventID scmEventCNFID = 0;
       static const TEventID scmEventREQID = 0;
       static const TEventID scmEventRID = 1;
-      static const TEventID scmEventCNFID = 0;
 
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
       CInternalFB<forte::iec61499::events::FORTE_E_SR> fb_E_SR;
@@ -46,7 +45,6 @@ namespace forte::iec61499::events::timers {
       void readInputData(TEventID paEIID) override;
       void writeOutputData(TEventID paEIID) override;
       void setInitialValues() override;
-      CDataConnection *getIf2InConUnchecked(TPortId paDIID) override;
 
     public:
       FORTE_E_PULSE(StringId paInstanceNameId, CFBContainer &paContainer);
@@ -64,5 +62,6 @@ namespace forte::iec61499::events::timers {
       CEventConnection *getEOConUnchecked(TPortId) override;
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
+      CDataConnection *getIf2InConUnchecked(TPortId) override;
   };
 } // namespace forte::iec61499::events::timers

--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TOF_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TOF_fbt.h
@@ -8,11 +8,12 @@
  ***
  *** FORTE Library Element
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter 3.1.100.202604172003!
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.2.0.202606092002!
  ***
  *** Name: E_TOF
  *** Description: standard timer function block (off-delay timing)
  *** Version:
+ ***     3.2: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
@@ -28,7 +29,7 @@
 #include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
 #include "forte/iec61499/events/E_RF_TRIG_fbt.h"
-#include "forte/iec61499/events/E_RS_fbt.h"
+#include "forte/iec61499/events/E_SR_fbt.h"
 
 namespace forte::iec61499::events::timers {
   class FORTE_E_TOF final : public CCompositeFB {
@@ -41,7 +42,7 @@ namespace forte::iec61499::events::timers {
 
       CInternalFB<forte::iec61499::events::FORTE_E_RF_TRIG> fb_E_RF_TRIG;
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY;
-      CInternalFB<forte::iec61499::events::FORTE_E_RS> fb_E_RS;
+      CInternalFB<forte::iec61499::events::FORTE_E_SR> fb_E_SR;
 
       void readInputData(TEventID paEIID) override;
       void writeOutputData(TEventID paEIID) override;

--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TONOF_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TONOF_fbt.h
@@ -13,6 +13,7 @@
  *** Name: E_TONOF
  *** Description: standard timer function block (on/off-delay timing)
  *** Version:
+ ***     3.2: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
@@ -28,7 +29,7 @@
 #include "forte/forte_st_util.h"
 #include "forte/iec61499/events/E_DELAY_fbt.h"
 #include "forte/iec61499/events/E_RF_TRIG_fbt.h"
-#include "forte/iec61499/events/E_RS_fbt.h"
+#include "forte/iec61499/events/E_SR_fbt.h"
 
 namespace forte::iec61499::events::timers {
   class FORTE_E_TONOF final : public CCompositeFB {
@@ -41,7 +42,7 @@ namespace forte::iec61499::events::timers {
 
       CInternalFB<forte::iec61499::events::FORTE_E_RF_TRIG> fb_E_RF_TRIG;
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY_ON;
-      CInternalFB<forte::iec61499::events::FORTE_E_RS> fb_E_RS;
+      CInternalFB<forte::iec61499::events::FORTE_E_SR> fb_E_SR;
       CInternalFB<forte::iec61499::events::FORTE_E_DELAY> fb_E_DELAY_OFF;
 
       void readInputData(TEventID paEIID) override;

--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TON_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TON_fbt.h
@@ -13,6 +13,7 @@
  *** Name: E_TON
  *** Description: standard timer function block (on-delay timing)
  *** Version:
+ ***     3.2: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -

--- a/stdfblib/events/include/forte/iec61499/events/timers/E_TP_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/timers/E_TP_fbt.h
@@ -13,6 +13,7 @@
  *** Name: E_TP
  *** Description: standard timer function block (pulse)
  *** Version:
+ ***     3.2: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.1: 2026-05-13/Franz Höpfinger - HR Agrartechnik GmbH - E_R_TRIG instead of E_PERMIT
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs

--- a/stdfblib/events/src/timers/E_PULSE_fbt.cpp
+++ b/stdfblib/events/src/timers/E_PULSE_fbt.cpp
@@ -1,47 +1,46 @@
 /*************************************************************************
- *** Copyright (c) 2023, 2024 HR Agrartechnik GmbH
+ *** Copyright (c) 2023 HR Agrartechnik GmbH
  *** This program and the accompanying materials are made available under the
  *** terms of the Eclipse Public License 2.0 which is available at
  *** http://www.eclipse.org/legal/epl-2.0.
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.2.0.202606092002!
  ***
  *** Name: E_PULSE
  *** Description: standard timer function block (pulse)
  *** Version:
- ***     1.0: 2023-08-21/Franz Hoepfinger - HR Agrartechnik GmbH - initial implementation as E_IMPULSE
- ***     1.0: 2024-03-05/Franz Hoepfinger - HR Agrartechnik GmbH - renamed to E_PULSE
- ***     1.1: 2024-04-23/Franz Hoepfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     3.1: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
+ ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
+ ***     1.0.1: 2024-03-05/Franz Höpfinger - HR Agrartechnik GmbH - renamed to E_PULSE
+ ***     1.0: 2023-08-21/Franz Höpfinger - HR Agrartechnik GmbH - initial implementation as E_IMPULSE
  *************************************************************************/
 
 #include "forte/iec61499/events/timers/E_PULSE_fbt.h"
 
-#include "forte/iec61131_functions.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
+#include "forte/forte_st_util.h"
 
 using namespace std::literals;
 using namespace forte::literals;
 
 namespace forte::iec61499::events::timers {
   namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
+    const auto cEventOutputNames = std::array{"CNF"_STRID};
     const auto cDataInputNames = std::array{"PT"_STRID};
     const auto cDataOutputNames = std::array{"Q"_STRID};
-    const auto cEventInputNames = std::array{"REQ"_STRID, "R"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
 
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
-        .mEITypeNames = cEventInputTypeIds,
+        .mEITypeNames = {},
         .mEONames = cEventOutputNames,
-        .mEOTypeNames = cEventOutputTypeIds,
+        .mEOTypeNames = {},
         .mDINames = cDataInputNames,
         .mDONames = cDataOutputNames,
         .mDIONames = {},
@@ -70,7 +69,7 @@ namespace forte::iec61499::events::timers {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_E_PULSE, "iec61499::events::timers::E_PULSE"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_E_PULSE, "iec61499::events::timers::E_PULSE"_STRID, TypeHash)
 
   FORTE_E_PULSE::FORTE_E_PULSE(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
@@ -100,7 +99,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_PULSE::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, fb_E_SR->conn_Q.getValue(), conn_Q);
+        writeData(1, fb_E_SR->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -142,7 +141,7 @@ namespace forte::iec61499::events::timers {
     return nullptr;
   }
 
-  CDataConnection *FORTE_E_PULSE::getIf2InConUnchecked(TPortId paIndex) {
+  CDataConnection *FORTE_E_PULSE::getIf2InConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
       case 0: return &conn_if2in_PT;
     }

--- a/stdfblib/events/src/timers/E_TOF_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TOF_fbt.cpp
@@ -13,6 +13,7 @@
  *** Name: E_TOF
  *** Description: standard timer function block (off-delay timing)
  *** Version:
+ ***     3.2: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
@@ -49,19 +50,19 @@ namespace forte::iec61499::events::timers {
 
     const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
         {{}, "REQ"_STRID, "E_RF_TRIG"_STRID, "EI"_STRID},
-        {"E_RS"_STRID, "EO"_STRID, {}, "CNF"_STRID},
-        {"E_DELAY"_STRID, "EO"_STRID, "E_RS"_STRID, "R"_STRID},
-        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_RS"_STRID, "S"_STRID},
-        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY"_STRID, "START"_STRID},
-        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
-        {{}, "R"_STRID, "E_RS"_STRID, "R"_STRID},
+        {"E_SR"_STRID, "EO"_STRID, {}, "CNF"_STRID},
+        {"E_DELAY"_STRID, "EO"_STRID, "E_SR"_STRID, "R"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_SR"_STRID, "S"_STRID},
+        {{}, "R"_STRID, "E_SR"_STRID, "R"_STRID},
         {{}, "R"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY"_STRID, "START"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY"_STRID, "STOP"_STRID},
     });
 
     const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
         {{}, "IN"_STRID, "E_RF_TRIG"_STRID, "QI"_STRID},
         {{}, "PT"_STRID, "E_DELAY"_STRID, "DT"_STRID},
-        {"E_RS"_STRID, "Q"_STRID, {}, "Q"_STRID},
+        {"E_SR"_STRID, "Q"_STRID, {}, "Q"_STRID},
     });
 
     const SCFB_FBNData cFBNData = {
@@ -77,7 +78,7 @@ namespace forte::iec61499::events::timers {
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
       fb_E_RF_TRIG("E_RF_TRIG"_STRID, *this),
       fb_E_DELAY("E_DELAY"_STRID, *this),
-      fb_E_RS("E_RS"_STRID, *this),
+      fb_E_SR("E_SR"_STRID, *this),
       conn_CNF(*this, 0),
       conn_IN(nullptr),
       conn_PT(nullptr),
@@ -89,7 +90,7 @@ namespace forte::iec61499::events::timers {
     CCompositeFB::setInitialValues();
     conn_if2in_IN.getValue() = 0_BOOL;
     conn_if2in_PT.getValue() = 0_TIME;
-    fb_E_RS->conn_Q.getValue() = 0_BOOL;
+    fb_E_SR->conn_Q.getValue() = 0_BOOL;
   }
 
   void FORTE_E_TOF::readInputData(const TEventID paEIID) {
@@ -106,7 +107,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_TOF::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(2, fb_E_RS->conn_Q.getValue(), conn_Q);
+        writeData(2, fb_E_SR->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -123,7 +124,7 @@ namespace forte::iec61499::events::timers {
 
   CIEC_ANY *FORTE_E_TOF::getDO(const size_t paIndex) {
     switch (paIndex) {
-      case 0: return &fb_E_RS->conn_Q.getValue();
+      case 0: return &fb_E_SR->conn_Q.getValue();
     }
     return nullptr;
   }

--- a/stdfblib/events/src/timers/E_TONOF_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TONOF_fbt.cpp
@@ -13,6 +13,7 @@
  *** Name: E_TONOF
  *** Description: standard timer function block (on/off-delay timing)
  *** Version:
+ ***     3.2: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
@@ -49,21 +50,22 @@ namespace forte::iec61499::events::timers {
 
     const auto cEventConnections = std::to_array<SCFB_FBConnectionData>({
         {{}, "REQ"_STRID, "E_RF_TRIG"_STRID, "EI"_STRID},
-        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY_ON"_STRID, "START"_STRID},
-        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY_ON"_STRID, "STOP"_STRID},
-        {"E_DELAY_ON"_STRID, "EO"_STRID, "E_RS"_STRID, "S"_STRID},
-        {"E_RS"_STRID, "EO"_STRID, {}, "CNF"_STRID},
-        {"E_DELAY_OFF"_STRID, "EO"_STRID, "E_RS"_STRID, "R"_STRID},
-        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY_OFF"_STRID, "START"_STRID},
-        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY_OFF"_STRID, "STOP"_STRID},
-        {{}, "R"_STRID, "E_RS"_STRID, "R"_STRID},
+        {"E_DELAY_ON"_STRID, "EO"_STRID, "E_SR"_STRID, "S"_STRID},
+        {"E_SR"_STRID, "EO"_STRID, {}, "CNF"_STRID},
+        {"E_DELAY_OFF"_STRID, "EO"_STRID, "E_SR"_STRID, "R"_STRID},
+        {{}, "R"_STRID, "E_SR"_STRID, "R"_STRID},
         {{}, "R"_STRID, "E_DELAY_OFF"_STRID, "STOP"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY_ON"_STRID, "START"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY_ON"_STRID, "STOP"_STRID},
+        {"E_RF_TRIG"_STRID, "ER"_STRID, "E_DELAY_OFF"_STRID, "STOP"_STRID},
+        {"E_RF_TRIG"_STRID, "EF"_STRID, "E_DELAY_OFF"_STRID, "START"_STRID},
+        {{}, "R"_STRID, "E_DELAY_ON"_STRID, "STOP"_STRID},
     });
 
     const auto cDataConnections = std::to_array<SCFB_FBConnectionData>({
         {{}, "IN"_STRID, "E_RF_TRIG"_STRID, "QI"_STRID},
         {{}, "PT_ON"_STRID, "E_DELAY_ON"_STRID, "DT"_STRID},
-        {"E_RS"_STRID, "Q"_STRID, {}, "Q"_STRID},
+        {"E_SR"_STRID, "Q"_STRID, {}, "Q"_STRID},
         {{}, "PT_OFF"_STRID, "E_DELAY_OFF"_STRID, "DT"_STRID},
     });
 
@@ -80,7 +82,7 @@ namespace forte::iec61499::events::timers {
       CCompositeFB(paContainer, cFBInterfaceSpec, paInstanceNameId, cFBNData),
       fb_E_RF_TRIG("E_RF_TRIG"_STRID, *this),
       fb_E_DELAY_ON("E_DELAY_ON"_STRID, *this),
-      fb_E_RS("E_RS"_STRID, *this),
+      fb_E_SR("E_SR"_STRID, *this),
       fb_E_DELAY_OFF("E_DELAY_OFF"_STRID, *this),
       conn_CNF(*this, 0),
       conn_IN(nullptr),
@@ -96,7 +98,7 @@ namespace forte::iec61499::events::timers {
     conn_if2in_IN.getValue() = 0_BOOL;
     conn_if2in_PT_ON.getValue() = 0_TIME;
     conn_if2in_PT_OFF.getValue() = 0_TIME;
-    fb_E_RS->conn_Q.getValue() = 0_BOOL;
+    fb_E_SR->conn_Q.getValue() = 0_BOOL;
   }
 
   void FORTE_E_TONOF::readInputData(const TEventID paEIID) {
@@ -114,7 +116,7 @@ namespace forte::iec61499::events::timers {
   void FORTE_E_TONOF::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
       case scmEventCNFID: {
-        writeData(3, fb_E_RS->conn_Q.getValue(), conn_Q);
+        writeData(3, fb_E_SR->conn_Q.getValue(), conn_Q);
         break;
       }
       default: break;
@@ -132,7 +134,7 @@ namespace forte::iec61499::events::timers {
 
   CIEC_ANY *FORTE_E_TONOF::getDO(const size_t paIndex) {
     switch (paIndex) {
-      case 0: return &fb_E_RS->conn_Q.getValue();
+      case 0: return &fb_E_SR->conn_Q.getValue();
     }
     return nullptr;
   }

--- a/stdfblib/events/src/timers/E_TON_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TON_fbt.cpp
@@ -13,6 +13,7 @@
  *** Name: E_TON
  *** Description: standard timer function block (on-delay timing)
  *** Version:
+ ***     3.2: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.1: 2026-05-08/Franz Höpfinger - HR Agrartechnik GmbH - E_RF_TRIG instead of E_SWITCH
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.0: 2024-03-04/Franz Höpfinger - HR Agrartechnik GmbH -

--- a/stdfblib/events/src/timers/E_TP_fbt.cpp
+++ b/stdfblib/events/src/timers/E_TP_fbt.cpp
@@ -13,6 +13,7 @@
  *** Name: E_TP
  *** Description: standard timer function block (pulse)
  *** Version:
+ ***     3.2: 2026-06-22/Franz Höpfinger - HR Agrartechnik GmbH - validate all timers
  ***     3.1: 2026-05-13/Franz Höpfinger - HR Agrartechnik GmbH - E_R_TRIG instead of E_PERMIT
  ***     3.0: 2025-04-14/Patrick Aigner -  - changed package
  ***     1.1: 2024-04-23/Franz Höpfinger - HR Agrartechnik GmbH - Add a Reset to Timer FBs
@@ -96,10 +97,6 @@ namespace forte::iec61499::events::timers {
       case scmEventREQID: {
         readData(0, conn_if2in_IN.getValue(), conn_IN);
         readData(1, conn_if2in_PT.getValue(), conn_PT);
-        break;
-      }
-      case scmEventRID: {
-        readData(0, conn_if2in_IN.getValue(), conn_IN);
         break;
       }
       default: break;


### PR DESCRIPTION
Update standard timer function blocks (E_PULSE, E_TOF, E_TON, E_TONOF, E_TP) to fix a bug which came in accidentially last commit. 

https://github.com/eclipse-4diac/4diac-ide/pull/2625
https://github.com/eclipse-4diac/4diac-forte/pull/978