### PR TITLE
Ensure unique IDs for adapter instances to prevent event overlap

### DIFF
--- a/modules/embrick/types/Slave.cpp
+++ b/modules/embrick/types/Slave.cpp
@@ -33,7 +33,7 @@ namespace forte::eclipse4diac::io::embrick {
       IOConfigFBMultiSlave(
           paSlaveConfigurationIO, paSlaveConfigurationIO_num, paType, paContainer, paInterfaceSpec, paInstanceNameId),
       var_BusAdapterIn("BusAdapterIn"_STRID, *this, 0),
-      var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0),
+      var_BusAdapterOut("BusAdapterOut"_STRID, *this, 1),
       mSlave(nullptr) {
   }
 

--- a/modules/ethercat/types/ECCoupler.cpp
+++ b/modules/ethercat/types/ECCoupler.cpp
@@ -28,7 +28,7 @@ namespace forte::eclipse4diac::io::ethercat {
 
   FORTE_ECCoupler::FORTE_ECCoupler(forte::StringId paInstanceNameId, CFBContainer &paContainer) :
       FORTE_ECDevice(paInstanceNameId, paContainer, ECBusDeviceHandler::DeviceType::ECCoupler),
-      var_ModuleAdapterOut("ModuleAdapterOut"_STRID, *this, 1) {
+      var_ModuleAdapterOut("ModuleAdapterOut"_STRID, *this, 2) {
   }
 
   bool FORTE_ECCoupler::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {

--- a/modules/ethercat/types/ECDevice.cpp
+++ b/modules/ethercat/types/ECDevice.cpp
@@ -40,13 +40,13 @@ namespace forte::eclipse4diac::io::ethercat {
   const TForteUInt8 FORTE_ECDevice::scmSlaveConfigurationIONum = 0;
 
   FORTE_ECDevice::FORTE_ECDevice(const forte::StringId paInstanceNameId,
-                               CFBContainer &paContainer,
-                               ECBusDeviceHandler::DeviceType paDeviceType) :
+                                 CFBContainer &paContainer,
+                                 ECBusDeviceHandler::DeviceType paDeviceType) :
       CGenFunctionBlock<forte::io::IOConfigFBMultiSlave>(paContainer,
-                                           paInstanceNameId,
-                                           scmSlaveConfigurationIO,
-                                           scmSlaveConfigurationIONum,
-                                           static_cast<int>(paDeviceType)),
+                                                         paInstanceNameId,
+                                                         scmSlaveConfigurationIO,
+                                                         scmSlaveConfigurationIONum,
+                                                         static_cast<int>(paDeviceType)),
       conn_MAPO(*this, 0),
       conn_IND(*this, 1),
       conn_QI(nullptr),
@@ -54,7 +54,7 @@ namespace forte::eclipse4diac::io::ethercat {
       conn_QO(*this, 0, var_QO),
       conn_STATUS(*this, 1, var_STATUS),
       var_BusAdapterIn("BusAdapterIn"_STRID, *this, 0),
-      var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0) {
+      var_BusAdapterOut("BusAdapterOut"_STRID, *this, 1) {
   }
 
   FORTE_ECDevice::~FORTE_ECDevice() {

--- a/modules/revolutionPi/fb/IORevPiAIO.cpp
+++ b/modules/revolutionPi/fb/IORevPiAIO.cpp
@@ -64,7 +64,7 @@ namespace forte::eclipse4diac::io::revpi {
       conn_QO(*this, 0, var_QO),
       conn_STATUS(*this, 1, var_STATUS),
       var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0),
-      var_BusAdapterIn("BusAdapterIn"_STRID, *this, 0) {};
+      var_BusAdapterIn("BusAdapterIn"_STRID, *this, 1) {};
 
   void FORTE_IORevPiAIO::initHandles() {
     uint8_t inputOffset = 0;

--- a/modules/revolutionPi/fb/IORevPiDIO.cpp
+++ b/modules/revolutionPi/fb/IORevPiDIO.cpp
@@ -110,7 +110,7 @@ namespace forte::eclipse4diac::io::revpi {
       conn_QO(*this, 0, var_QO),
       conn_STATUS(*this, 1, var_STATUS),
       var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0),
-      var_BusAdapterIn("BusAdapterIn"_STRID, *this, 0) {};
+      var_BusAdapterIn("BusAdapterIn"_STRID, *this, 1) {};
 
   void FORTE_IORevPiDIO::setInitialValues() {
     var_QI = 0_BOOL;

--- a/modules/wagokbus/types/WagoSlaveBase.cpp
+++ b/modules/wagokbus/types/WagoSlaveBase.cpp
@@ -24,7 +24,7 @@ WagoSlaveBase::WagoSlaveBase(int paType,
     IOConfigFBMultiSlave(
         scmSlaveConfigurationIO, scmSlaveConfigurationIONum, paType, paContainer, paInterfaceSpec, paInstanceNameId),
     var_BusAdapterOut("BusAdapterOut"_STRID, *this, 0),
-    var_BusAdapterIn("BusAdapterIn"_STRID, *this, 0) {
+    var_BusAdapterIn("BusAdapterIn"_STRID, *this, 1) {
 }
 
 void WagoSlaveBase::initWagoHandle(int paDIIndex,


### PR DESCRIPTION
Independent of plug or socket adapter instances need to be given a FB unique id. Otherwise input or output events of different adpaters will overlap and lead to wrong behavior. This was a problem in several IO modules.

FYI @wzj7531.