### PR TITLE
Fix copyright header for ethercat module in modules/CMakeLists.txt

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2025 Martin Erich Jobst
+# Copyright (c) 2025 Martin Erich Jobst, Sichuan Qunyuan Technology Co., Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +10,7 @@
 # Contributors:
 #    Martin Erich Jobst
 #      - initial API and implementation and/or initial documentation
-#    Sichuan Qunyuan Technology Co., Ltd.
+#    Zijun Tang
 #      - add ethercat module
 #############################################################################
 


### PR DESCRIPTION
## Summary

Follow-up to merged #968 — fixes the copyright header on `modules/CMakeLists.txt` per @azoitl's guidance on #982:

- Append `, Sichuan Qunyuan Technology Co., Ltd.` to the existing Copyright line
- List **Zijun Tang** (not the company) in Contributors

This file was already merged in #968; history is not rewritten.

## Test plan

- [x] Header-only change, no functional impact