### PR TITLE
Group codeql actions in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
Group codeql actions in dependabot updates to avoid version mismatch errors and unnecessary pull requests.