### PR TITLE
Regenerate RampLimitFS FORTE implementation for INIT fix

### DIFF
--- a/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/RampLimitFS_fbt.h
+++ b/modules/signalprocessing/include/forte/eclipse4diac/signalprocessing/RampLimitFS_fbt.h
@@ -6,41 +6,46 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.2.100.202608212006!
  ***
  *** Name: RampLimitFS
  *** Description: Setpoint Ramp: Step up and down Values with Fast and Slow mode
  *** Version:
- ***     1.0: 2024-09-20/Franz Höpfinger - HR Agrartechnik GmbH -
+ ***     3.1: 2026-08-12/Franz Höpfinger - HR Agrartechnik GmbH - add init and correct WITH, add upper and lower limit
+ ***                                       reached indicators
+ ***     3.0: 2025-04-14/Patrick Aigner  - changed package
  ***     1.1: 2024-10-02/Franz Höpfinger - HR Agrartechnik GmbH - Rename to RampLimitFS
+ ***     1.0: 2024-09-20/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #pragma once
 
 #include "forte/simplefb.h"
+#include "forte/datatypes/forte_bool.h"
 #include "forte/datatypes/forte_dint.h"
 #include "forte/forte_st_util.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
 
 namespace forte::eclipse4diac::signalprocessing {
   class FORTE_RampLimitFS final : public CSimpleFB {
       DECLARE_FIRMWARE_FB(FORTE_RampLimitFS)
 
     private:
-      static const TEventID scmEventZEROID = 0;
-      static const TEventID scmEventUP_SLOWID = 1;
-      static const TEventID scmEventUP_FASTID = 2;
-      static const TEventID scmEventDOWN_SLOWID = 3;
-      static const TEventID scmEventDOWN_FASTID = 4;
-      static const TEventID scmEventFULLID = 5;
-      static const TEventID scmEventLOADID = 6;
-      static const TEventID scmEventCNFID = 0;
+      static const TEventID scmEventINITOID = 0;
+      static const TEventID scmEventCNFID = 1;
+      static const TEventID scmEventINITID = 0;
+      static const TEventID scmEventZEROID = 1;
+      static const TEventID scmEventUP_SLOWID = 2;
+      static const TEventID scmEventUP_FASTID = 3;
+      static const TEventID scmEventDOWN_SLOWID = 4;
+      static const TEventID scmEventDOWN_FASTID = 5;
+      static const TEventID scmEventFULLID = 6;
+      static const TEventID scmEventLOADID = 7;
 
       CIEC_ANY *getVarInternal(size_t) override;
 
+      void alg_INIT(void);
       void alg_ZERO(void);
       void alg_UP_SLOW(void);
       void alg_UP_FAST(void);
@@ -48,6 +53,15 @@ namespace forte::eclipse4diac::signalprocessing {
       void alg_DOWN_FAST(void);
       void alg_FULL(void);
       void alg_LOAD(void);
+
+      void enterStateINIT(CEventChainExecutionThread *const paECET);
+      void enterStateZERO(CEventChainExecutionThread *const paECET);
+      void enterStateUP_SLOW(CEventChainExecutionThread *const paECET);
+      void enterStateUP_FAST(CEventChainExecutionThread *const paECET);
+      void enterStateDOWN_SLOW(CEventChainExecutionThread *const paECET);
+      void enterStateDOWN_FAST(CEventChainExecutionThread *const paECET);
+      void enterStateFULL(CEventChainExecutionThread *const paECET);
+      void enterStateLOAD(CEventChainExecutionThread *const paECET);
 
       void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
 
@@ -65,7 +79,10 @@ namespace forte::eclipse4diac::signalprocessing {
       CIEC_DINT var_VAL_FULL;
 
       CIEC_DINT var_OUT;
+      CIEC_BOOL var_qAtZero;
+      CIEC_BOOL var_qAtFull;
 
+      CEventConnection conn_INITO;
       CEventConnection conn_CNF;
 
       CDataConnection *conn_PV;
@@ -75,6 +92,8 @@ namespace forte::eclipse4diac::signalprocessing {
       CDataConnection *conn_VAL_FULL;
 
       COutDataConnection<CIEC_DINT> conn_OUT;
+      COutDataConnection<CIEC_BOOL> conn_qAtZero;
+      COutDataConnection<CIEC_BOOL> conn_qAtFull;
 
       CIEC_ANY *getDI(size_t) override;
       CIEC_ANY *getDO(size_t) override;
@@ -82,13 +101,39 @@ namespace forte::eclipse4diac::signalprocessing {
       CDataConnection **getDIConUnchecked(TPortId) override;
       CDataConnection *getDOConUnchecked(TPortId) override;
 
+      void evt_INIT(const CIEC_DINT &paPV,
+                    const CIEC_DINT &paVAL_ZERO,
+                    const CIEC_DINT &paSLOW,
+                    const CIEC_DINT &paFAST,
+                    const CIEC_DINT &paVAL_FULL,
+                    COutputParameter<CIEC_DINT> paOUT,
+                    CAnyBitOutputParameter<CIEC_BOOL> paqAtZero,
+                    CAnyBitOutputParameter<CIEC_BOOL> paqAtFull) {
+        COutputGuard guard_OUT(paOUT);
+        COutputGuard guard_qAtZero(paqAtZero);
+        COutputGuard guard_qAtFull(paqAtFull);
+        var_PV = paPV;
+        var_VAL_ZERO = paVAL_ZERO;
+        var_SLOW = paSLOW;
+        var_FAST = paFAST;
+        var_VAL_FULL = paVAL_FULL;
+        executeEvent(scmEventINITID, nullptr);
+        *paOUT = var_OUT;
+        *paqAtZero = var_qAtZero;
+        *paqAtFull = var_qAtFull;
+      }
+
       void evt_ZERO(const CIEC_DINT &paPV,
                     const CIEC_DINT &paVAL_ZERO,
                     const CIEC_DINT &paSLOW,
                     const CIEC_DINT &paFAST,
                     const CIEC_DINT &paVAL_FULL,
-                    COutputParameter<CIEC_DINT> paOUT) {
-        COutputGuard guard_paOUT(paOUT);
+                    COutputParameter<CIEC_DINT> paOUT,
+                    CAnyBitOutputParameter<CIEC_BOOL> paqAtZero,
+                    CAnyBitOutputParameter<CIEC_BOOL> paqAtFull) {
+        COutputGuard guard_OUT(paOUT);
+        COutputGuard guard_qAtZero(paqAtZero);
+        COutputGuard guard_qAtFull(paqAtFull);
         var_PV = paPV;
         var_VAL_ZERO = paVAL_ZERO;
         var_SLOW = paSLOW;
@@ -96,6 +141,8 @@ namespace forte::eclipse4diac::signalprocessing {
         var_VAL_FULL = paVAL_FULL;
         executeEvent(scmEventZEROID, nullptr);
         *paOUT = var_OUT;
+        *paqAtZero = var_qAtZero;
+        *paqAtFull = var_qAtFull;
       }
 
       void evt_UP_SLOW(const CIEC_DINT &paPV,
@@ -103,8 +150,12 @@ namespace forte::eclipse4diac::signalprocessing {
                        const CIEC_DINT &paSLOW,
                        const CIEC_DINT &paFAST,
                        const CIEC_DINT &paVAL_FULL,
-                       COutputParameter<CIEC_DINT> paOUT) {
-        COutputGuard guard_paOUT(paOUT);
+                       COutputParameter<CIEC_DINT> paOUT,
+                       CAnyBitOutputParameter<CIEC_BOOL> paqAtZero,
+                       CAnyBitOutputParameter<CIEC_BOOL> paqAtFull) {
+        COutputGuard guard_OUT(paOUT);
+        COutputGuard guard_qAtZero(paqAtZero);
+        COutputGuard guard_qAtFull(paqAtFull);
         var_PV = paPV;
         var_VAL_ZERO = paVAL_ZERO;
         var_SLOW = paSLOW;
@@ -112,6 +163,8 @@ namespace forte::eclipse4diac::signalprocessing {
         var_VAL_FULL = paVAL_FULL;
         executeEvent(scmEventUP_SLOWID, nullptr);
         *paOUT = var_OUT;
+        *paqAtZero = var_qAtZero;
+        *paqAtFull = var_qAtFull;
       }
 
       void evt_UP_FAST(const CIEC_DINT &paPV,
@@ -119,8 +172,12 @@ namespace forte::eclipse4diac::signalprocessing {
                        const CIEC_DINT &paSLOW,
                        const CIEC_DINT &paFAST,
                        const CIEC_DINT &paVAL_FULL,
-                       COutputParameter<CIEC_DINT> paOUT) {
-        COutputGuard guard_paOUT(paOUT);
+                       COutputParameter<CIEC_DINT> paOUT,
+                       CAnyBitOutputParameter<CIEC_BOOL> paqAtZero,
+                       CAnyBitOutputParameter<CIEC_BOOL> paqAtFull) {
+        COutputGuard guard_OUT(paOUT);
+        COutputGuard guard_qAtZero(paqAtZero);
+        COutputGuard guard_qAtFull(paqAtFull);
         var_PV = paPV;
         var_VAL_ZERO = paVAL_ZERO;
         var_SLOW = paSLOW;
@@ -128,6 +185,8 @@ namespace forte::eclipse4diac::signalprocessing {
         var_VAL_FULL = paVAL_FULL;
         executeEvent(scmEventUP_FASTID, nullptr);
         *paOUT = var_OUT;
+        *paqAtZero = var_qAtZero;
+        *paqAtFull = var_qAtFull;
       }
 
       void evt_DOWN_SLOW(const CIEC_DINT &paPV,
@@ -135,8 +194,12 @@ namespace forte::eclipse4diac::signalprocessing {
                          const CIEC_DINT &paSLOW,
                          const CIEC_DINT &paFAST,
                          const CIEC_DINT &paVAL_FULL,
-                         COutputParameter<CIEC_DINT> paOUT) {
-        COutputGuard guard_paOUT(paOUT);
+                         COutputParameter<CIEC_DINT> paOUT,
+                         CAnyBitOutputParameter<CIEC_BOOL> paqAtZero,
+                         CAnyBitOutputParameter<CIEC_BOOL> paqAtFull) {
+        COutputGuard guard_OUT(paOUT);
+        COutputGuard guard_qAtZero(paqAtZero);
+        COutputGuard guard_qAtFull(paqAtFull);
         var_PV = paPV;
         var_VAL_ZERO = paVAL_ZERO;
         var_SLOW = paSLOW;
@@ -144,6 +207,8 @@ namespace forte::eclipse4diac::signalprocessing {
         var_VAL_FULL = paVAL_FULL;
         executeEvent(scmEventDOWN_SLOWID, nullptr);
         *paOUT = var_OUT;
+        *paqAtZero = var_qAtZero;
+        *paqAtFull = var_qAtFull;
       }
 
       void evt_DOWN_FAST(const CIEC_DINT &paPV,
@@ -151,8 +216,12 @@ namespace forte::eclipse4diac::signalprocessing {
                          const CIEC_DINT &paSLOW,
                          const CIEC_DINT &paFAST,
                          const CIEC_DINT &paVAL_FULL,
-                         COutputParameter<CIEC_DINT> paOUT) {
-        COutputGuard guard_paOUT(paOUT);
+                         COutputParameter<CIEC_DINT> paOUT,
+                         CAnyBitOutputParameter<CIEC_BOOL> paqAtZero,
+                         CAnyBitOutputParameter<CIEC_BOOL> paqAtFull) {
+        COutputGuard guard_OUT(paOUT);
+        COutputGuard guard_qAtZero(paqAtZero);
+        COutputGuard guard_qAtFull(paqAtFull);
         var_PV = paPV;
         var_VAL_ZERO = paVAL_ZERO;
         var_SLOW = paSLOW;
@@ -160,6 +229,8 @@ namespace forte::eclipse4diac::signalprocessing {
         var_VAL_FULL = paVAL_FULL;
         executeEvent(scmEventDOWN_FASTID, nullptr);
         *paOUT = var_OUT;
+        *paqAtZero = var_qAtZero;
+        *paqAtFull = var_qAtFull;
       }
 
       void evt_FULL(const CIEC_DINT &paPV,
@@ -167,8 +238,12 @@ namespace forte::eclipse4diac::signalprocessing {
                     const CIEC_DINT &paSLOW,
                     const CIEC_DINT &paFAST,
                     const CIEC_DINT &paVAL_FULL,
-                    COutputParameter<CIEC_DINT> paOUT) {
-        COutputGuard guard_paOUT(paOUT);
+                    COutputParameter<CIEC_DINT> paOUT,
+                    CAnyBitOutputParameter<CIEC_BOOL> paqAtZero,
+                    CAnyBitOutputParameter<CIEC_BOOL> paqAtFull) {
+        COutputGuard guard_OUT(paOUT);
+        COutputGuard guard_qAtZero(paqAtZero);
+        COutputGuard guard_qAtFull(paqAtFull);
         var_PV = paPV;
         var_VAL_ZERO = paVAL_ZERO;
         var_SLOW = paSLOW;
@@ -176,6 +251,8 @@ namespace forte::eclipse4diac::signalprocessing {
         var_VAL_FULL = paVAL_FULL;
         executeEvent(scmEventFULLID, nullptr);
         *paOUT = var_OUT;
+        *paqAtZero = var_qAtZero;
+        *paqAtFull = var_qAtFull;
       }
 
       void evt_LOAD(const CIEC_DINT &paPV,
@@ -183,8 +260,12 @@ namespace forte::eclipse4diac::signalprocessing {
                     const CIEC_DINT &paSLOW,
                     const CIEC_DINT &paFAST,
                     const CIEC_DINT &paVAL_FULL,
-                    COutputParameter<CIEC_DINT> paOUT) {
-        COutputGuard guard_paOUT(paOUT);
+                    COutputParameter<CIEC_DINT> paOUT,
+                    CAnyBitOutputParameter<CIEC_BOOL> paqAtZero,
+                    CAnyBitOutputParameter<CIEC_BOOL> paqAtFull) {
+        COutputGuard guard_OUT(paOUT);
+        COutputGuard guard_qAtZero(paqAtZero);
+        COutputGuard guard_qAtFull(paqAtFull);
         var_PV = paPV;
         var_VAL_ZERO = paVAL_ZERO;
         var_SLOW = paSLOW;
@@ -192,15 +273,8 @@ namespace forte::eclipse4diac::signalprocessing {
         var_VAL_FULL = paVAL_FULL;
         executeEvent(scmEventLOADID, nullptr);
         *paOUT = var_OUT;
-      }
-
-      void operator()(const CIEC_DINT &paPV,
-                      const CIEC_DINT &paVAL_ZERO,
-                      const CIEC_DINT &paSLOW,
-                      const CIEC_DINT &paFAST,
-                      const CIEC_DINT &paVAL_FULL,
-                      COutputParameter<CIEC_DINT> paOUT) {
-        evt_ZERO(paPV, paVAL_ZERO, paSLOW, paFAST, paVAL_FULL, paOUT);
+        *paqAtZero = var_qAtZero;
+        *paqAtFull = var_qAtFull;
       }
   };
 } // namespace forte::eclipse4diac::signalprocessing

--- a/modules/signalprocessing/src/eclipse4diac/signalprocessing/RampLimitFS_fbt.cpp
+++ b/modules/signalprocessing/src/eclipse4diac/signalprocessing/RampLimitFS_fbt.cpp
@@ -6,41 +6,47 @@
  ***
  *** SPDX-License-Identifier: EPL-2.0
  ***
- *** This file was generated using the 4DIAC FORTE Export Filter V1.0.x NG!
+ *** FORTE Library Element
+ ***
+ *** This file was generated using the 4DIAC FORTE Export Filter 3.2.100.202608212006!
  ***
  *** Name: RampLimitFS
  *** Description: Setpoint Ramp: Step up and down Values with Fast and Slow mode
  *** Version:
- ***     1.0: 2024-09-20/Franz Höpfinger - HR Agrartechnik GmbH -
+ ***     3.1: 2026-08-12/Franz Höpfinger - HR Agrartechnik GmbH - add init and correct WITH, add upper and lower limit
+ ***                                       reached indicators
+ ***     3.0: 2025-04-14/Patrick Aigner  - changed package
  ***     1.1: 2024-10-02/Franz Höpfinger - HR Agrartechnik GmbH - Rename to RampLimitFS
+ ***     1.0: 2024-09-20/Franz Höpfinger - HR Agrartechnik GmbH -
  *************************************************************************/
 
 #include "forte/eclipse4diac/signalprocessing/RampLimitFS_fbt.h"
 
-#include "forte/datatypes/forte_any_elementary_variant.h"
-#include "forte/datatypes/forte_any_num_variant.h"
+#include "forte/datatypes/forte_bool.h"
 #include "forte/datatypes/forte_dint.h"
+#include "forte/forte_st_util.h"
 #include "forte/iec61131_functions/func_ADD.h"
+#include "forte/iec61131_functions/func_GE.h"
 #include "forte/iec61131_functions/func_GT.h"
+#include "forte/iec61131_functions/func_LE.h"
 #include "forte/iec61131_functions/func_LT.h"
 #include "forte/iec61131_functions/func_SUB.h"
-#include "forte/datatypes/forte_array_common.h"
-#include "forte/datatypes/forte_array.h"
-#include "forte/datatypes/forte_array_fixed.h"
-#include "forte/datatypes/forte_array_variable.h"
 
+using namespace std::literals;
 using namespace forte::literals;
 
 namespace forte::eclipse4diac::signalprocessing {
   namespace {
+    constexpr std::string_view TypeHash = ""sv;
+
+    const auto cEventInputNames = std::array{"INIT"_STRID,      "ZERO"_STRID,      "UP_SLOW"_STRID, "UP_FAST"_STRID,
+                                             "DOWN_SLOW"_STRID, "DOWN_FAST"_STRID, "FULL"_STRID,    "LOAD"_STRID};
+    const auto cEventInputTypeIds = std::array{"EInit"_STRID, "Event"_STRID, "Event"_STRID, "Event"_STRID,
+                                               "Event"_STRID, "Event"_STRID, "Event"_STRID, "Event"_STRID};
+    const auto cEventOutputNames = std::array{"INITO"_STRID, "CNF"_STRID};
+    const auto cEventOutputTypeIds = std::array{"EInit"_STRID, "Event"_STRID};
     const auto cDataInputNames = std::array{"PV"_STRID, "VAL_ZERO"_STRID, "SLOW"_STRID, "FAST"_STRID, "VAL_FULL"_STRID};
-    const auto cDataOutputNames = std::array{"OUT"_STRID};
-    const auto cEventInputNames = std::array{"ZERO"_STRID,      "UP_SLOW"_STRID, "UP_FAST"_STRID, "DOWN_SLOW"_STRID,
-                                             "DOWN_FAST"_STRID, "FULL"_STRID,    "LOAD"_STRID};
-    const auto cEventInputTypeIds = std::array{"Event"_STRID, "Event"_STRID, "Event"_STRID, "Event"_STRID,
-                                               "Event"_STRID, "Event"_STRID, "Event"_STRID};
-    const auto cEventOutputNames = std::array{"CNF"_STRID};
-    const auto cEventOutputTypeIds = std::array{"Event"_STRID};
+    const auto cDataOutputNames = std::array{"OUT"_STRID, "qAtZero"_STRID, "qAtFull"_STRID};
     const SFBInterfaceSpec cFBInterfaceSpec = {
         .mEINames = cEventInputNames,
         .mEITypeNames = cEventInputTypeIds,
@@ -54,70 +60,144 @@ namespace forte::eclipse4diac::signalprocessing {
     };
   } // namespace
 
-  DEFINE_FIRMWARE_FB(FORTE_RampLimitFS, "eclipse4diac::signalprocessing::RampLimitFS"_STRID)
+  DEFINE_FIRMWARE_FB(FORTE_RampLimitFS, "eclipse4diac::signalprocessing::RampLimitFS"_STRID, TypeHash)
 
   FORTE_RampLimitFS::FORTE_RampLimitFS(const StringId paInstanceNameId, CFBContainer &paContainer) :
       CSimpleFB(paContainer, cFBInterfaceSpec, paInstanceNameId, {}),
-      conn_CNF(*this, 0),
+      var_PV(0_DINT),
+      var_VAL_ZERO(0_DINT),
+      var_SLOW(0_DINT),
+      var_FAST(0_DINT),
+      var_VAL_FULL(0_DINT),
+      var_OUT(0_DINT),
+      var_qAtZero(0_BOOL),
+      var_qAtFull(0_BOOL),
+      conn_INITO(*this, 0),
+      conn_CNF(*this, 1),
       conn_PV(nullptr),
       conn_VAL_ZERO(nullptr),
       conn_SLOW(nullptr),
       conn_FAST(nullptr),
       conn_VAL_FULL(nullptr),
-      conn_OUT(*this, 0, var_OUT) {
+      conn_OUT(*this, 0, var_OUT),
+      conn_qAtZero(*this, 1, var_qAtZero),
+      conn_qAtFull(*this, 2, var_qAtFull) {
   }
 
   void FORTE_RampLimitFS::setInitialValues() {
+    CSimpleFB::setInitialValues();
     var_PV = 0_DINT;
     var_VAL_ZERO = 0_DINT;
     var_SLOW = 0_DINT;
     var_FAST = 0_DINT;
     var_VAL_FULL = 0_DINT;
     var_OUT = 0_DINT;
+    var_qAtZero = 0_BOOL;
+    var_qAtFull = 0_BOOL;
   }
 
   void FORTE_RampLimitFS::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
     switch (paEIID) {
-      case scmEventZEROID: alg_ZERO(); break;
-      case scmEventUP_SLOWID: alg_UP_SLOW(); break;
-      case scmEventUP_FASTID: alg_UP_FAST(); break;
-      case scmEventDOWN_SLOWID: alg_DOWN_SLOW(); break;
-      case scmEventDOWN_FASTID: alg_DOWN_FAST(); break;
-      case scmEventFULLID: alg_FULL(); break;
-      case scmEventLOADID: alg_LOAD(); break;
+      case scmEventINITID: enterStateINIT(paECET); break;
+      case scmEventZEROID: enterStateZERO(paECET); break;
+      case scmEventUP_SLOWID: enterStateUP_SLOW(paECET); break;
+      case scmEventUP_FASTID: enterStateUP_FAST(paECET); break;
+      case scmEventDOWN_SLOWID: enterStateDOWN_SLOW(paECET); break;
+      case scmEventDOWN_FASTID: enterStateDOWN_FAST(paECET); break;
+      case scmEventFULLID: enterStateFULL(paECET); break;
+      case scmEventLOADID: enterStateLOAD(paECET); break;
       default: break;
     }
+  }
+
+  void FORTE_RampLimitFS::enterStateINIT(CEventChainExecutionThread *const paECET) {
+    alg_INIT();
+    sendOutputEvent(scmEventINITOID, paECET);
+  }
+
+  void FORTE_RampLimitFS::enterStateZERO(CEventChainExecutionThread *const paECET) {
+    alg_ZERO();
+    sendOutputEvent(scmEventCNFID, paECET);
+  }
+
+  void FORTE_RampLimitFS::enterStateUP_SLOW(CEventChainExecutionThread *const paECET) {
+    alg_UP_SLOW();
+    sendOutputEvent(scmEventCNFID, paECET);
+  }
+
+  void FORTE_RampLimitFS::enterStateUP_FAST(CEventChainExecutionThread *const paECET) {
+    alg_UP_FAST();
+    sendOutputEvent(scmEventCNFID, paECET);
+  }
+
+  void FORTE_RampLimitFS::enterStateDOWN_SLOW(CEventChainExecutionThread *const paECET) {
+    alg_DOWN_SLOW();
+    sendOutputEvent(scmEventCNFID, paECET);
+  }
+
+  void FORTE_RampLimitFS::enterStateDOWN_FAST(CEventChainExecutionThread *const paECET) {
+    alg_DOWN_FAST();
+    sendOutputEvent(scmEventCNFID, paECET);
+  }
+
+  void FORTE_RampLimitFS::enterStateFULL(CEventChainExecutionThread *const paECET) {
+    alg_FULL();
+    sendOutputEvent(scmEventCNFID, paECET);
+  }
+
+  void FORTE_RampLimitFS::enterStateLOAD(CEventChainExecutionThread *const paECET) {
+    alg_LOAD();
     sendOutputEvent(scmEventCNFID, paECET);
   }
 
   void FORTE_RampLimitFS::readInputData(const TEventID paEIID) {
     switch (paEIID) {
+      case scmEventINITID: {
+        readData(0, var_PV, conn_PV);
+        readData(1, var_VAL_ZERO, conn_VAL_ZERO);
+        readData(2, var_SLOW, conn_SLOW);
+        readData(3, var_FAST, conn_FAST);
+        readData(4, var_VAL_FULL, conn_VAL_FULL);
+        break;
+      }
       case scmEventZEROID: {
         readData(1, var_VAL_ZERO, conn_VAL_ZERO);
+        readData(4, var_VAL_FULL, conn_VAL_FULL);
         break;
       }
       case scmEventUP_SLOWID: {
         readData(2, var_SLOW, conn_SLOW);
+        readData(1, var_VAL_ZERO, conn_VAL_ZERO);
+        readData(4, var_VAL_FULL, conn_VAL_FULL);
         break;
       }
       case scmEventUP_FASTID: {
         readData(3, var_FAST, conn_FAST);
+        readData(1, var_VAL_ZERO, conn_VAL_ZERO);
+        readData(4, var_VAL_FULL, conn_VAL_FULL);
         break;
       }
       case scmEventDOWN_SLOWID: {
         readData(2, var_SLOW, conn_SLOW);
+        readData(1, var_VAL_ZERO, conn_VAL_ZERO);
+        readData(4, var_VAL_FULL, conn_VAL_FULL);
         break;
       }
       case scmEventDOWN_FASTID: {
         readData(3, var_FAST, conn_FAST);
+        readData(1, var_VAL_ZERO, conn_VAL_ZERO);
+        readData(4, var_VAL_FULL, conn_VAL_FULL);
         break;
       }
       case scmEventFULLID: {
+        readData(1, var_VAL_ZERO, conn_VAL_ZERO);
         readData(4, var_VAL_FULL, conn_VAL_FULL);
         break;
       }
       case scmEventLOADID: {
         readData(0, var_PV, conn_PV);
+        readData(1, var_VAL_ZERO, conn_VAL_ZERO);
+        readData(4, var_VAL_FULL, conn_VAL_FULL);
         break;
       }
       default: break;
@@ -126,8 +206,16 @@ namespace forte::eclipse4diac::signalprocessing {
 
   void FORTE_RampLimitFS::writeOutputData(const TEventID paEIID) {
     switch (paEIID) {
+      case scmEventINITOID: {
+        writeData(5, var_OUT, conn_OUT);
+        writeData(6, var_qAtZero, conn_qAtZero);
+        writeData(7, var_qAtFull, conn_qAtFull);
+        break;
+      }
       case scmEventCNFID: {
-        writeData(cFBInterfaceSpec.getNumDIs() + 0, var_OUT, conn_OUT);
+        writeData(5, var_OUT, conn_OUT);
+        writeData(6, var_qAtZero, conn_qAtZero);
+        writeData(7, var_qAtFull, conn_qAtFull);
         break;
       }
       default: break;
@@ -148,13 +236,16 @@ namespace forte::eclipse4diac::signalprocessing {
   CIEC_ANY *FORTE_RampLimitFS::getDO(const size_t paIndex) {
     switch (paIndex) {
       case 0: return &var_OUT;
+      case 1: return &var_qAtZero;
+      case 2: return &var_qAtFull;
     }
     return nullptr;
   }
 
   CEventConnection *FORTE_RampLimitFS::getEOConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
-      case 0: return &conn_CNF;
+      case 0: return &conn_INITO;
+      case 1: return &conn_CNF;
     }
     return nullptr;
   }
@@ -173,6 +264,8 @@ namespace forte::eclipse4diac::signalprocessing {
   CDataConnection *FORTE_RampLimitFS::getDOConUnchecked(const TPortId paIndex) {
     switch (paIndex) {
       case 0: return &conn_OUT;
+      case 1: return &conn_qAtZero;
+      case 2: return &conn_qAtFull;
     }
     return nullptr;
   }
@@ -181,66 +274,104 @@ namespace forte::eclipse4diac::signalprocessing {
     return nullptr;
   }
 
+  void FORTE_RampLimitFS::alg_INIT(void) {
+
+#line 7 "RampLimitFS.fbt"
+    var_OUT = var_VAL_ZERO;
+#line 8 "RampLimitFS.fbt"
+    var_qAtZero = func_LE(var_OUT, var_VAL_ZERO);
+#line 9 "RampLimitFS.fbt"
+    var_qAtFull = func_GE(var_OUT, var_VAL_FULL);
+  }
+
   void FORTE_RampLimitFS::alg_ZERO(void) {
 
-#line 2 "RampLimitFS.fbt"
+#line 17 "RampLimitFS.fbt"
     var_OUT = var_VAL_ZERO;
+#line 18 "RampLimitFS.fbt"
+    var_qAtZero = func_LE(var_OUT, var_VAL_ZERO);
+#line 19 "RampLimitFS.fbt"
+    var_qAtFull = func_GE(var_OUT, var_VAL_FULL);
   }
 
   void FORTE_RampLimitFS::alg_UP_SLOW(void) {
 
-#line 6 "RampLimitFS.fbt"
+#line 27 "RampLimitFS.fbt"
     var_OUT = func_ADD(var_OUT, var_SLOW);
-#line 7 "RampLimitFS.fbt"
+#line 28 "RampLimitFS.fbt"
     if (func_GT(var_OUT, var_VAL_FULL)) {
-#line 8 "RampLimitFS.fbt"
+#line 29 "RampLimitFS.fbt"
       var_OUT = var_VAL_FULL;
     }
+#line 31 "RampLimitFS.fbt"
+    var_qAtZero = func_LE(var_OUT, var_VAL_ZERO);
+#line 32 "RampLimitFS.fbt"
+    var_qAtFull = func_GE(var_OUT, var_VAL_FULL);
   }
 
   void FORTE_RampLimitFS::alg_UP_FAST(void) {
 
-#line 13 "RampLimitFS.fbt"
+#line 40 "RampLimitFS.fbt"
     var_OUT = func_ADD(var_OUT, var_FAST);
-#line 14 "RampLimitFS.fbt"
+#line 41 "RampLimitFS.fbt"
     if (func_GT(var_OUT, var_VAL_FULL)) {
-#line 15 "RampLimitFS.fbt"
+#line 42 "RampLimitFS.fbt"
       var_OUT = var_VAL_FULL;
     }
+#line 44 "RampLimitFS.fbt"
+    var_qAtZero = func_LE(var_OUT, var_VAL_ZERO);
+#line 45 "RampLimitFS.fbt"
+    var_qAtFull = func_GE(var_OUT, var_VAL_FULL);
   }
 
   void FORTE_RampLimitFS::alg_DOWN_SLOW(void) {
 
-#line 20 "RampLimitFS.fbt"
+#line 53 "RampLimitFS.fbt"
     var_OUT = func_SUB(var_OUT, var_SLOW);
-#line 21 "RampLimitFS.fbt"
+#line 54 "RampLimitFS.fbt"
     if (func_LT(var_OUT, var_VAL_ZERO)) {
-#line 22 "RampLimitFS.fbt"
+#line 55 "RampLimitFS.fbt"
       var_OUT = var_VAL_ZERO;
     }
+#line 57 "RampLimitFS.fbt"
+    var_qAtZero = func_LE(var_OUT, var_VAL_ZERO);
+#line 58 "RampLimitFS.fbt"
+    var_qAtFull = func_GE(var_OUT, var_VAL_FULL);
   }
 
   void FORTE_RampLimitFS::alg_DOWN_FAST(void) {
 
-#line 27 "RampLimitFS.fbt"
+#line 66 "RampLimitFS.fbt"
     var_OUT = func_SUB(var_OUT, var_FAST);
-#line 28 "RampLimitFS.fbt"
+#line 67 "RampLimitFS.fbt"
     if (func_LT(var_OUT, var_VAL_ZERO)) {
-#line 29 "RampLimitFS.fbt"
+#line 68 "RampLimitFS.fbt"
       var_OUT = var_VAL_ZERO;
     }
+#line 70 "RampLimitFS.fbt"
+    var_qAtZero = func_LE(var_OUT, var_VAL_ZERO);
+#line 71 "RampLimitFS.fbt"
+    var_qAtFull = func_GE(var_OUT, var_VAL_FULL);
   }
 
   void FORTE_RampLimitFS::alg_FULL(void) {
 
-#line 34 "RampLimitFS.fbt"
+#line 79 "RampLimitFS.fbt"
     var_OUT = var_VAL_FULL;
+#line 80 "RampLimitFS.fbt"
+    var_qAtZero = func_LE(var_OUT, var_VAL_ZERO);
+#line 81 "RampLimitFS.fbt"
+    var_qAtFull = func_GE(var_OUT, var_VAL_FULL);
   }
 
   void FORTE_RampLimitFS::alg_LOAD(void) {
 
-#line 38 "RampLimitFS.fbt"
+#line 90 "RampLimitFS.fbt"
     var_OUT = var_PV;
+#line 91 "RampLimitFS.fbt"
+    var_qAtZero = func_LE(var_OUT, var_VAL_ZERO);
+#line 92 "RampLimitFS.fbt"
+    var_qAtFull = func_GE(var_OUT, var_VAL_FULL);
   }
 
 } // namespace forte::eclipse4diac::signalprocessing


### PR DESCRIPTION
Matches the RampLimitFS.fbt fix: adds an EInit INIT/INITO event pair that
latches all five data inputs (PV, VAL_ZERO, SLOW, FAST, VAL_FULL), and
adds the previously-missing VAL_FULL/VAL_ZERO reads to
UP_SLOW/UP_FAST/DOWN_SLOW/DOWN_FAST's readInputData - each of those
algorithms clamps against VAL_FULL/VAL_ZERO but wasn't reading it before.
Regenerated with the current 4DIAC FORTE Export Filter (3.1.100.202604172003).


References: 
https://github.com/eclipse-4diac/4diac-ide/pull/2739
https://github.com/franz-hoepfinger-4diac-org/4diac-forte/pull/31
https://github.com/franz-hoepfinger-4diac-org/4diac-ide/pull/25