### PR TITLE
Add EtherCAT IO function blocks (PR 2 of 3)

### DIFF
--- a/core/include/forte/io/configFB/CMakeLists.txt
+++ b/core/include/forte/io/configFB/CMakeLists.txt
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2025 Martin Erich Jobst
+# Copyright (c) 2025 Martin Erich Jobst, Sichuan Qunyuan Technology Co., Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +10,8 @@
 # Contributors:
 #    Martin Erich Jobst
 #      - initial API and implementation and/or initial documentation
+#    Zijun Tang
+#      - add createSlaveHandler() hook and generic FB constructor to io_slave_multi
 #############################################################################
 
 target_sources(forte-core PUBLIC

--- a/core/include/forte/io/configFB/io_slave_multi.h
+++ b/core/include/forte/io/configFB/io_slave_multi.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 - 2018 fortiss GmbH
+ * Copyright (c) 2017 fortiss GmbH, Sichuan Qunyuan Technology Co., Ltd.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +9,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
+ *   Zijun Tang - add createSlaveHandler() hook and generic FB constructor
  *******************************************************************************/
 
 #ifndef SRC_CORE_IO_CONFIGFB_SLAVE_MULTI_H_
@@ -29,6 +30,14 @@ namespace forte::io {
                            CFBContainer &paContainer,
                            const SFBInterfaceSpec &paInterfaceSpec,
                            const StringId paInstanceNameId);
+
+      IOConfigFBMultiSlave(CFBContainer &paContainer,
+                           const SFBInterfaceSpec &paInterfaceSpec,
+                           forte::StringId paInstanceNameId,
+                           const TForteUInt8 *const paSlaveConfigurationIO,
+                           TForteUInt8 paSlaveConfigurationIONum,
+                           int paType);
+
       ~IOConfigFBMultiSlave() override;
 
     protected:
@@ -73,6 +82,10 @@ namespace forte::io {
 
       virtual void initHandles() = 0;
 
+      virtual bool createSlaveHandler() {
+        return true;
+      }
+
       void initHandle(IODeviceController::HandleDescriptor &paHandleDescriptor);
 
       static const CIEC_WSTRING scmOK;
@@ -97,6 +110,7 @@ namespace forte::io {
       static const CIEC_WSTRING scmStopped;
       static const char *const scmNotFound;
       static const char *const scmIncorrectType;
+      static const char *const scmCreateSlaveHandlerFailed;
   };
 
 } // namespace forte::io

--- a/core/src/io/configFB/CMakeLists.txt
+++ b/core/src/io/configFB/CMakeLists.txt
@@ -1,12 +1,13 @@
 # *******************************************************************************
-# Copyright (c) 2017 fortiss GmbH This program and the accompanying materials
+# Copyright (c) 2017 fortiss GmbH, Sichuan Qunyuan Technology Co., Ltd. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0 which
 # is available at http://www.eclipse.org/legal/epl-2.0.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-# Contributors: Johannes Messmer *   - initial API and implementation and/or
+# Contributors: Johannes Messmer - initial API and implementation and/or
 # initial documentation
+#    Zijun Tang - add createSlaveHandler() hook and generic FB constructor to io_slave_multi
 # *******************************************************************************/
 
 # ############################################################################

--- a/core/src/io/configFB/io_slave_multi.cpp
+++ b/core/src/io/configFB/io_slave_multi.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 - 2018 fortiss GmbH
+ * Copyright (c) 2017 fortiss GmbH, Sichuan Qunyuan Technology Co., Ltd.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +9,7 @@
  * Contributors:
  *   Johannes Messmer - initial API and implementation and/or initial documentation
  *   Jose Cabral - Cleaning of namespaces
+ *   Zijun Tang - add createSlaveHandler() hook and generic FB constructor
  *******************************************************************************/
 
 #include "forte/io/configFB/io_slave_multi.h"
@@ -22,6 +23,7 @@ namespace forte::io {
   const char *const IOConfigFBMultiSlave::scmMasterNotFound("Master not found");
   const char *const IOConfigFBMultiSlave::scmNotFound("Module not found");
   const char *const IOConfigFBMultiSlave::scmIncorrectType("Module type is incorrect");
+  const char *const IOConfigFBMultiSlave::scmCreateSlaveHandlerFailed("Create slave handler failed");
 
   IOConfigFBMultiSlave::IOConfigFBMultiSlave(const TForteUInt8 *const paSlaveConfigurationIO,
                                              const TForteUInt8 paSlaveConfigurationIONum,
@@ -40,6 +42,16 @@ namespace forte::io {
     for (int i = 0; i < mSlaveConfigurationIONum; i++) {
       mSlaveConfigurationIOIsDefault[i] = false;
     }
+  }
+
+  IOConfigFBMultiSlave::IOConfigFBMultiSlave(CFBContainer &paContainer,
+                                             const SFBInterfaceSpec &paInterfaceSpec,
+                                             forte::StringId paInstanceNameId,
+                                             const TForteUInt8 *const paSlaveConfigurationIO,
+                                             TForteUInt8 paSlaveConfigurationIONum,
+                                             int paType) :
+      IOConfigFBMultiSlave(
+          paSlaveConfigurationIO, paSlaveConfigurationIONum, paType, paContainer, paInterfaceSpec, paInstanceNameId) {
   }
 
   IOConfigFBMultiSlave::~IOConfigFBMultiSlave() {
@@ -159,6 +171,11 @@ namespace forte::io {
     }
 
     IODeviceMultiController &controller = getController();
+
+    if (!createSlaveHandler()) {
+      DEVLOG_ERROR("[IOConfigFBMultiSlave] Create slave handler failed\n");
+      return scmCreateSlaveHandlerFailed;
+    }
 
     // Check if slave exists
     if (!controller.isSlaveAvailable(mIndex)) {

--- a/modules/ethercat/CMakeLists.txt
+++ b/modules/ethercat/CMakeLists.txt
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
-#   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+#   Zijun Tang - initial API and implementation
 # *******************************************************************************/
 
 if (NOT LINUX)
@@ -22,10 +22,10 @@ if (NOT FORTE_MODULE_ETHERCAT)
 endif ()
 
 # ############################################################################
-# EtherCAT core integration (IgH ecrt, bus handler, device layer)
+# EtherCAT IO function blocks (PR 2 of 3)
 # ############################################################################
 
-add_library(forte-ethercat
+add_library(forte-ethercat         
             handler/bus.h
             handler/bus.cpp
             device/bus_device_handler.h
@@ -34,10 +34,37 @@ add_library(forte-ethercat
             device/handle.cpp
             device/ec_device.h
             device/ec_device.cpp
+            device/ec_module.h
+            device/ec_module.cpp
             device/model/ec_model.h
             device/model/ec_model.cpp
+            utils/esi_catalog.h
+            utils/esi_catalog.cpp
+            utils/esi_io_configurator.h
+            utils/esi_io_configurator.cpp
+            utils/esi_xml_utils.h
+            types/ECBusAdapter.h
+            types/ECBusAdapter.cpp
+            types/ECDevice.h
+            types/ECDevice.cpp
+            types/ECModule.h
+            types/ECModule.cpp
+            types/ECCoupler.h
+            types/ECCoupler.cpp
+            types/GEN_ECCoupler_fbt.h
+            types/GEN_ECCoupler_fbt.cpp
+            types/GEN_ECDevice_fbt.h
+            types/GEN_ECDevice_fbt.cpp
+            types/GEN_ECModule_fbt.h
+            types/GEN_ECModule_fbt.cpp
+            types/ECController.h
+            types/ECController.cpp
+            structs/ECDeviceConfig.h
+            structs/ECDeviceConfig.cpp
+            structs/ECModuleConfig.h
+            structs/ECModuleConfig.cpp
 )
 target_link_libraries(forte-ethercat PUBLIC forte-core)
-target_link_libraries(forte-ethercat PRIVATE ethercat)
+target_link_libraries(forte-ethercat PRIVATE ethercat tinyxml)
 target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-ethercat,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-ethercat>>)
 install(TARGETS forte-ethercat EXPORT forte-export FILE_SET HEADERS)

--- a/modules/ethercat/device/bus_device_handler.cpp
+++ b/modules/ethercat/device/bus_device_handler.cpp
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
 #include "bus_device_handler.h"

--- a/modules/ethercat/device/bus_device_handler.h
+++ b/modules/ethercat/device/bus_device_handler.h
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
 #pragma once

--- a/modules/ethercat/device/ec_module.cpp
+++ b/modules/ethercat/device/ec_module.cpp
@@ -11,22 +11,15 @@
  *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
-#include "ec_device.h"
+#include "ec_module.h"
 
 namespace forte::eclipse4diac::io::ethercat {
-
-  ECDeviceHandler::ECDeviceHandler(ECBusHandler *paBus, 
-                                   ECBusDeviceHandler::DeviceType paDeviceType, 
+  ECModuleHandler::ECModuleHandler(ECBusHandler *paBus, 
                                    size_t paDeviceIndex) : 
-      ECBusDeviceHandler(paBus, paDeviceType, paDeviceIndex) {
+      ECBusDeviceHandler(paBus, DeviceType::ECModule, paDeviceIndex) {
   }
 
-  void ECDeviceHandler::setConfig(struct ECBusDeviceHandler::Config *paConfig) {
+  void ECModuleHandler::setConfig(struct ECBusDeviceHandler::Config *paConfig) {
     mConfig = *static_cast<Config *>(paConfig);
-
-    mECDeviceModel.mAlias = mConfig.mAlias;
-    mECDeviceModel.mPosition = mConfig.mPosition;
-    mECDeviceModel.mVendorId = mConfig.mVendorId;
-    mECDeviceModel.mProductCode = mConfig.mProductCode;
   }
 }

--- a/modules/ethercat/device/ec_module.h
+++ b/modules/ethercat/device/ec_module.h
@@ -11,30 +11,34 @@
  *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
-#pragma once
-
 #include "bus_device_handler.h"
-#include "model/ec_model.h"
+#include "ec_device.h"
+#include <cstdint>
 
 namespace forte::eclipse4diac::io::ethercat {
 
-  class ECDeviceHandler : public ECBusDeviceHandler {
+  class ECModuleHandler : public ECBusDeviceHandler {
     
     public:
       struct Config : ECBusDeviceHandler::Config {
-        uint16_t mAlias;
-        uint16_t mPosition;
-        uint32_t mVendorId;
-        uint32_t mProductCode;
+        uint32_t mModuleIdent;
+        uint16_t mSlot;
       };
-
-      ECDeviceModel mECDeviceModel;
 
       void setConfig(struct ECBusDeviceHandler::Config *paConfig) override;
 
-      ECDeviceHandler(ECBusHandler *paBus, ECBusDeviceHandler::DeviceType paDeviceType, size_t paDeviceIndex);
+      ECModuleHandler(ECBusHandler *paBus, size_t paDeviceIndex);
+
+      uint32_t moduleIdent() const {
+        return mConfig.mModuleIdent;
+      }
+
+      uint16_t slot() const {
+        return mConfig.mSlot;
+      }
 
     protected:
+      ECModuleHandler *mDeviceHandler;
       struct Config mConfig;
   };
 }

--- a/modules/ethercat/device/handle.cpp
+++ b/modules/ethercat/device/handle.cpp
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
 #include "handle.h"

--- a/modules/ethercat/device/handle.h
+++ b/modules/ethercat/device/handle.h
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
 #pragma once
@@ -39,7 +39,7 @@ namespace forte::eclipse4diac::io::ethercat {
         return mHandleId;
       }
 
-      /** Domain byte offset for EtherCAT registration (EsiFileParser / ECDeviceModel). */
+      /** Domain byte offset for EtherCAT registration (EsiIoConfigurator / ECDeviceModel). */
       unsigned int *ecDomainOffsetPtr() {
         return &mECDomainDataOffset;
       }

--- a/modules/ethercat/device/model/ec_model.cpp
+++ b/modules/ethercat/device/model/ec_model.cpp
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
 #include "ec_model.h"

--- a/modules/ethercat/device/model/ec_model.h
+++ b/modules/ethercat/device/model/ec_model.h
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
 #pragma once

--- a/modules/ethercat/handler/bus.cpp
+++ b/modules/ethercat/handler/bus.cpp
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
 // #include <sched.h>
@@ -17,6 +17,8 @@
 #include "forte/io/mapper/io_mapper.h"
 #include "bus.h"
 #include "../device/ec_device.h"
+#include "../utils/esi_catalog.h"
+#include "../utils/esi_io_configurator.h"
 
 namespace forte::eclipse4diac::io::ethercat {
 
@@ -39,7 +41,9 @@ namespace forte::eclipse4diac::io::ethercat {
     mInitializedFlag(false),
     mLoopPreparedFlag(false),
     mEnableFlag(false),
-    mIsShuttingDown(false){
+    mIsShuttingDown(false),
+    mEsiCatalog(std::make_unique<EsiCatalog>()),
+    mEsiIoConfigurator(std::make_unique<EsiIoConfigurator>(*mEsiCatalog)) {
   }
 
   void ECBusHandler::setConfig(struct IODeviceController::Config *paConfig) {
@@ -144,6 +148,9 @@ namespace forte::eclipse4diac::io::ethercat {
       ecrt_release_master(mECController);
       mECController = nullptr;
     }
+
+    mEsiIoConfigurator.reset();
+    mEsiCatalog.reset();
 
     mECDomain = nullptr;
     mECDomainPd = nullptr;
@@ -355,6 +362,22 @@ namespace forte::eclipse4diac::io::ethercat {
       }
       DEVLOG_INFO("[ECBusHandler]: EtherCAT cycle resumed.\n");
     }
+  }
+
+  EsiCatalog &ECBusHandler::esiCatalog() {
+    return *mEsiCatalog;
+  }
+
+  const EsiCatalog &ECBusHandler::esiCatalog() const {
+    return *mEsiCatalog;
+  }
+
+  EsiIoConfigurator &ECBusHandler::esiConfigurator() {
+    return *mEsiIoConfigurator;
+  }
+
+  const EsiIoConfigurator &ECBusHandler::esiConfigurator() const {
+    return *mEsiIoConfigurator;
   }
 
 }

--- a/modules/ethercat/handler/bus.h
+++ b/modules/ethercat/handler/bus.h
@@ -8,11 +8,12 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *   Sichuan Qunyuan Technology Co., Ltd. - initial API and implementation
+ *   Zijun Tang - initial API and implementation
  *******************************************************************************/
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <ecrt.h>
 #include "../device/bus_device_handler.h"
@@ -22,6 +23,8 @@ namespace forte::eclipse4diac::io::ethercat {
 
   class ECBusDeviceHandler;
   class ECDeviceHandler;
+  class EsiCatalog;
+  class EsiIoConfigurator;
 
   class ECBusHandler : public forte::io::IODeviceMultiController {
 
@@ -67,6 +70,11 @@ namespace forte::eclipse4diac::io::ethercat {
 
       ECDeviceHandler *getParentDevice(ECBusDeviceHandler *paDevice);
 
+      EsiCatalog &esiCatalog();
+      const EsiCatalog &esiCatalog() const;
+      EsiIoConfigurator &esiConfigurator();
+      const EsiIoConfigurator &esiConfigurator() const;
+
     protected:
       const char* init() override;
       void deInit() override;
@@ -98,6 +106,9 @@ namespace forte::eclipse4diac::io::ethercat {
       bool mLoopPreparedFlag;
       bool mEnableFlag;
       bool mIsShuttingDown;
+
+      std::unique_ptr<EsiCatalog> mEsiCatalog;
+      std::unique_ptr<EsiIoConfigurator> mEsiIoConfigurator;
   };
 
 }

--- a/modules/ethercat/structs/ECDeviceConfig.cpp
+++ b/modules/ethercat/structs/ECDeviceConfig.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "ECDeviceConfig.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  StringId CIEC_ECDeviceConfig::getStructTypeNameID() const {
+    return "ECDeviceConfig"_STRID;
+  }
+
+  const StringId CIEC_ECDeviceConfig::scmElementNames[] = {"Alias"_STRID, "Position"_STRID, "VendorId"_STRID, "ProductCode"_STRID};
+
+  DEFINE_FIRMWARE_DATATYPE(ECDeviceConfig, "ECDeviceConfig"_STRID);
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/structs/ECDeviceConfig.h
+++ b/modules/ethercat/structs/ECDeviceConfig.h
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/datatypes/forte_struct.h"
+#include "forte/datatypes/forte_uint.h"
+#include "forte/datatypes/forte_udint.h"
+#include "forte/typelib.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class CIEC_ECDeviceConfig : public CIEC_STRUCT {
+      DECLARE_FIRMWARE_DATATYPE(ECDeviceConfig);
+
+    public:
+      CIEC_UINT Alias;
+      CIEC_UINT Position;
+      CIEC_UDINT VendorId;
+      CIEC_UDINT ProductCode;
+
+      CIEC_ECDeviceConfig() = default;
+
+      size_t getStructSize() const override {
+        return 4;
+      }
+
+      const StringId *elementNames() const override {
+        return scmElementNames;
+      }
+
+      StringId getStructTypeNameID() const override;
+
+      CIEC_ANY *getMember(size_t paMemberIndex) override {
+        switch (paMemberIndex) {
+          case 0: return &Alias;
+          case 1: return &Position;
+          case 2: return &VendorId;
+          case 3: return &ProductCode;
+        }
+        return nullptr;
+      }
+
+      const CIEC_ANY *getMember(size_t paMemberIndex) const override {
+        switch (paMemberIndex) {
+          case 0: return &Alias;
+          case 1: return &Position;
+          case 2: return &VendorId;
+          case 3: return &ProductCode;
+        }
+        return nullptr;
+      }
+
+    private:
+      static const StringId scmElementNames[];
+  };
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/structs/ECModuleConfig.cpp
+++ b/modules/ethercat/structs/ECModuleConfig.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "ECModuleConfig.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  StringId CIEC_ECModuleConfig::getStructTypeNameID() const {
+    return "ECModuleConfig"_STRID;
+  }
+
+  const StringId CIEC_ECModuleConfig::scmElementNames[] = {"ModuleIdent"_STRID, "Slot"_STRID};
+
+  DEFINE_FIRMWARE_DATATYPE(ECModuleConfig, "ECModuleConfig"_STRID);
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/structs/ECModuleConfig.h
+++ b/modules/ethercat/structs/ECModuleConfig.h
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/datatypes/forte_struct.h"
+#include "forte/datatypes/forte_udint.h"
+#include "forte/datatypes/forte_uint.h"
+#include "forte/typelib.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class CIEC_ECModuleConfig : public CIEC_STRUCT {
+      DECLARE_FIRMWARE_DATATYPE(ECModuleConfig);
+
+    public:
+      CIEC_UDINT ModuleIdent;
+      CIEC_UINT Slot;
+
+      CIEC_ECModuleConfig() = default;
+
+      size_t getStructSize() const override {
+        return 2;
+      }
+
+      const StringId *elementNames() const override {
+        return scmElementNames;
+      }
+
+      StringId getStructTypeNameID() const override;
+
+      CIEC_ANY *getMember(size_t paMemberIndex) override {
+        switch (paMemberIndex) {
+          case 0: return &ModuleIdent;
+          case 1: return &Slot;
+        }
+        return nullptr;
+      }
+
+      const CIEC_ANY *getMember(size_t paMemberIndex) const override {
+        switch (paMemberIndex) {
+          case 0: return &ModuleIdent;
+          case 1: return &Slot;
+        }
+        return nullptr;
+      }
+
+    private:
+      static const StringId scmElementNames[];
+  };
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/ECBusAdapter.cpp
+++ b/modules/ethercat/types/ECBusAdapter.cpp
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "ECBusAdapter.h"
+
+#include <array>
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  namespace {
+    const forte::StringId cDataInputNames[] = {"QO"_STRID};
+    const forte::StringId cDataOutputNames[] = {"QI"_STRID, "ControllerId"_STRID, "Index"_STRID};
+    const forte::StringId cEventInputNames[] = {"INITO"_STRID};
+    const forte::StringId cEventInputTypeIds[] = {"EInit"_STRID};
+    const forte::StringId cEventOutputNames[] = {"INIT"_STRID};
+    const forte::StringId cEventOutputTypeIds[] = {"EInit"_STRID};
+
+    const SFBInterfaceSpec scmFBInterfaceSpecSocket = {
+        .mEINames = cEventInputNames,
+        .mEITypeNames = cEventInputTypeIds,
+        .mEONames = cEventOutputNames,
+        .mEOTypeNames = cEventOutputTypeIds,
+        .mDINames = cDataInputNames,
+        .mDONames = cDataOutputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const SFBInterfaceSpec scmFBInterfaceSpecPlug = {
+        .mEINames = cEventOutputNames,
+        .mEITypeNames = cEventOutputTypeIds,
+        .mEONames = cEventInputNames,
+        .mEOTypeNames = cEventInputTypeIds,
+        .mDINames = cDataOutputNames,
+        .mDONames = cDataInputNames,
+        .mDIONames = {},
+        .mSocketNames = {},
+        .mPlugNames = {},
+    };
+
+    const auto scmSlaveConfigurationIO = std::array<const TForteUInt8, 0>{};
+  } // namespace
+
+  DEFINE_ADAPTER_TYPE(FORTE_ECBusAdapter, "eclipse4diac::io::ethercat::ECBusAdapter"_STRID)
+
+  FORTE_ECBusAdapter::FORTE_ECBusAdapter(CFBContainer &paContainer,
+                                         const SFBInterfaceSpec &paInterfaceSpec,
+                                         const forte::StringId paInstanceNameId,
+                                         TForteUInt8 paParentAdapterlistID) :
+      IOConfigFBMultiAdapter(
+          scmSlaveConfigurationIO, paContainer, paInterfaceSpec, paInstanceNameId, paParentAdapterlistID) {
+  }
+
+  void FORTE_ECBusAdapter::setInitialValues() {
+  }
+
+  FORTE_ECBusAdapter_Plug::FORTE_ECBusAdapter_Plug(forte::StringId paInstanceNameId,
+                                                   CFBContainer &paContainer,
+                                                   TForteUInt8 paParentAdapterlistID) :
+      FORTE_ECBusAdapter(paContainer, scmFBInterfaceSpecPlug, paInstanceNameId, paParentAdapterlistID),
+      conn_INITO(*this, 0),
+      conn_QI(nullptr),
+      conn_ControllerId(nullptr),
+      conn_Index(nullptr),
+      conn_QO(*this, 0, var_QO) {
+  }
+
+  void FORTE_ECBusAdapter_Plug::readInputData(TEventID paEIID) {
+    if (paEIID == scmEventINITID) {
+      readData(0, var_QI, conn_QI);
+      readData(1, var_MasterId, conn_ControllerId);
+      readData(2, var_Index, conn_Index);
+      if (getPeer() != nullptr) {
+        getSocket()->var_QI = var_QI;
+        getSocket()->var_MasterId = var_MasterId;
+        getSocket()->var_Index = var_Index;
+      }
+    }
+  }
+
+  void FORTE_ECBusAdapter_Plug::writeOutputData(TEventID paEIID) {
+    if (paEIID == scmEventINITOID) {
+      writeData(scmFBInterfaceSpecPlug.getNumDIs() + 0, var_QO, conn_QO);
+    }
+  }
+
+  CEventConnection *FORTE_ECBusAdapter_Plug::getEOConUnchecked(TPortId paEONum) {
+    return (paEONum == 0) ? &conn_INITO : nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECBusAdapter_Plug::getDI(TPortId paDINum) {
+    switch (paDINum) {
+      case 0: return &var_QI; break;
+      case 1: return &var_MasterId; break;
+      case 2: return &var_Index; break;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_ECBusAdapter_Plug::getDIConUnchecked(TPortId paDINum) {
+    switch (paDINum) {
+      case 0: return &conn_QI; break;
+      case 1: return &conn_ControllerId; break;
+      case 2: return &conn_Index; break;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_ECBusAdapter_Plug::getDOConUnchecked(TPortId paDONum) {
+    return (paDONum == 0) ? &conn_QO : nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECBusAdapter_Plug::getDO(TPortId paDONum) {
+    return (paDONum == 0) ? &var_QO : nullptr;
+  }
+
+  FORTE_ECBusAdapter_Socket *FORTE_ECBusAdapter_Plug::getSocket() {
+    return static_cast<FORTE_ECBusAdapter_Socket *>(getPeer());
+  }
+
+  FORTE_ECBusAdapter_Socket::FORTE_ECBusAdapter_Socket(forte::StringId paInstanceNameId,
+                                                       CFBContainer &paContainer,
+                                                       TForteUInt8 paParentAdapterlistID) :
+      FORTE_ECBusAdapter(paContainer, scmFBInterfaceSpecSocket, paInstanceNameId, paParentAdapterlistID),
+      conn_QO(nullptr),
+      conn_INIT(*this, 0),
+      conn_QI(*this, 0, var_QI),
+      conn_ControllerId(*this, 1, var_MasterId),
+      conn_Index(*this, 2, var_Index) {
+  }
+
+  void FORTE_ECBusAdapter_Socket::readInputData(TEventID paEIID) {
+    if (paEIID == scmEventINITOID) {
+      readData(0, var_QO, conn_QO);
+      if (getPeer() != nullptr) {
+        getPlug()->var_QO = var_QO;
+      }
+    }
+  }
+
+  void FORTE_ECBusAdapter_Socket::writeOutputData(TEventID paEIID) {
+    if (paEIID == scmEventINITID) {
+      writeData(scmFBInterfaceSpecSocket.getNumDIs() + 0, var_QI, conn_QI);
+      writeData(scmFBInterfaceSpecSocket.getNumDIs() + 1, var_MasterId, conn_ControllerId);
+      writeData(scmFBInterfaceSpecSocket.getNumDIs() + 2, var_Index, conn_Index);
+    }
+  }
+
+  CEventConnection *FORTE_ECBusAdapter_Socket::getEOConUnchecked(TPortId paEONum) {
+    return (paEONum == 0) ? &conn_INIT : nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECBusAdapter_Socket::getDI(TPortId paDINum) {
+    return (paDINum == 0) ? &var_QO : nullptr;
+  }
+
+  CDataConnection **FORTE_ECBusAdapter_Socket::getDIConUnchecked(TPortId paDINum) {
+    return (paDINum == 0) ? &conn_QO : nullptr;
+  }
+
+  CDataConnection *FORTE_ECBusAdapter_Socket::getDOConUnchecked(TPortId paDONum) {
+    switch (paDONum) {
+      case 0: return &conn_QI; break;
+      case 1: return &conn_ControllerId; break;
+      case 2: return &conn_Index; break;
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECBusAdapter_Socket::getDO(TPortId paDONum) {
+    switch (paDONum) {
+      case 0: return &var_QI; break;
+      case 1: return &var_MasterId; break;
+      case 2: return &var_Index; break;
+    }
+    return nullptr;
+  }
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/types/ECBusAdapter.h
+++ b/modules/ethercat/types/ECBusAdapter.h
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/io/configFB/io_adapter_multi.h"
+#include "forte/datatypes/forte_uint.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECBusAdapter : public forte::io::IOConfigFBMultiAdapter {
+    DECLARE_ADAPTER_TYPE(FORTE_ECBusAdapter)
+
+    public:
+      static const TEventID scmEventINITOID = 0;
+      static const TEventID scmEventINITID = 0;
+
+      TEventID evt_INITO() {
+        return getParentAdapterListEventID() + scmEventINITOID;
+      }
+
+      TEventID evt_INIT() {
+        return getParentAdapterListEventID() + scmEventINITID;
+      }
+
+      ~FORTE_ECBusAdapter() override = default;
+
+      void setInitialValues() override;
+
+      CIEC_ANY *getDeviceConfigPin(int) override {
+        return nullptr;
+      }
+
+    protected:
+      FORTE_ECBusAdapter(CFBContainer &paContainer,
+                         const SFBInterfaceSpec &paInterfaceSpec,
+                         const forte::StringId paInstanceNameId,
+                         TForteUInt8 paParentAdapterlistID);
+  };
+
+  class FORTE_ECBusAdapter_Socket;
+
+  class FORTE_ECBusAdapter_Plug final : public FORTE_ECBusAdapter {
+    public:
+      FORTE_ECBusAdapter_Plug(forte::StringId paInstanceNameId,
+                              CFBContainer &paContainer,
+                              TForteUInt8 paParentAdapterlistID);
+      ~FORTE_ECBusAdapter_Plug() override = default;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+
+      CEventConnection conn_INITO;
+
+      CDataConnection *conn_QI;
+      CDataConnection *conn_ControllerId;
+      CDataConnection *conn_Index;
+
+      COutDataConnection<CIEC_BOOL> conn_QO;
+
+    protected:
+      CEventConnection *getEOConUnchecked(TPortId paEONum) override;
+      CIEC_ANY *getDI(TPortId paDINum) override;
+      CDataConnection **getDIConUnchecked(TPortId paDINum) override;
+      CDataConnection *getDOConUnchecked(TPortId paDONum) override;
+      CIEC_ANY *getDO(TPortId paDONum) override;
+
+    private:
+      FORTE_ECBusAdapter_Socket *getSocket();
+  };
+
+  class FORTE_ECBusAdapter_Socket final : public FORTE_ECBusAdapter {
+    public:
+      FORTE_ECBusAdapter_Socket(forte::StringId paInstanceNameId,
+                                CFBContainer &paContainer,
+                                TForteUInt8 paParentAdapterlistID);
+      ~FORTE_ECBusAdapter_Socket() override = default;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+
+      CDataConnection *conn_QO;
+
+      CEventConnection conn_INIT;
+
+      COutDataConnection<CIEC_BOOL> conn_QI;
+      COutDataConnection<CIEC_UINT> conn_ControllerId;
+      COutDataConnection<CIEC_UINT> conn_Index;
+
+    protected:
+      CEventConnection *getEOConUnchecked(TPortId paEONum) override;
+      CIEC_ANY *getDI(TPortId paDINum) override;
+      CDataConnection **getDIConUnchecked(TPortId paDINum) override;
+      CDataConnection *getDOConUnchecked(TPortId paDONum) override;
+      CIEC_ANY *getDO(TPortId paDONum) override;
+
+    private:
+      FORTE_ECBusAdapter_Plug *getPlug() {
+        return static_cast<FORTE_ECBusAdapter_Plug *>(getPeer());
+      }
+  };
+}

--- a/modules/ethercat/types/ECController.cpp
+++ b/modules/ethercat/types/ECController.cpp
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "ECController.h"
+#include "../handler/bus.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  DEFINE_FIRMWARE_FB(FORTE_ECController, "eclipse4diac::io::ethercat::ECController"_STRID,
+                     "v2:SHA3-512:zdg7DeWvo5613AFG13T0n485ZdrDL9FBrnCW3_pjeBIh7Imn522te-wa85a-yODs2Hb5ClODMYi-r23BwH_ZiA==")
+
+  namespace {
+    const auto cDataInputNames = std::array{"QI"_STRID, "Enable"_STRID, "ControllerId"_STRID, "UpdateInterval"_STRID};
+    const auto cDataOutputNames = std::array{"QO"_STRID, "STATUS"_STRID};
+    const auto cEventInputNames = std::array{"INIT"_STRID, "REQ"_STRID};
+    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
+    const auto cEventOutputNames = std::array{"INITO"_STRID, "CNF"_STRID, "IND"_STRID};
+    const auto cEventOutputTypeIds = std::array{"Event"_STRID, "Event"_STRID, "EVENT"_STRID};
+    const auto cPlugNameIds = std::array{"BusAdapterOut"_STRID};
+
+    const SFBInterfaceSpec cFBInterfaceSpec = {
+      .mEINames = cEventInputNames,
+      .mEITypeNames = cEventInputTypeIds,
+      .mEONames = cEventOutputNames,
+      .mEOTypeNames = cEventOutputTypeIds,
+      .mDINames = cDataInputNames,
+      .mDONames = cDataOutputNames,
+      .mDIONames = {},
+      .mSocketNames = {},
+      .mPlugNames = cPlugNameIds,
+    };
+  }
+
+  FORTE_ECController::FORTE_ECController(const forte::StringId paInstanceNameId, CFBContainer &paContainer) :
+      IOConfigFBMultiMaster(paContainer, cFBInterfaceSpec, paInstanceNameId),
+      var_QI(0_BOOL),
+      var_Enable(0_BOOL),
+      var_ControllerId(0_UINT),
+      var_UpdateInterval(0_TIME),
+      conn_INITO(*this, 0),
+      conn_CNF(*this, 1),
+      conn_IND(*this, 2),
+      conn_QI(nullptr),
+      conn_Enable(nullptr),
+      conn_ControllerId(nullptr),
+      conn_UpdateInterval(nullptr),
+      conn_QO(*this, 0, var_QO),
+      conn_STATUS(*this, 1, var_STATUS),
+      var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0) {
+  };
+
+  FORTE_ECController::~FORTE_ECController() {
+    // var_STATUS is destroyed before ~IOConfigFBController runs. Shut down the bus here while
+    // STATUS()/getDO() are still valid; base destructor deInit() then finds mController == nullptr.
+    deInit(nullptr, true);
+  }
+
+  void FORTE_ECController::setInitialValues() {
+    var_QI = 0_BOOL;
+    var_Enable = 0_BOOL;
+    var_ControllerId = 0_UINT;
+    var_UpdateInterval.setFromMilliSeconds(1);
+    var_QO = 0_BOOL;
+    var_STATUS = u""_WSTRING;
+  }
+
+  void FORTE_ECController::readInputData(const TEventID paEIED) {
+    switch (paEIED){
+      case scmEventINITID:
+      case scmEventREQID:
+        readData(0, var_QI, conn_QI);
+        readData(1, var_Enable, conn_Enable);
+        readData(2, var_ControllerId, conn_ControllerId);
+        readData(3, var_UpdateInterval, conn_UpdateInterval);
+        break;
+      default:break;
+    }
+  }
+
+  void FORTE_ECController::writeOutputData(const TEventID paEIID) {
+    switch(paEIID) {
+      case scmEventIND:
+      case scmEventCNF:
+      case scmEventINITOID: {
+        writeData(cFBInterfaceSpec.getNumDIs() + 0, var_QO, conn_QO);
+        writeData(cFBInterfaceSpec.getNumDIs() + 1, var_STATUS, conn_STATUS);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_ECController::getDI(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QI;
+      case 1: return &var_Enable;
+      case 2: return &var_ControllerId;
+      case 3: return &var_UpdateInterval;
+    }
+    return nullptr;
+  }
+
+  CIEC_ANY *FORTE_ECController::getDO(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QO;
+      case 1: return &var_STATUS;
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_ECController::getEOConUnchecked(const TPortId paIndex) {
+    switch(paIndex) {
+      case 0: return &conn_INITO;
+      case 1: return &conn_CNF;
+      case 2: return &conn_IND;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_ECController::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QI;
+      case 1: return &conn_Enable;
+      case 2: return &conn_ControllerId;
+      case 3: return &conn_UpdateInterval;
+    }
+    return nullptr;
+  }
+
+  CDataConnection *FORTE_ECController::getDOConUnchecked(const TPortId paIndex) {
+    switch(paIndex) {
+      case 0: return &conn_QO;
+      case 1: return &conn_STATUS;
+    }
+    return nullptr;
+  }
+
+  forte::IPlugPin *FORTE_ECController::getPlugPinUnchecked(size_t paIndex) {
+    return (paIndex == 0) ? &var_BusAdapterOut : nullptr;
+  }
+
+  forte::io::IODeviceController *FORTE_ECController::createDeviceController(CDeviceExecution &paDeviceExecution) {
+    return new ECBusHandler(paDeviceExecution);
+  }
+
+  void FORTE_ECController::setConfig() {
+    ECBusHandler::Config config;
+    config.mECControllerId = var_ControllerId.operator TForteUInt16();
+    config.mUpdateInterval = static_cast<unsigned int>(var_UpdateInterval.getInMicroSeconds());
+    DEVLOG_INFO("ECControllerId is:%d, and UpdateInterval is: %d\n", config.mECControllerId, config.mUpdateInterval);
+    getDeviceController()->setConfig(&config);
+  }
+
+  void FORTE_ECController::onStartup(CEventChainExecutionThread *const paECET) {
+    var_BusAdapterOut->var_Index = 0_UINT;
+    IOConfigFBMultiMaster::onStartup(paECET);
+  }
+
+  EMGMResponse FORTE_ECController::changeExecutionState(EMGMCommandType paCommand) {
+    if (paCommand == EMGMCommandType::Kill || paCommand == EMGMCommandType::Stop) {
+      if (auto *bus = static_cast<ECBusHandler *>(getDeviceController()); bus != nullptr) {
+        bus->enableECCycle(false);
+      }
+    }
+
+    return IOConfigFBMultiMaster::changeExecutionState(paCommand);
+  }
+
+  void FORTE_ECController::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    if (paEIID == scmEventREQID) {
+      // Align with legacy EtherCAT behavior: REQ toggles cyclic bus execution.
+      readInputData(paEIID);
+      auto *bus = static_cast<ECBusHandler *>(getDeviceController());
+      if (bus != nullptr) {
+        bus->enableECCycle(var_Enable);
+      }
+      sendOutputEvent(scmEventCNF, paECET);
+    }
+    IOConfigFBMultiMaster::executeEvent(paEIID, paECET);
+  }
+      
+}

--- a/modules/ethercat/types/ECController.h
+++ b/modules/ethercat/types/ECController.h
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/io/configFB/io_master_multi.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_uint.h"
+#include "forte/datatypes/forte_udint.h"
+#include "forte/datatypes/forte_wstring.h"
+#include "forte/datatypes/forte_time.h"
+#include "ECBusAdapter.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECController final : public forte::io::IOConfigFBMultiMaster {
+      DECLARE_FIRMWARE_FB(FORTE_ECController)
+    
+    private:
+      static const TEventID scmEventINITID = 0;
+      static const TEventID scmEventREQID = 1;
+      static const TEventID scmEventINITO = 0;
+      static const TEventID scmEventCNF = 1;
+      static const TEventID scmEventIND = 2;
+      static const int scmBusAdapterOutAdpNum = 0;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      void setInitialValues() override;
+
+    protected:
+      forte::io::IODeviceController *createDeviceController(CDeviceExecution &paDeviceExecution) override;
+
+      void setConfig() override;
+
+      void onStartup(CEventChainExecutionThread *const paECET) override;
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+    public:
+      FORTE_ECController(forte::StringId paInstanceNameId, CFBContainer &paContainer);
+      ~FORTE_ECController() override;
+
+      EMGMResponse changeExecutionState(EMGMCommandType paCommand) override;
+
+      CIEC_BOOL var_QI;
+      CIEC_BOOL var_Enable;
+      CIEC_UINT var_ControllerId;
+      CIEC_TIME var_UpdateInterval;
+
+      CIEC_BOOL var_QO;
+      CIEC_WSTRING var_STATUS;
+
+      CEventConnection conn_INITO;
+      CEventConnection conn_IND;
+      CEventConnection conn_CNF;
+
+      CDataConnection *conn_QI;
+      CDataConnection *conn_Enable;
+      CDataConnection *conn_ControllerId;
+      CDataConnection *conn_UpdateInterval;
+
+      COutDataConnection<CIEC_BOOL> conn_QO;
+      COutDataConnection<CIEC_WSTRING> conn_STATUS;
+
+      CIEC_ANY *getDI(size_t) override;
+      CIEC_ANY *getDO(size_t) override;
+
+      forte::CPlugPin<FORTE_ECBusAdapter_Plug> var_BusAdapterOut;
+
+      CEventConnection *getEOConUnchecked(TPortId) override;
+      CDataConnection **getDIConUnchecked(TPortId) override;
+      CDataConnection *getDOConUnchecked(TPortId) override;
+      forte::IPlugPin *getPlugPinUnchecked(size_t) override;
+
+      void evt_INIT(const CIEC_BOOL &paQI,
+                    const CIEC_BOOL &paEnable,
+                    const CIEC_UINT &paControllerId,
+                    const CIEC_TIME &paUpdateInterval,
+                    CAnyBitOutputParameter<CIEC_BOOL> paQO,
+                    COutputParameter<CIEC_WSTRING> paSTATUS) {
+        COutputGuard guard_paQO(paQO);
+        COutputGuard guard_paSTATUS(paSTATUS);
+        var_QI = paQI;
+        var_Enable = paEnable;
+        var_ControllerId = paControllerId;
+        var_UpdateInterval = paUpdateInterval;
+        receiveInputEvent(scmEventINITID, nullptr);
+        *paQO = var_QO;
+        *paSTATUS = var_STATUS;
+      }
+
+      void operator()(const CIEC_BOOL &paQI,
+                      const CIEC_BOOL &paEnable,
+                      const CIEC_UINT &paControllerId,
+                      const CIEC_TIME &paUpdateInterval,
+                      CAnyBitOutputParameter<CIEC_BOOL> paQO,
+                      COutputParameter<CIEC_WSTRING> paSTATUS) {
+        evt_INIT(paQI, paEnable, paControllerId, paUpdateInterval, paQO, paSTATUS);
+      }
+  };
+}

--- a/modules/ethercat/types/ECCoupler.cpp
+++ b/modules/ethercat/types/ECCoupler.cpp
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "ECCoupler.h"
+
+#include "../handler/bus.h"
+#include "../device/ec_device.h"
+#include "forte/iec61131_functions/func_AND.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  namespace {
+    const auto cCouplerPlugNames = std::array{"BusAdapterOut"_STRID, "ModuleAdapterOut"_STRID};
+  } // namespace
+
+  DEFINE_FIRMWARE_FB(FORTE_ECCoupler, "eclipse4diac::io::ethercat::ECCoupler"_STRID)
+
+  FORTE_ECCoupler::FORTE_ECCoupler(forte::StringId paInstanceNameId, CFBContainer &paContainer) :
+      FORTE_ECDevice(paInstanceNameId, paContainer, ECBusDeviceHandler::DeviceType::ECCoupler),
+      var_ModuleAdapterOut("ModuleAdapterOut"_STRID, *this, 1) {
+  }
+
+  bool FORTE_ECCoupler::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    if (!FORTE_ECDevice::createInterfaceSpec(paConfigString, paInterfaceSpec)) {
+      return false;
+    }
+    paInterfaceSpec.mPlugNames = cCouplerPlugNames;
+    return true;
+  }
+
+  void FORTE_ECCoupler::executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    if (BusAdapterIn().INIT() == paEIID) {
+      if(BusAdapterIn().var_QI == true) {
+        if(var_ModuleAdapterOut.getAdapterBlock()->getPeer() != nullptr) {
+          var_ModuleAdapterOut->var_QI = true_BOOL;
+          var_ModuleAdapterOut->var_Index = CIEC_UINT((static_cast<TForteUInt16>(var_BusAdapterIn->var_Index) + 1) * 100);
+          var_ModuleAdapterOut->var_MasterId = var_BusAdapterIn->var_MasterId;
+          sendAdapterEvent(*var_ModuleAdapterOut, FORTE_ECBusAdapter::scmEventINITID, paECET);
+        }    
+      }
+    }
+  
+    FORTE_ECDevice::executeEvent(paEIID, paECET);
+  }
+
+  void FORTE_ECCoupler::forwardInitConfirmation(CEventChainExecutionThread *const paECET) {
+    CIEC_BOOL combinedQO = QO();
+    if(var_BusAdapterOut.getAdapterBlock()->getPeer() != nullptr) {
+      combinedQO = func_AND(combinedQO, var_BusAdapterOut->var_QO);
+    }
+    if(var_ModuleAdapterOut.getAdapterBlock()->getPeer() != nullptr) {
+      combinedQO = func_AND(combinedQO, var_ModuleAdapterOut->var_QO);
+    }
+    var_BusAdapterIn->var_QO = combinedQO;
+    sendAdapterEvent(*var_BusAdapterIn, forte::io::IOConfigFBMultiAdapter::scmEventINITOID, paECET);
+  }
+
+  forte::IPlugPin *FORTE_ECCoupler::getPlugPinUnchecked(size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_BusAdapterOut;
+      case 1: return &var_ModuleAdapterOut;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  bool FORTE_ECCoupler::createSlaveHandler() {  
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *handler = new ECDeviceHandler(&bus, ECBusDeviceHandler::DeviceType::ECCoupler, mIndex);
+    ECDeviceHandler::Config cfg{};
+    cfg.mAlias = static_cast<TForteUInt16>(Config().Alias);
+    cfg.mPosition = static_cast<TForteUInt16>(Config().Position);
+    cfg.mVendorId = static_cast<TForteUInt32>(Config().VendorId);
+    cfg.mProductCode = static_cast<TForteUInt32>(Config().ProductCode);
+    handler->setConfig(&cfg);
+    handler->mDelegate = this;
+    bus.addDevice(handler);
+    return true;
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/ECCoupler.h
+++ b/modules/ethercat/types/ECCoupler.h
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECDevice.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECCoupler : public FORTE_ECDevice {
+      DECLARE_FIRMWARE_FB(FORTE_ECCoupler)
+
+    public:
+      FORTE_ECCoupler(forte::StringId paInstanceNameId, CFBContainer &paContainer);
+      ~FORTE_ECCoupler() override = default;
+
+    protected:
+      bool createSlaveHandler() override;
+
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      forte::IPlugPin *getPlugPinUnchecked(size_t paIndex) override;
+      bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
+
+      void forwardInitConfirmation(CEventChainExecutionThread *const paECET);
+
+      forte::CPlugPin<FORTE_ECBusAdapter_Plug> var_ModuleAdapterOut;
+
+      FORTE_ECBusAdapter &ModuleAdapterOut() {
+        return (*static_cast<FORTE_ECBusAdapter *>(getPlugPinUnchecked(1)->getAdapterBlock()));
+      }
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/ECDevice.cpp
+++ b/modules/ethercat/types/ECDevice.cpp
@@ -1,0 +1,275 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "ECDevice.h"
+
+#include "../handler/bus.h"
+#include "../device/ec_device.h"
+#include "../utils/esi_io_configurator.h"
+#include "forte/util/string_utils.h"
+
+#include <string>
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  namespace {
+    const auto cSocketNameIds = std::array{"BusAdapterIn"_STRID};
+    const auto cPlugNameIds = std::array{"BusAdapterOut"_STRID};
+
+    const auto cEventInputNameIds = std::array{"MAP"_STRID};
+    const auto cEventOutputNameIds = std::array{"MAPO"_STRID, "IND"_STRID};
+
+    const auto cEventInputTypeIds = std::array{"Event"_STRID};
+    const auto cEventOutputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
+  } // namespace
+
+  DEFINE_GENERIC_FIRMWARE_FB(FORTE_ECDevice, "eclipse4diac::io::ethercat::GEN_ECDevice"_STRID)
+
+  const TForteUInt8 FORTE_ECDevice::scmSlaveConfigurationIO[] = {};
+  const TForteUInt8 FORTE_ECDevice::scmSlaveConfigurationIONum = 0;
+
+  FORTE_ECDevice::FORTE_ECDevice(const forte::StringId paInstanceNameId,
+                               CFBContainer &paContainer,
+                               ECBusDeviceHandler::DeviceType paDeviceType) :
+      CGenFunctionBlock<forte::io::IOConfigFBMultiSlave>(paContainer,
+                                           paInstanceNameId,
+                                           scmSlaveConfigurationIO,
+                                           scmSlaveConfigurationIONum,
+                                           static_cast<int>(paDeviceType)),
+      conn_MAPO(*this, 0),
+      conn_IND(*this, 1),
+      conn_QI(nullptr),
+      conn_Config(nullptr),
+      conn_QO(*this, 0, var_QO),
+      conn_STATUS(*this, 1, var_STATUS),
+      var_BusAdapterIn("BusAdapterIn"_STRID, *this, 0),
+      var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0) {
+  }
+
+  FORTE_ECDevice::~FORTE_ECDevice() {
+    const size_t numDIs = getFBInterfaceSpec().getNumDIs();
+    const size_t genOffset = getGenDIOffset();
+    const size_t safeGenDINums = (numDIs > genOffset) ? (numDIs - genOffset) : 0;
+    for (size_t i = 0; i < safeGenDINums && mGenDIs; ++i) {
+      delete mGenDIs[i];
+    }
+  }
+
+  void FORTE_ECDevice::readInputData(const TEventID paEIID) {
+    if (paEIID == scmEventMAPID) {
+      readData(0, var_QI, conn_QI);
+      readData(1, var_Config, conn_Config);
+      for (TPortId i = 0; i < static_cast<TPortId>(getGenDINums()); ++i) {
+        readData(static_cast<TPortId>(i + getGenDIOffset()), *mGenDIs[i], mGenDIConns[i]);
+      }
+    }
+  }
+
+  void FORTE_ECDevice::writeOutputData(const TEventID paEIID) {
+    const size_t numDIs = getFBInterfaceSpec().getNumDIs();
+    switch (paEIID) {
+      case scmEventMAPOID: {
+        writeData(numDIs + 0, var_QO, conn_QO);
+        break;
+      }
+      case scmEventINDID: {
+        writeData(numDIs + 0, var_QO, conn_QO);
+        writeData(numDIs + 1, var_STATUS, conn_STATUS);
+        break;
+      }
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_ECDevice::mappingDi(const TPortId paRelativeIndex) {
+    return getDI(static_cast<TPortId>(getGenDIOffset() + paRelativeIndex));
+  }
+
+  void FORTE_ECDevice::registerMappedHandle(forte::io::IODeviceController::HandleDescriptor &paDesc) {
+    initHandle(paDesc);
+  }
+
+  CIEC_ANY *FORTE_ECDevice::getDI(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QI;
+      case 1: return &var_Config;
+      default: return mGenDIs[paIndex - getGenDIOffset()];
+    }
+  }
+
+  CIEC_ANY *FORTE_ECDevice::getDO(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QO;
+      case 1: return &var_STATUS;
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_ECDevice::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_MAPO;
+      case 1: return &conn_IND;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_ECDevice::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QI;
+      case 1: return &conn_Config;
+      default: return CGenFunctionBlock<forte::io::IOConfigFBMultiSlave>::getDIConUnchecked(paIndex);
+    }
+  }
+
+  CDataConnection *FORTE_ECDevice::getDOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QO;
+      case 1: return &conn_STATUS;
+    }
+    return nullptr;
+  }
+
+  forte::IPlugPin *FORTE_ECDevice::getPlugPinUnchecked(const size_t paIndex) {
+    return (paIndex == 0) ? &var_BusAdapterOut : nullptr;
+  }
+
+  forte::ISocketPin *FORTE_ECDevice::getSocketPinUnchecked(const size_t paIndex) {
+    return (paIndex == 0) ? &var_BusAdapterIn : nullptr;
+  }
+
+  void FORTE_ECDevice::createGenInputData() {
+    const size_t n = getGenDINums();
+    mGenDIs = std::make_unique<CIEC_ANY *[]>(n);
+    for (size_t i = 0; i < n; ++i) {
+      mGenDIs[i] = new CIEC_WSTRING();
+    }
+  }
+
+  bool FORTE_ECDevice::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    std::string tempstring(paConfigString);
+    const char *sParamA = nullptr;
+    const char *sParamB = nullptr;
+
+    const size_t firstUnderscore = tempstring.find('_');
+    const size_t secondUnderscore = tempstring.find('_', firstUnderscore == std::string::npos ? 0 : firstUnderscore + 1);
+    if (firstUnderscore != std::string::npos && secondUnderscore != std::string::npos &&
+        firstUnderscore + 1 < tempstring.size() && secondUnderscore + 1 < tempstring.size()) {
+      tempstring[secondUnderscore] = '\0';
+      sParamA = &(tempstring[firstUnderscore + 1]);
+      sParamB = &(tempstring[secondUnderscore + 1]);
+    }
+
+    if (sParamB == nullptr) {
+      return false;
+    }
+
+    configureDIDOs(sParamA, sParamB, paInterfaceSpec);
+
+    paInterfaceSpec.mEINames = cEventInputNameIds;
+    paInterfaceSpec.mEITypeNames = cEventInputTypeIds;
+    paInterfaceSpec.mEONames = cEventOutputNameIds;
+    paInterfaceSpec.mEOTypeNames = cEventOutputTypeIds;
+    paInterfaceSpec.mSocketNames = cSocketNameIds;
+    paInterfaceSpec.mPlugNames = cPlugNameIds;
+    return true;
+  }
+
+  void FORTE_ECDevice::configureDIDOs(const char *paDIConfigString,
+                                     const char *paDOConfigString,
+                                     SFBInterfaceSpec &paInterfaceSpec) {
+    mDiNames.clear();
+    mDoNames.clear();
+
+    mDiNames.emplace_back("QI"_STRID);
+    mDiNames.emplace_back("Config"_STRID);
+
+    mNumInPdus = static_cast<size_t>(util::strtol(paDIConfigString, nullptr, 10));
+    mNumOutPdus = static_cast<size_t>(util::strtol(paDOConfigString, nullptr, 10));
+
+    generateGenericInterfacePointNameArray("IN_", mDiNames, mNumInPdus);
+    generateGenericInterfacePointNameArray("OUT_", mDiNames, mNumOutPdus);
+
+    mDoNames.emplace_back("QO"_STRID);
+    mDoNames.emplace_back("STATUS"_STRID);
+
+    paInterfaceSpec.mDINames = mDiNames;
+    paInterfaceSpec.mDONames = mDoNames;
+  }
+
+  bool FORTE_ECDevice::createSlaveHandler() {
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *handler = new ECDeviceHandler(&bus, ECBusDeviceHandler::DeviceType::ECDevice, mIndex);
+    ECDeviceHandler::Config cfg{};
+    cfg.mAlias = static_cast<TForteUInt16>(Config().Alias);
+    cfg.mPosition = static_cast<TForteUInt16>(Config().Position);
+    cfg.mVendorId = static_cast<TForteUInt32>(Config().VendorId);
+    cfg.mProductCode = static_cast<TForteUInt32>(Config().ProductCode);
+    handler->setConfig(&cfg);
+    handler->mDelegate = this;
+    bus.addDevice(handler);
+    return true;
+  }
+
+  const char *FORTE_ECDevice::init() {
+    const auto productCode = static_cast<TForteUInt32>(Config().ProductCode);
+    std::string errMsg;
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    if (!bus.esiConfigurator().validateDevice(productCode, errMsg)) {
+      mLastError = errMsg;
+      return mLastError.c_str();
+    }
+    return nullptr;
+  }
+
+  void FORTE_ECDevice::deInit() { 
+    auto &bus = *static_cast<ECBusHandler *>(&getController()); 
+    ECBusDeviceHandler *device = bus.getDevice(mIndex);
+    if (device != nullptr && device->mDelegate == this) {
+      device->mDelegate = nullptr;
+    }
+  }
+
+  void FORTE_ECDevice::initHandles() {
+    if (!QI()) {
+      return;
+    }
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *device = static_cast<ECDeviceHandler *>(bus.getDevice(mIndex));
+    if (nullptr == device) {
+      return;
+    }
+    if (bus.isLoopPrepared()) {
+      bus.esiConfigurator().remapDeviceIOHandles(static_cast<TForteUInt32>(Config().ProductCode), device, *this);
+    } else {
+      bus.esiConfigurator().initDeviceIOHandles(static_cast<TForteUInt32>(Config().ProductCode), device, *this);
+    }
+  }
+
+  void FORTE_ECDevice::onDeviceStatus(ECBusDeviceHandler::DeviceStatus paStatus, ECBusDeviceHandler::DeviceStatus) {
+    switch (paStatus) {
+      case ECBusDeviceHandler::OK: STATUS() = scmOK; break;
+      case ECBusDeviceHandler::Error: STATUS() = u"Error"_WSTRING; break;
+      case ECBusDeviceHandler::NotInitialized: STATUS() = u"NotInitialized"_WSTRING; break;
+      default: STATUS() = u"Unknown"_WSTRING; break;
+    }
+    sendOutputEvent(scmEventINDID, getEventChainExecutor());
+  }
+
+  void FORTE_ECDevice::onDeviceDestroy() {
+    deInit();
+    QO() = false_BOOL;
+    STATUS() = u"Device destroyed"_WSTRING;
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/types/ECDevice.h
+++ b/modules/ethercat/types/ECDevice.h
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECBusAdapter.h"
+#include "../structs/ECDeviceConfig.h"
+#include "../device/bus_device_handler.h"
+#include "forte/adapter.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_wstring.h"
+#include "forte/io/configFB/io_slave_multi.h"
+#include "forte/io/device/io_controller.h"
+#include "forte/genfb.h"
+#include <string>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECDevice : public CGenFunctionBlock<forte::io::IOConfigFBMultiSlave>, public ECBusDeviceHandler::Delegate {
+      DECLARE_GENERIC_FIRMWARE_FB(FORTE_ECDevice)
+
+    public:
+      FORTE_ECDevice(forte::StringId paInstanceNameId,
+                    CFBContainer &paContainer,
+                    ECBusDeviceHandler::DeviceType paDeviceType = ECBusDeviceHandler::DeviceType::ECDevice);
+      ~FORTE_ECDevice() override;
+
+      void onDeviceStatus(ECBusDeviceHandler::DeviceStatus paStatus, ECBusDeviceHandler::DeviceStatus paOldStatus) override;
+      void onDeviceDestroy() override;
+
+      CIEC_ECDeviceConfig &Config() {
+        return var_Config;
+      }
+
+      size_t numInMappings() const {
+        return mNumInPdus;
+      }
+
+      size_t numOutMappings() const {
+        return mNumOutPdus;
+      }
+
+      CIEC_ANY *mappingDi(TPortId paRelativeIndex);
+      void registerMappedHandle(forte::io::IODeviceController::HandleDescriptor &paDesc);
+
+    protected:
+      virtual bool createSlaveHandler() override;
+      const char *init() override;
+      void deInit() override;
+      void initHandles() override;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+
+      size_t getGenDIOffset() override {
+        return 2;
+      }
+
+      size_t getGenDOOffset() override {
+        return 2;
+      }
+
+      void createGenInputData() override;
+
+      CIEC_ANY *getDI(TPortId paIndex) override;
+      CIEC_ANY *getDO(TPortId paIndex) override;
+
+      CEventConnection *getEOConUnchecked(TPortId paIndex) override;
+      CDataConnection **getDIConUnchecked(TPortId paIndex) override;
+      CDataConnection *getDOConUnchecked(TPortId paIndex) override;
+
+      forte::IPlugPin *getPlugPinUnchecked(size_t paIndex) override;
+      forte::ISocketPin *getSocketPinUnchecked(size_t paIndex) override;
+
+      CIEC_BOOL var_QI;
+      CIEC_ECDeviceConfig var_Config;
+      CIEC_BOOL var_QO;
+      CIEC_WSTRING var_STATUS;
+
+      CEventConnection conn_MAPO;
+      CEventConnection conn_IND;
+
+      CDataConnection *conn_QI;
+      CDataConnection *conn_Config;
+
+      COutDataConnection<CIEC_BOOL> conn_QO;
+      COutDataConnection<CIEC_WSTRING> conn_STATUS;
+
+      forte::CSocketPin<FORTE_ECBusAdapter_Socket> var_BusAdapterIn;
+      forte::CPlugPin<FORTE_ECBusAdapter_Plug> var_BusAdapterOut;
+
+      std::unique_ptr<CIEC_ANY *[]> mGenDIs;
+
+    protected:
+      static const TForteUInt8 scmSlaveConfigurationIO[];
+      static const TForteUInt8 scmSlaveConfigurationIONum;
+
+      bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
+      void configureDIDOs(const char *paDIConfigString, const char *paDOConfigString, SFBInterfaceSpec &paInterfaceSpec);
+
+      std::vector<StringId> mDiNames;
+      std::vector<StringId> mDoNames;
+
+      size_t mNumInPdus{};
+      size_t mNumOutPdus{};
+      std::string mLastError;
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/types/ECModule.cpp
+++ b/modules/ethercat/types/ECModule.cpp
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "ECModule.h"
+
+#include "../handler/bus.h"
+#include "../device/ec_device.h"
+#include "../device/ec_module.h"
+#include "../utils/esi_io_configurator.h"
+#include "forte/util/string_utils.h"
+
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+  namespace {
+    const auto cSocketNameIds = std::array{"ModuleAdapterIn"_STRID};
+    const auto cPlugNameIds = std::array{"ModuleAdapterOut"_STRID};
+    const auto cEventInputNameIds = std::array{"MAP"_STRID};
+    const auto cEventOutputNameIds = std::array{"MAPO"_STRID, "IND"_STRID};
+    const auto cEventInputTypeIds = std::array{"Event"_STRID};
+    const auto cEventOutputTypeIds = std::array{"Event"_STRID, "Event"_STRID};
+  } // namespace
+
+  DEFINE_GENERIC_FIRMWARE_FB(FORTE_ECModule, "eclipse4diac::io::ethercat::GEN_ECModule"_STRID)
+
+  const TForteUInt8 FORTE_ECModule::scmSlaveConfigurationIO[] = {};
+  const TForteUInt8 FORTE_ECModule::scmSlaveConfigurationIONum = 0;
+
+  FORTE_ECModule::FORTE_ECModule(const forte::StringId paInstanceNameId, CFBContainer &paContainer) :
+      CGenFunctionBlock<forte::io::IOConfigFBMultiSlave>(paContainer,
+                                           paInstanceNameId,
+                                           scmSlaveConfigurationIO,
+                                           scmSlaveConfigurationIONum,
+                                           static_cast<int>(ECBusDeviceHandler::DeviceType::ECModule)),
+      conn_MAPO(*this, 0),
+      conn_IND(*this, 1),
+      conn_QI(nullptr),
+      conn_Config(nullptr),
+      conn_QO(*this, 0, var_QO),
+      conn_STATUS(*this, 1, var_STATUS),    
+      var_ModuleAdapterIn("ModuleAdapterIn"_STRID, *this, 0),
+      var_ModuleAdapterOut("ModuleAdapterOut"_STRID, *this, 1) {
+  }
+
+  FORTE_ECModule::~FORTE_ECModule() {
+    const size_t numDIs = getFBInterfaceSpec().getNumDIs();
+    const size_t genOffset = getGenDIOffset();
+    const size_t safeGenDINums = (numDIs > genOffset) ? (numDIs - genOffset) : 0;
+    for (size_t i = 0; i < safeGenDINums && mGenDIs; ++i) {
+      delete mGenDIs[i];
+    }
+  }
+
+  void FORTE_ECModule::readInputData(const TEventID paEIID) {
+    if (paEIID == scmEventMAPID) {
+      readData(0, var_QI, conn_QI);
+      readData(1, var_Config, conn_Config);
+      for (TPortId i = 0; i < static_cast<TPortId>(getGenDINums()); ++i) {
+        readData(static_cast<TPortId>(i + getGenDIOffset()), *mGenDIs[i], mGenDIConns[i]);
+      }
+    }
+  }
+
+  void FORTE_ECModule::writeOutputData(const TEventID paEIID) {
+    const size_t numDIs = getFBInterfaceSpec().getNumDIs();
+    switch (paEIID) {
+      case scmEventMAPOID: writeData(numDIs + 0, var_QO, conn_QO); break;
+      case scmEventINDID:
+        writeData(numDIs + 0, var_QO, conn_QO);
+        writeData(numDIs + 1, var_STATUS, conn_STATUS);
+        break;
+      default: break;
+    }
+  }
+
+  CIEC_ANY *FORTE_ECModule::mappingDi(const TPortId paRelativeIndex) {
+    return getDI(static_cast<TPortId>(getGenDIOffset() + paRelativeIndex));
+  }
+
+  void FORTE_ECModule::registerMappedHandle(forte::io::IODeviceController::HandleDescriptor &paDesc) {
+    initHandle(paDesc);
+  }
+
+  CIEC_ANY *FORTE_ECModule::getDI(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QI;
+      case 1: return &var_Config;
+      default: return mGenDIs[paIndex - getGenDIOffset()];
+    }
+  }
+
+  CIEC_ANY *FORTE_ECModule::getDO(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &var_QO;
+      case 1: return &var_STATUS;
+    }
+    return nullptr;
+  }
+
+  CEventConnection *FORTE_ECModule::getEOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_MAPO;
+      case 1: return &conn_IND;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  CDataConnection **FORTE_ECModule::getDIConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QI;
+      case 1: return &conn_Config;
+      default: return CGenFunctionBlock<forte::io::IOConfigFBMultiSlave>::getDIConUnchecked(paIndex);
+    }
+  }
+
+  CDataConnection *FORTE_ECModule::getDOConUnchecked(const TPortId paIndex) {
+    switch (paIndex) {
+      case 0: return &conn_QO;
+      case 1: return &conn_STATUS;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  forte::IPlugPin *FORTE_ECModule::getPlugPinUnchecked(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_ModuleAdapterOut;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  forte::ISocketPin *FORTE_ECModule::getSocketPinUnchecked(const size_t paIndex) {
+    switch (paIndex) {
+      case 0: return &var_ModuleAdapterIn;
+      default: break;
+    }
+    return nullptr;
+  }
+
+  void FORTE_ECModule::createGenInputData() {
+    const size_t n = getGenDINums();
+    mGenDIs = std::make_unique<CIEC_ANY *[]>(n);
+    for (size_t i = 0; i < n; ++i) {
+      mGenDIs[i] = new CIEC_WSTRING();
+    }
+  }
+
+  bool FORTE_ECModule::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    std::string tempstring(paConfigString);
+    const char *sParamA = nullptr;
+    const char *sParamB = nullptr;
+    const size_t firstUnderscore = tempstring.find('_');
+    const size_t secondUnderscore =
+        tempstring.find('_', firstUnderscore == std::string::npos ? 0 : firstUnderscore + 1);
+    if (firstUnderscore != std::string::npos && secondUnderscore != std::string::npos &&
+        firstUnderscore + 1 < tempstring.size() && secondUnderscore + 1 < tempstring.size()) {
+      tempstring[secondUnderscore] = '\0';
+      sParamA = &(tempstring[firstUnderscore + 1]);
+      sParamB = &(tempstring[secondUnderscore + 1]);
+    }
+    if (sParamB == nullptr) {
+      return false;
+    }
+
+    configureDIDOs(sParamA, sParamB, paInterfaceSpec);
+    paInterfaceSpec.mEINames = cEventInputNameIds;
+    paInterfaceSpec.mEITypeNames = cEventInputTypeIds;
+    paInterfaceSpec.mEONames = cEventOutputNameIds;
+    paInterfaceSpec.mEOTypeNames = cEventOutputTypeIds;
+    paInterfaceSpec.mSocketNames = cSocketNameIds;
+    paInterfaceSpec.mPlugNames = cPlugNameIds;
+    return true;
+  }
+
+  void FORTE_ECModule::configureDIDOs(const char *paDIConfigString,
+                                      const char *paDOConfigString,
+                                      SFBInterfaceSpec &paInterfaceSpec) {
+    mDiNames.clear();
+    mDoNames.clear();
+    mDiNames.emplace_back("QI"_STRID);
+    mDiNames.emplace_back("Config"_STRID);
+    mNumInPdus = static_cast<size_t>(util::strtol(paDIConfigString, nullptr, 10));
+    mNumOutPdus = static_cast<size_t>(util::strtol(paDOConfigString, nullptr, 10));
+    generateGenericInterfacePointNameArray("IN_", mDiNames, mNumInPdus);
+    generateGenericInterfacePointNameArray("OUT_", mDiNames, mNumOutPdus);
+    mDoNames.emplace_back("QO"_STRID);
+    mDoNames.emplace_back("STATUS"_STRID);
+    paInterfaceSpec.mDINames = mDiNames;
+    paInterfaceSpec.mDONames = mDoNames;
+  }
+
+  bool FORTE_ECModule::createSlaveHandler() {
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *handler = new ECModuleHandler(&bus, mIndex);
+    ECModuleHandler::Config cfg{};
+    cfg.mModuleIdent = static_cast<TForteUInt32>(Config().ModuleIdent);
+    cfg.mSlot = static_cast<TForteUInt16>(Config().Slot);
+    handler->setConfig(&cfg);
+    handler->mDelegate = this;
+    bus.addDevice(handler);
+    return true;
+  }
+
+  const char *FORTE_ECModule::init() {
+    const auto moduleIdent = static_cast<TForteUInt32>(Config().ModuleIdent);
+    std::string errMsg;
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    if (!bus.esiConfigurator().validateModule(moduleIdent, errMsg)) {
+      mLastError = errMsg;
+      return mLastError.c_str();
+    }
+    return nullptr;
+  }
+
+  void FORTE_ECModule::deInit() {
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    ECBusDeviceHandler *device = bus.getDevice(mIndex);
+    if (device != nullptr && device->mDelegate == this) {
+      device->mDelegate = nullptr;
+    }
+  }
+
+  void FORTE_ECModule::initHandles() {
+    auto &bus = *static_cast<ECBusHandler *>(&getController());
+    auto *module = static_cast<ECModuleHandler *>(bus.getDevice(mIndex));
+    if (nullptr == module) {
+      return;
+    }
+    ECBusDeviceHandler *parent = bus.getDevice(mIndex / 100 - 1);
+    auto *device = static_cast<ECDeviceHandler *>(parent);
+    if (nullptr == device) {
+      return;
+    }
+    if (bus.isLoopPrepared()) {
+      bus.esiConfigurator().remapModuleIOHandles(module->moduleIdent(), device, module, *this);
+    } else {
+      bus.esiConfigurator().initModuleIOHandles(module->moduleIdent(), device, module, *this);
+    }
+  }
+
+  void FORTE_ECModule::onDeviceStatus(ECBusDeviceHandler::DeviceStatus paStatus, ECBusDeviceHandler::DeviceStatus) {
+    switch (paStatus) {
+      case ECBusDeviceHandler::OK: STATUS() = scmOK; break;
+      case ECBusDeviceHandler::Error: STATUS() = u"Error"_WSTRING; break;
+      case ECBusDeviceHandler::NotInitialized: STATUS() = u"NotInitialized"_WSTRING; break;
+      default: STATUS() = u"Unknown"_WSTRING; break;
+    }
+    sendOutputEvent(scmEventINDID, getEventChainExecutor());
+  }
+
+  void FORTE_ECModule::onDeviceDestroy() {
+    deInit();
+    QO() = false_BOOL;
+    STATUS() = u"Device destroyed"_WSTRING;
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/ECModule.h
+++ b/modules/ethercat/types/ECModule.h
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECBusAdapter.h"
+#include "../structs/ECModuleConfig.h"
+#include "../device/bus_device_handler.h"
+#include "forte/adapter.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_wstring.h"
+#include "forte/io/configFB/io_slave_multi.h"
+#include "forte/io/device/io_controller.h"
+#include "forte/genfb.h"
+#include <string>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class FORTE_ECModule : public CGenFunctionBlock<forte::io::IOConfigFBMultiSlave>, public ECBusDeviceHandler::Delegate {
+      DECLARE_GENERIC_FIRMWARE_FB(FORTE_ECModule)
+
+    public:
+      FORTE_ECModule(forte::StringId paInstanceNameId, CFBContainer &paContainer);
+      ~FORTE_ECModule() override;
+
+      void onDeviceStatus(ECBusDeviceHandler::DeviceStatus paStatus, ECBusDeviceHandler::DeviceStatus paOldStatus) override;
+      void onDeviceDestroy() override;
+
+      size_t numInMappings() const {
+        return mNumInPdus;
+      }
+
+      CIEC_ECModuleConfig &Config() {
+        return var_Config;
+      }
+
+      CIEC_ANY *mappingDi(TPortId paRelativeIndex);
+      void registerMappedHandle(forte::io::IODeviceController::HandleDescriptor &paDesc);
+
+    protected:
+      bool createSlaveHandler() override;
+      const char *init() override;
+      void deInit() override;
+      void initHandles() override;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+      //void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      size_t getGenDIOffset() override {
+        return 2;
+      }
+
+      size_t getGenDOOffset() override {
+        return 2;
+      }
+
+      FORTE_ECBusAdapter &ModuleAdapterOut() {
+        return (*static_cast<FORTE_ECBusAdapter *>(getPlugPinUnchecked(0)->getAdapterBlock()));
+      }
+
+      FORTE_ECBusAdapter &ModuleAdapterIn() {
+        return (*static_cast<FORTE_ECBusAdapter *>(getSocketPinUnchecked(0)->getAdapterBlock()));
+      }
+
+      void createGenInputData() override;
+
+      CIEC_ANY *getDI(TPortId paIndex) override;
+      CIEC_ANY *getDO(TPortId paIndex) override;
+
+      CEventConnection *getEOConUnchecked(TPortId paIndex) override;
+      CDataConnection **getDIConUnchecked(TPortId paIndex) override;
+      CDataConnection *getDOConUnchecked(TPortId paIndex) override;
+
+      forte::IPlugPin *getPlugPinUnchecked(size_t paIndex) override;
+      forte::ISocketPin *getSocketPinUnchecked(size_t paIndex) override;
+
+      CIEC_BOOL var_QI;
+      CIEC_ECModuleConfig var_Config;
+      CIEC_BOOL var_QO;
+      CIEC_WSTRING var_STATUS;
+
+      CEventConnection conn_MAPO;
+      CEventConnection conn_IND;
+
+      CDataConnection *conn_QI;
+      CDataConnection *conn_Config;
+
+      COutDataConnection<CIEC_BOOL> conn_QO;
+      COutDataConnection<CIEC_WSTRING> conn_STATUS;
+   
+      forte::CSocketPin<FORTE_ECBusAdapter_Socket> var_ModuleAdapterIn;
+      forte::CPlugPin<FORTE_ECBusAdapter_Plug> var_ModuleAdapterOut;
+
+      std::unique_ptr<CIEC_ANY *[]> mGenDIs;
+
+      std::vector<StringId> mDiNames;
+      std::vector<StringId> mDoNames;
+
+      size_t mNumInPdus{};
+      size_t mNumOutPdus{};
+      std::string mLastError;
+
+      static const TForteUInt8 scmSlaveConfigurationIO[];
+      static const TForteUInt8 scmSlaveConfigurationIONum;
+
+      bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
+
+      void configureDIDOs(const char *paDIConfigString, const char *paDOConfigString, SFBInterfaceSpec &paInterfaceSpec);
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECCoupler_fbt.cpp
+++ b/modules/ethercat/types/GEN_ECCoupler_fbt.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "GEN_ECCoupler_fbt.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_ECCoupler, "eclipse4diac::io::ethercat::GEN_ECCoupler"_STRID)
+
+  GEN_ECCoupler::GEN_ECCoupler(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      FORTE_ECCoupler(paInstanceNameId, paContainer) {
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECCoupler_fbt.h
+++ b/modules/ethercat/types/GEN_ECCoupler_fbt.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECCoupler.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class GEN_ECCoupler : public FORTE_ECCoupler {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_ECCoupler)
+
+    public:
+      GEN_ECCoupler(const StringId paInstanceNameId, CFBContainer &paContainer);
+      ~GEN_ECCoupler() override = default;
+
+      template<typename... Args>
+      void evt_MAP(Args &&...paArgs) {
+        writeInputArguments(std::forward<Args>(paArgs)...);
+        receiveInputEvent(scmEventMAPID, nullptr);
+        readOutputArguments(std::forward<Args>(paArgs)...);
+      }
+
+      template<typename ...Args>
+        void operator()(Args &&...paArgs) {
+        evt_INIT(std::forward<Args>(paArgs)...);
+      }
+  };
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECDevice_fbt.cpp
+++ b/modules/ethercat/types/GEN_ECDevice_fbt.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "GEN_ECDevice_fbt.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_ECDevice, "eclipse4diac::io::ethercat::GEN_ECDevice"_STRID)
+
+  GEN_ECDevice::GEN_ECDevice(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      FORTE_ECDevice(paInstanceNameId, paContainer) {
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECDevice_fbt.h
+++ b/modules/ethercat/types/GEN_ECDevice_fbt.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECDevice.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class GEN_ECDevice : public FORTE_ECDevice {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_ECDevice)
+
+    public:
+      GEN_ECDevice(const StringId paInstanceNameId, CFBContainer &paContainer);
+      ~GEN_ECDevice() override = default;
+
+      template<typename... Args>
+      void evt_MAP(Args &&...paArgs) {
+        writeInputArguments(std::forward<Args>(paArgs)...);
+        receiveInputEvent(scmEventMAPID, nullptr);
+        readOutputArguments(std::forward<Args>(paArgs)...);
+      }
+
+      template<typename ...Args>
+        void operator()(Args &&...paArgs) {
+        evt_INIT(std::forward<Args>(paArgs)...);
+      }
+  };
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECModule_fbt.cpp
+++ b/modules/ethercat/types/GEN_ECModule_fbt.cpp
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "GEN_ECModule_fbt.h"
+
+using namespace forte::literals;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_ECModule, "eclipse4diac::io::ethercat::GEN_ECModule"_STRID)
+
+  GEN_ECModule::GEN_ECModule(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      FORTE_ECModule(paInstanceNameId, paContainer) {
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/types/GEN_ECModule_fbt.h
+++ b/modules/ethercat/types/GEN_ECModule_fbt.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "ECModule.h"
+
+namespace forte::eclipse4diac::io::ethercat {
+  class GEN_ECModule : public FORTE_ECModule {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_ECModule)
+
+    public:
+      GEN_ECModule(const StringId paInstanceNameId, CFBContainer &paContainer);
+      ~GEN_ECModule() override = default;
+
+      template<typename... Args>
+      void evt_MAP(Args &&...paArgs) {
+        writeInputArguments(std::forward<Args>(paArgs)...);
+        receiveInputEvent(scmEventMAPID, nullptr);
+        readOutputArguments(std::forward<Args>(paArgs)...);
+      }
+
+      template<typename ...Args>
+        void operator()(Args &&...paArgs) {
+        evt_INIT(std::forward<Args>(paArgs)...);
+      }
+  };
+} // namespace forte::eclipse4diac::io::ethercat
+

--- a/modules/ethercat/utils/esi_catalog.cpp
+++ b/modules/ethercat/utils/esi_catalog.cpp
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "esi_catalog.h"
+#include "esi_xml_utils.h"
+
+#include "forte/util/devlog.h"
+
+#include <cstring>
+#include <filesystem>
+#include <tinyxml.h>
+#include <unistd.h>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  namespace {
+    const std::string scmEmptyVendor;
+
+    std::string resolveDevicesFolder() {
+      char exePath[4096];
+      const ssize_t len = readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
+      if (len <= 0) {
+        return {};
+      }
+      exePath[len] = '\0';
+      char *lastSlash = strrchr(exePath, '/');
+      if (nullptr == lastSlash) {
+        return {};
+      }
+      *lastSlash = '\0';
+      return std::string(exePath) + "/devices/";
+    }
+  } // namespace
+
+  EsiCatalog::EsiCatalog() {
+    mDevicesFolder = resolveDevicesFolder();
+    buildIndex();
+  }
+
+  EsiCatalog::~EsiCatalog() = default;
+
+  void EsiCatalog::buildIndex() {
+    if (mDevicesFolder.empty() || !std::filesystem::exists(mDevicesFolder)) {
+      if (!mDevicesFolder.empty()) {
+        DEVLOG_WARNING("ethercat[EsiCatalog]: ESI folder not found: %s\n", mDevicesFolder.c_str());
+      }
+      return;
+    }
+
+    for (const auto &entry : std::filesystem::directory_iterator(mDevicesFolder)) {
+      if (!entry.is_regular_file()) {
+        continue;
+      }
+      const std::string extension = entry.path().extension().string();
+      if (!(extension == ".xml" || extension == ".XML")) {
+        continue;
+      }
+      indexEsiFile(entry.path().string());
+    }
+  }
+
+  void EsiCatalog::indexEsiFile(const std::string &paFilePath) {
+    TiXmlDocument doc(paFilePath.c_str());
+    if (!doc.LoadFile()) {
+      return;
+    }
+    auto *root = doc.RootElement();
+    if (nullptr == root) {
+      return;
+    }
+    auto *descriptions = root->FirstChildElement("Descriptions");
+    if (nullptr == descriptions) {
+      return;
+    }
+
+    std::string vendorName;
+    if (auto *vendor = root->FirstChildElement("Vendor")) {
+      if (auto *name = vendor->FirstChildElement("Name"); name && name->GetText()) {
+        vendorName = name->GetText();
+      }
+    }
+
+    if (auto *devices = descriptions->FirstChildElement("Devices")) {
+      for (auto *device = devices->FirstChildElement("Device"); device != nullptr;
+           device = device->NextSiblingElement("Device")) {
+        if (auto *type = device->FirstChildElement("Type")) {
+          const char *pc = type->Attribute("ProductCode");
+          if (pc) {
+            const uint32_t key = parseEcNumber(pc);
+            mDeviceKeyToPath[key] = paFilePath;
+            mDeviceVendorMap[key] = vendorName;
+          }
+        }
+      }
+    }
+
+    if (auto *modules = descriptions->FirstChildElement("Modules")) {
+      for (auto *module = modules->FirstChildElement("Module"); module != nullptr;
+           module = module->NextSiblingElement("Module")) {
+        if (auto *type = module->FirstChildElement("Type")) {
+          const char *mi = type->Attribute("ModuleIdent");
+          if (mi) {
+            const uint32_t key = parseEcNumber(mi);
+            mModuleKeyToPath[key] = paFilePath;
+            mModuleVendorMap[key] = vendorName;
+          }
+        }
+      }
+    }
+  }
+
+  TiXmlDocument *EsiCatalog::loadDocument(const std::string &paFilePath) {
+    if (auto existing = mDocuments.find(paFilePath); existing != mDocuments.end()) {
+      return existing->second.get();
+    }
+    auto doc = std::make_unique<TiXmlDocument>(paFilePath.c_str());
+    if (!doc->LoadFile()) {
+      return nullptr;
+    }
+    auto *rawDoc = doc.get();
+    mDocuments.emplace(paFilePath, std::move(doc));
+    return rawDoc;
+  }
+
+  bool EsiCatalog::findDeviceInDocument(TiXmlDocument *paDocument,
+                                          uint32_t paProductCode,
+                                          TiXmlElement *&paDeviceElement,
+                                          std::string &paErrMsg) {
+    if (nullptr == paDocument || nullptr == paDocument->RootElement()) {
+      paErrMsg = "Invalid ESI XML root";
+      return false;
+    }
+    auto *descriptions = paDocument->RootElement()->FirstChildElement("Descriptions");
+    auto *devices = descriptions ? descriptions->FirstChildElement("Devices") : nullptr;
+    if (nullptr == devices) {
+      paErrMsg = "No Devices section in ESI";
+      return false;
+    }
+    for (auto *device = devices->FirstChildElement("Device"); device; device = device->NextSiblingElement("Device")) {
+      auto *type = device->FirstChildElement("Type");
+      if (!type) {
+        continue;
+      }
+      const char *pc = type->Attribute("ProductCode");
+      if (pc && parseEcNumber(pc) == paProductCode) {
+        paDeviceElement = device;
+        return true;
+      }
+    }
+    paErrMsg = std::string("Device ProductCode ") + std::to_string(paProductCode) + " not found in ESI";
+    return false;
+  }
+
+  bool EsiCatalog::findModuleInDocument(TiXmlDocument *paDocument,
+                                        uint32_t paModuleIdent,
+                                        TiXmlElement *&paModuleElement,
+                                        std::string &paErrMsg) {
+    if (nullptr == paDocument || nullptr == paDocument->RootElement()) {
+      paErrMsg = "Invalid ESI XML root";
+      return false;
+    }
+    auto *descriptions = paDocument->RootElement()->FirstChildElement("Descriptions");
+    auto *modules = descriptions ? descriptions->FirstChildElement("Modules") : nullptr;
+    if (nullptr == modules) {
+      paErrMsg = "No Modules section in ESI";
+      return false;
+    }
+    for (auto *module = modules->FirstChildElement("Module"); module; module = module->NextSiblingElement("Module")) {
+      auto *type = module->FirstChildElement("Type");
+      if (!type) {
+        continue;
+      }
+      const char *mi = type->Attribute("ModuleIdent");
+      if (mi && parseEcNumber(mi) == paModuleIdent) {
+        paModuleElement = module;
+        return true;
+      }
+    }
+    paErrMsg = std::string("ModuleIdent ") + std::to_string(paModuleIdent) + " not found in ESI";
+    return false;
+  }
+
+  TiXmlElement *EsiCatalog::resolveDevice(uint32_t paProductCode, std::string &paErrMsg) {
+    if (auto cached = mDeviceElements.find(paProductCode); cached != mDeviceElements.end()) {
+      return cached->second;
+    }
+
+    auto pathIt = mDeviceKeyToPath.find(paProductCode);
+    if (pathIt == mDeviceKeyToPath.end()) {
+      paErrMsg = std::string("No ESI file for ProductCode ") + std::to_string(paProductCode);
+      return nullptr;
+    }
+
+    TiXmlDocument *doc = loadDocument(pathIt->second);
+    if (nullptr == doc) {
+      paErrMsg = std::string("Failed to load ESI file: ") + pathIt->second;
+      return nullptr;
+    }
+
+    TiXmlElement *deviceElement = nullptr;
+    if (!findDeviceInDocument(doc, paProductCode, deviceElement, paErrMsg)) {
+      return nullptr;
+    }
+
+    mDeviceElements[paProductCode] = deviceElement;
+    return deviceElement;
+  }
+
+  TiXmlElement *EsiCatalog::resolveModule(uint32_t paModuleIdent, std::string &paErrMsg) {
+    if (auto cached = mModuleElements.find(paModuleIdent); cached != mModuleElements.end()) {
+      return cached->second;
+    }
+
+    auto pathIt = mModuleKeyToPath.find(paModuleIdent);
+    if (pathIt == mModuleKeyToPath.end()) {
+      paErrMsg = std::string("No ESI file for ModuleIdent ") + std::to_string(paModuleIdent);
+      return nullptr;
+    }
+
+    TiXmlDocument *doc = loadDocument(pathIt->second);
+    if (nullptr == doc) {
+      paErrMsg = std::string("Failed to load ESI file: ") + pathIt->second;
+      return nullptr;
+    }
+
+    TiXmlElement *moduleElement = nullptr;
+    if (!findModuleInDocument(doc, paModuleIdent, moduleElement, paErrMsg)) {
+      return nullptr;
+    }
+
+    mModuleElements[paModuleIdent] = moduleElement;
+    return moduleElement;
+  }
+
+  bool EsiCatalog::validateDevice(uint32_t paProductCode, std::string &paErrMsg) {
+    return resolveDevice(paProductCode, paErrMsg) != nullptr;
+  }
+
+  bool EsiCatalog::validateModule(uint32_t paModuleIdent, std::string &paErrMsg) {
+    return resolveModule(paModuleIdent, paErrMsg) != nullptr;
+  }
+
+  const std::string &EsiCatalog::vendorForDevice(uint32_t paProductCode) const {
+    auto it = mDeviceVendorMap.find(paProductCode);
+    return it != mDeviceVendorMap.end() ? it->second : scmEmptyVendor;
+  }
+
+  const std::string &EsiCatalog::vendorForModule(uint32_t paModuleIdent) const {
+    auto it = mModuleVendorMap.find(paModuleIdent);
+    return it != mModuleVendorMap.end() ? it->second : scmEmptyVendor;
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/utils/esi_catalog.h
+++ b/modules/ethercat/utils/esi_catalog.h
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+
+class TiXmlDocument;
+class TiXmlElement;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class EsiCatalog {
+    public:
+      EsiCatalog();
+      ~EsiCatalog();
+
+      EsiCatalog(const EsiCatalog &) = delete;
+      EsiCatalog &operator=(const EsiCatalog &) = delete;
+
+      bool validateDevice(uint32_t paProductCode, std::string &paErrMsg);
+      bool validateModule(uint32_t paModuleIdent, std::string &paErrMsg);
+
+      TiXmlElement *resolveDevice(uint32_t paProductCode, std::string &paErrMsg);
+      TiXmlElement *resolveModule(uint32_t paModuleIdent, std::string &paErrMsg);
+
+      const std::string &vendorForDevice(uint32_t paProductCode) const;
+      const std::string &vendorForModule(uint32_t paModuleIdent) const;
+
+    private:
+      void buildIndex();
+      void indexEsiFile(const std::string &paFilePath);
+      TiXmlDocument *loadDocument(const std::string &paFilePath);
+      bool findDeviceInDocument(TiXmlDocument *paDocument,
+                                uint32_t paProductCode,
+                                TiXmlElement *&paDeviceElement,
+                                std::string &paErrMsg);
+      bool findModuleInDocument(TiXmlDocument *paDocument,
+                                uint32_t paModuleIdent,
+                                TiXmlElement *&paModuleElement,
+                                std::string &paErrMsg);
+
+      std::string mDevicesFolder;
+      std::map<uint32_t, std::string> mDeviceKeyToPath;
+      std::map<uint32_t, std::string> mModuleKeyToPath;
+      std::map<uint32_t, std::string> mDeviceVendorMap;
+      std::map<uint32_t, std::string> mModuleVendorMap;
+      std::map<std::string, std::unique_ptr<TiXmlDocument>> mDocuments;
+      std::map<uint32_t, TiXmlElement *> mDeviceElements;
+      std::map<uint32_t, TiXmlElement *> mModuleElements;
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/utils/esi_io_configurator.cpp
+++ b/modules/ethercat/utils/esi_io_configurator.cpp
@@ -1,0 +1,337 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#include "esi_io_configurator.h"
+
+#include "../device/ec_device.h"
+#include "../device/ec_module.h"
+#include "../handler/bus.h"
+#include "../types/ECDevice.h"
+#include "../types/ECModule.h"
+#include "esi_xml_utils.h"
+#include "forte/util/string_utils.h"
+
+#include <string>
+#include <tinyxml.h>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  namespace {
+
+    void applyVendorModulePdoEntryIndexCorrection(const std::string &paVendorName, uint16_t &paEntryIndex) {
+      if (paVendorName == "SiChuan Odot Automation System Co.,Ltd.") {
+        paEntryIndex = static_cast<uint16_t>(paEntryIndex + 1U);
+      } else if (paVendorName == "Inovance") {
+        paEntryIndex = static_cast<uint16_t>(paEntryIndex - 1U);
+      }
+    }
+
+  } // namespace
+
+  EsiIoConfigurator::EsiIoConfigurator(EsiCatalog &paCatalog) : mCatalog(paCatalog) {}
+
+  bool EsiIoConfigurator::validateDevice(uint32_t paProductCode, std::string &paErrMsg) {
+    return mCatalog.validateDevice(paProductCode, paErrMsg);
+  }
+
+  bool EsiIoConfigurator::validateModule(uint32_t paModuleIdent, std::string &paErrMsg) {
+    return mCatalog.validateModule(paModuleIdent, paErrMsg);
+  }
+
+  void EsiIoConfigurator::getPdoSizeInfo(TiXmlElement *paElement,
+                                           FORTE_ECDevice &paDevice,
+                                           uint16_t &paRcvBufferSize,
+                                           uint16_t &paSendBufferSize) {
+    int inputIndex = 0;
+    for (auto *tx = paElement->FirstChildElement("TxPdo"); tx; tx = tx->NextSiblingElement("TxPdo")) {
+      if (!tx->Attribute("Sm")) {
+        continue;
+      }
+      for (auto *entry = tx->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const auto *idVar = static_cast<const CIEC_WSTRING *>(paDevice.mappingDi(inputIndex++));
+        if (!idVar->getValue() || idVar->getValue()[0] == '\0') {
+          continue;
+        }
+        const char *bitLen = entry->FirstChildElement("BitLen")->GetText();
+        paRcvBufferSize += static_cast<uint16_t>(util::strtoul(bitLen, nullptr, 10));
+      }
+    }
+
+    inputIndex = static_cast<int>(paDevice.numInMappings());
+    for (auto *rx = paElement->FirstChildElement("RxPdo"); rx; rx = rx->NextSiblingElement("RxPdo")) {
+      if (!rx->Attribute("Sm")) {
+        continue;
+      }
+      for (auto *entry = rx->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const auto *idVar = static_cast<const CIEC_WSTRING *>(paDevice.mappingDi(inputIndex++));
+        if (!idVar->getValue() || idVar->getValue()[0] == '\0') {
+          continue;
+        }
+        const char *bitLen = entry->FirstChildElement("BitLen")->GetText();
+        paSendBufferSize += static_cast<uint16_t>(util::strtoul(bitLen, nullptr, 10));
+      }
+    }
+    paRcvBufferSize /= 8;
+    paSendBufferSize /= 8;
+  }
+
+  void EsiIoConfigurator::getPdoSizeInfo(TiXmlElement *paElement,
+                                           FORTE_ECModule &paDevice,
+                                           uint16_t &paRcvBufferSize,
+                                           uint16_t &paSendBufferSize) {
+    int inputIndex = 0;
+    for (auto *tx = paElement->FirstChildElement("TxPdo"); tx; tx = tx->NextSiblingElement("TxPdo")) {
+      if (!tx->Attribute("Sm")) {
+        continue;
+      }
+      for (auto *entry = tx->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const auto *idVar = static_cast<const CIEC_WSTRING *>(paDevice.mappingDi(inputIndex++));
+        if (!idVar->getValue() || idVar->getValue()[0] == '\0') {
+          continue;
+        }
+        const char *bitLen = entry->FirstChildElement("BitLen")->GetText();
+        paRcvBufferSize += static_cast<uint16_t>(util::strtoul(bitLen, nullptr, 10));
+      }
+    }
+
+    inputIndex = static_cast<int>(paDevice.numInMappings());
+    for (auto *rx = paElement->FirstChildElement("RxPdo"); rx; rx = rx->NextSiblingElement("RxPdo")) {
+      if (!rx->Attribute("Sm")) {
+        continue;
+      }
+      for (auto *entry = rx->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const auto *idVar = static_cast<const CIEC_WSTRING *>(paDevice.mappingDi(inputIndex++));
+        if (!idVar->getValue() || idVar->getValue()[0] == '\0') {
+          continue;
+        }
+        const char *bitLen = entry->FirstChildElement("BitLen")->GetText();
+        paSendBufferSize += static_cast<uint16_t>(util::strtoul(bitLen, nullptr, 10));
+      }
+    }
+    paRcvBufferSize /= 8;
+    paSendBufferSize /= 8;
+  }
+
+  void EsiIoConfigurator::parseDevicePdo(const std::string &paPdoType,
+                                         TiXmlElement *paElement,
+                                         ECDeviceHandler *paDeviceHandler,
+                                         FORTE_ECDevice &paDevice,
+                                         bool paRemapOnly) {
+    const SyncDir dir = (paPdoType == "RxPdo") ? SyncDir::Out : SyncDir::In;
+    int diIndex = (dir == SyncDir::In) ? 0 : static_cast<int>(paDevice.numInMappings());
+    int handleIndex = 0;
+    int entryIndexInInterface = 0;
+    int offset = 0;
+    for (auto *pdoElement = paElement->FirstChildElement(paPdoType.c_str()); pdoElement;
+         pdoElement = pdoElement->NextSiblingElement(paPdoType.c_str())) {
+      if (!pdoElement->Attribute("Sm")) {
+        continue;
+      }
+      const char *indexStr = pdoElement->FirstChildElement("Index")->GetText();
+      const uint16_t pdoIndex = static_cast<uint16_t>(parseEcNumber(indexStr));
+      if (!paRemapOnly) {
+        paDeviceHandler->mECDeviceModel.addPdo(pdoIndex, dir);
+      }
+
+      for (auto *entry = pdoElement->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const char *entryIndexText = entry->FirstChildElement("Index")->GetText();
+        const uint16_t entryIndex = static_cast<uint16_t>(parseEcNumber(entryIndexText));
+        const uint8_t subIndex =
+            static_cast<uint8_t>(util::strtoul(entry->FirstChildElement("SubIndex")->GetText(), nullptr, 10));
+        const uint8_t bitLen =
+            static_cast<uint8_t>(util::strtoul(entry->FirstChildElement("BitLen")->GetText(), nullptr, 10));
+        if (!paRemapOnly) {
+          paDeviceHandler->mECDeviceModel.addPdoEntry(pdoIndex, entryIndex, subIndex, bitLen);
+        }
+
+        auto *idVar = static_cast<CIEC_WSTRING *>(paDevice.mappingDi(diIndex + entryIndexInInterface++));
+        const char *idText = idVar->getValue();
+        if (nullptr == idText || idText[0] == '\0') {
+          continue;
+        }
+
+        std::string handleId{idText};
+        ECBusHandler::HandleDescriptor desc(handleId,
+                                            dir == SyncDir::In ? forte::io::IOMapper::Direction::In
+                                                               : forte::io::IOMapper::Direction::Out,
+                                            paDeviceHandler->index(),
+                                            static_cast<uint8_t>(offset),
+                                            static_cast<uint8_t>(bitLen / 8));
+        paDevice.registerMappedHandle(desc);
+        offset += bitLen / 8;
+
+        ECDeviceHandle *handle = (dir == SyncDir::In) ? paDeviceHandler->getInputHandle(handleIndex)
+                                                      : paDeviceHandler->getOutputHandle(handleIndex);
+        if (handle) {
+          if (paRemapOnly) {
+            paDeviceHandler->mECDeviceModel.restoreHandleDomainOffset(entryIndex, subIndex, handle->ecDomainOffsetPtr());
+          } else {
+            paDeviceHandler->mECDeviceModel.addEntryReg(entryIndex, subIndex, handle->ecDomainOffsetPtr());
+          }
+        }
+        handleIndex++;
+      }
+    }
+  }
+
+  void EsiIoConfigurator::parseModulePdo(const std::string &paPdoType,
+                                         TiXmlElement *paElement,
+                                         ECDeviceHandler *paDeviceHandler,
+                                         ECModuleHandler *paModuleHandler,
+                                         FORTE_ECModule &paDevice,
+                                         bool paRemapOnly) {
+    const std::string &vendorName = mCatalog.vendorForModule(paModuleHandler->moduleIdent());
+
+    const SyncDir dir = (paPdoType == "RxPdo") ? SyncDir::Out : SyncDir::In;
+    int diIndex = (dir == SyncDir::In) ? 0 : static_cast<int>(paDevice.numInMappings());
+    int handleIndex = 0;
+    int entryIndexInInterface = 0;
+    int offset = 0;
+    for (auto *pdoElement = paElement->FirstChildElement(paPdoType.c_str()); pdoElement;
+         pdoElement = pdoElement->NextSiblingElement(paPdoType.c_str())) {
+      if (!pdoElement->Attribute("Sm")) {
+        continue;
+      }
+      uint16_t pdoIndex = static_cast<uint16_t>(parseEcNumber(pdoElement->FirstChildElement("Index")->GetText()));
+      pdoIndex = static_cast<uint16_t>(pdoIndex + paDeviceHandler->mECDeviceModel.mSlotPdoInc * paModuleHandler->slot());
+      if (!paRemapOnly) {
+        paDeviceHandler->mECDeviceModel.addPdo(pdoIndex, dir);
+      }
+
+      for (auto *entry = pdoElement->FirstChildElement("Entry"); entry; entry = entry->NextSiblingElement("Entry")) {
+        const char *entryIndexText = entry->FirstChildElement("Index")->GetText();
+        uint16_t entryIndex = static_cast<uint16_t>(parseEcNumber(entryIndexText));
+        const uint8_t subIndex =
+            static_cast<uint8_t>(util::strtoul(entry->FirstChildElement("SubIndex")->GetText(), nullptr, 10));
+        const uint8_t bitLen =
+            static_cast<uint8_t>(util::strtoul(entry->FirstChildElement("BitLen")->GetText(), nullptr, 10));
+        applyVendorModulePdoEntryIndexCorrection(vendorName, entryIndex);
+        entryIndex =
+            static_cast<uint16_t>(entryIndex + paDeviceHandler->mECDeviceModel.mSlotIndexInc * paModuleHandler->slot());
+        if (!paRemapOnly) {
+          paDeviceHandler->mECDeviceModel.addPdoEntry(pdoIndex, entryIndex, subIndex, bitLen);
+        }
+
+        auto *idVar = static_cast<CIEC_WSTRING *>(paDevice.mappingDi(diIndex + entryIndexInInterface++));
+        const char *idText = idVar->getValue();
+        if (nullptr == idText || idText[0] == '\0') {
+          continue;
+        }
+
+        std::string handleId{idText};
+        ECBusHandler::HandleDescriptor desc(handleId,
+                                            dir == SyncDir::In ? forte::io::IOMapper::Direction::In
+                                                               : forte::io::IOMapper::Direction::Out,
+                                            paModuleHandler->index(),
+                                            static_cast<uint8_t>(offset),
+                                            static_cast<uint8_t>(bitLen / 8));
+        paDevice.registerMappedHandle(desc);
+        offset += bitLen / 8;
+
+        ECDeviceHandle *handle = (dir == SyncDir::In) ? paModuleHandler->getInputHandle(handleIndex)
+                                                      : paModuleHandler->getOutputHandle(handleIndex);
+        if (handle) {
+          if (paRemapOnly) {
+            paDeviceHandler->mECDeviceModel.restoreHandleDomainOffset(entryIndex, subIndex, handle->ecDomainOffsetPtr());
+          } else {
+            paDeviceHandler->mECDeviceModel.addEntryReg(entryIndex, subIndex, handle->ecDomainOffsetPtr());
+          }
+        }
+        handleIndex++;
+      }
+    }
+  }
+
+  void EsiIoConfigurator::initDeviceIOHandles(uint32_t paProductCode,
+                                              ECDeviceHandler *paDeviceHandler,
+                                              FORTE_ECDevice &paDevice) {
+    std::string errMsg;
+    TiXmlElement *deviceElement = mCatalog.resolveDevice(paProductCode, errMsg);
+    if (nullptr == deviceElement) {
+      return;
+    }
+
+    if (paDeviceHandler->mDeviceType == ECBusDeviceHandler::DeviceType::ECCoupler) {
+      if (auto *slots = deviceElement->FirstChildElement("Slots")) {
+        paDeviceHandler->mECDeviceModel.mSlotIndexInc =
+            static_cast<uint32_t>(util::strtoul(slots->Attribute("SlotIndexIncrement"), nullptr, 10));
+        paDeviceHandler->mECDeviceModel.mSlotPdoInc =
+            static_cast<uint32_t>(util::strtoul(slots->Attribute("SlotPdoIncrement"), nullptr, 10));
+      }
+    }
+
+    uint8_t smIndex = 0;
+    for (auto *sm = deviceElement->FirstChildElement("Sm"); sm; sm = sm->NextSiblingElement("Sm")) {
+      if (!sm->GetText()) {
+        smIndex++;
+        continue;
+      }
+      const std::string smText = sm->GetText();
+      if (smText == "Outputs" || smText == "Inputs") {
+        paDeviceHandler->mECDeviceModel.addSync(smIndex, smText == "Outputs" ? SyncDir::Out : SyncDir::In);
+      }
+      smIndex++;
+    }
+
+    uint16_t recvSize = 0;
+    uint16_t sendSize = 0;
+    getPdoSizeInfo(deviceElement, paDevice, recvSize, sendSize);
+    paDeviceHandler->initBuffer(sendSize, recvSize);
+    parseDevicePdo("TxPdo", deviceElement, paDeviceHandler, paDevice);
+    parseDevicePdo("RxPdo", deviceElement, paDeviceHandler, paDevice);
+  }
+
+  void EsiIoConfigurator::initModuleIOHandles(uint32_t paModuleIdent,
+                                              ECDeviceHandler *paDeviceHandler,
+                                              ECModuleHandler *paModuleHandler,
+                                              FORTE_ECModule &paDevice) {
+    std::string errMsg;
+    TiXmlElement *moduleElement = mCatalog.resolveModule(paModuleIdent, errMsg);
+    if (nullptr == moduleElement) {
+      return;
+    }
+
+    uint16_t recvSize = 0;
+    uint16_t sendSize = 0;
+    getPdoSizeInfo(moduleElement, paDevice, recvSize, sendSize);
+    paModuleHandler->initBuffer(sendSize, recvSize);
+    parseModulePdo("TxPdo", moduleElement, paDeviceHandler, paModuleHandler, paDevice);
+    parseModulePdo("RxPdo", moduleElement, paDeviceHandler, paModuleHandler, paDevice);
+  }
+
+  void EsiIoConfigurator::remapDeviceIOHandles(uint32_t paProductCode,
+                                               ECDeviceHandler *paDeviceHandler,
+                                               FORTE_ECDevice &paDevice) {
+    std::string errMsg;
+    TiXmlElement *deviceElement = mCatalog.resolveDevice(paProductCode, errMsg);
+    if (nullptr == deviceElement) {
+      return;
+    }
+    parseDevicePdo("TxPdo", deviceElement, paDeviceHandler, paDevice, true);
+    parseDevicePdo("RxPdo", deviceElement, paDeviceHandler, paDevice, true);
+  }
+
+  void EsiIoConfigurator::remapModuleIOHandles(uint32_t paModuleIdent,
+                                               ECDeviceHandler *paDeviceHandler,
+                                               ECModuleHandler *paModuleHandler,
+                                               FORTE_ECModule &paDevice) {
+    std::string errMsg;
+    TiXmlElement *moduleElement = mCatalog.resolveModule(paModuleIdent, errMsg);
+    if (nullptr == moduleElement) {
+      return;
+    }
+    parseModulePdo("TxPdo", moduleElement, paDeviceHandler, paModuleHandler, paDevice, true);
+    parseModulePdo("RxPdo", moduleElement, paDeviceHandler, paModuleHandler, paDevice, true);
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/utils/esi_io_configurator.h
+++ b/modules/ethercat/utils/esi_io_configurator.h
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "esi_catalog.h"
+
+#include <cstdint>
+#include <string>
+
+class TiXmlElement;
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  class ECDeviceHandler;
+  class ECModuleHandler;
+  class FORTE_ECDevice;
+  class FORTE_ECModule;
+
+  class EsiIoConfigurator {
+    public:
+      explicit EsiIoConfigurator(EsiCatalog &paCatalog);
+
+      bool validateDevice(uint32_t paProductCode, std::string &paErrMsg);
+      bool validateModule(uint32_t paModuleIdent, std::string &paErrMsg);
+
+      void initDeviceIOHandles(uint32_t paProductCode, ECDeviceHandler *paDeviceHandler, FORTE_ECDevice &paDevice);
+      void initModuleIOHandles(uint32_t paModuleIdent,
+                               ECDeviceHandler *paDeviceHandler,
+                               ECModuleHandler *paModuleHandler,
+                               FORTE_ECModule &paDevice);
+
+      void remapDeviceIOHandles(uint32_t paProductCode, ECDeviceHandler *paDeviceHandler, FORTE_ECDevice &paDevice);
+      void remapModuleIOHandles(uint32_t paModuleIdent,
+                                ECDeviceHandler *paDeviceHandler,
+                                ECModuleHandler *paModuleHandler,
+                                FORTE_ECModule &paDevice);
+
+    private:
+      void getPdoSizeInfo(TiXmlElement *paElement,
+                          FORTE_ECDevice &paDevice,
+                          uint16_t &paRcvBufferSize,
+                          uint16_t &paSendBufferSize);
+      void getPdoSizeInfo(TiXmlElement *paElement,
+                          FORTE_ECModule &paDevice,
+                          uint16_t &paRcvBufferSize,
+                          uint16_t &paSendBufferSize);
+
+      void parseDevicePdo(const std::string &paPdoType,
+                          TiXmlElement *paElement,
+                          ECDeviceHandler *paDeviceHandler,
+                          FORTE_ECDevice &paDevice,
+                          bool paRemapOnly = false);
+      void parseModulePdo(const std::string &paPdoType,
+                          TiXmlElement *paElement,
+                          ECDeviceHandler *paDeviceHandler,
+                          ECModuleHandler *paModuleHandler,
+                          FORTE_ECModule &paDevice,
+                          bool paRemapOnly = false);
+
+      EsiCatalog &mCatalog;
+  };
+
+} // namespace forte::eclipse4diac::io::ethercat

--- a/modules/ethercat/utils/esi_xml_utils.h
+++ b/modules/ethercat/utils/esi_xml_utils.h
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Sichuan Qunyuan Technology Co., Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Zijun Tang - initial API and implementation
+ *******************************************************************************/
+
+#pragma once
+
+#include "forte/util/string_utils.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace forte::eclipse4diac::io::ethercat {
+
+  inline uint32_t parseEcNumber(const char *paText) {
+    if (nullptr == paText) {
+      return 0;
+    }
+    if (strlen(paText) > 2 && paText[0] == '#' && (paText[1] == 'x' || paText[1] == 'X')) {
+      return static_cast<uint32_t>(util::strtoul(paText + 2, nullptr, 16));
+    }
+    if (strlen(paText) > 2 && paText[0] == '0' && (paText[1] == 'x' || paText[1] == 'X')) {
+      return static_cast<uint32_t>(util::strtoul(paText + 2, nullptr, 16));
+    }
+    return static_cast<uint32_t>(util::strtoul(paText, nullptr, 10));
+  }
+
+} // namespace forte::eclipse4diac::io::ethercat


### PR DESCRIPTION
## Summary

Second PR in the **4diac FORTE** split series from #967 (approved by @azoitl), building on #968 (merged core library).

### Planned PR 2 scope (IO function blocks)

- Add `IOConfigHandlerFBMultiSlave` base class for multi-device IO handlers
- Add EtherCAT IO function blocks: `ECController`, `ECBusAdapter`, `ECDevice`, `ECModule`, `ECCoupler`
- Add device/module config structs and `ECModuleHandler` device layer
- Unify **ControllerId** naming on `ECController` and `ECBusAdapter` per @azoitl review

### Planned PR 3 scope (runtime ESI + generic FB) — included here

Per the original #967 split, FORTE **PR 3** was *ESI parsing and generic FB support*. That runtime code is included in this PR because `ECDevice` and `ECModule` depend on it at configuration time:

- Runtime `EsiFileParser` (ESI XML → PDO/handle setup)
- Generic firmware FBs: `GEN_ECDevice`, `GEN_ECModule`, `GEN_ECCoupler`
- Link `tinyxml` for ESI parsing

After this PR merges, the **4diac FORTE EtherCAT module** from the #967 split series should be complete on the Linux/IgH path.

IgH API names and FORTE core IO base classes (`IOConfigFBMultiMaster`, `var_MasterId`, …) remain unchanged.

## Related PRs (separate tracks)

| Track | PR | Repository |
|-------|-----|------------|
| FORTE PR 1 (core) | #968 (merged) | 4diac-forte |
| FORTE PR 2+3 (this PR) | #982 | 4diac-forte |
| Build dependency recipes | eclipse-4diac/4diac-fbe#72 | 4diac-fbe |
| **IDE** (typelibrary, ESI import wizard, deployment) | eclipse-4diac/4diac-ide#2581 | **4diac IDE** |

The **4diac IDE** work is a **separate repository and PR series**, not FORTE PR 3. IDE #2581 covers typelibrary entries, ESI import, and deployment alignment (e.g. `ControllerId` on `ECController.fbt`).

## Test plan

- [x] Build 4diac FORTE with `FORTE_MODULE_ETHERCAT=ON` on Linux
- [ ] Deploy application with `ECController` + `ECDevice` chain
- [ ] Verify IO handle mapping after controller activation