### PR TITLE
Add optional OPC UA over WebSocket (opc.ws://, opc.wss://) server endpoints

### DIFF
--- a/com/opc_ua/CMakeLists.txt
+++ b/com/opc_ua/CMakeLists.txt
@@ -1,16 +1,17 @@
 # *******************************************************************************************
 
-# Copyright (c) 2015-2016 Florian Froschermeier
-# <florian.froschermeier@tum.de>, fortiss GmbH This program and the
-# accompanying materials are made available under the terms of the Eclipse
-# Public License 2.0 which is available at
+# Copyright (c) 2015 Florian Froschermeier
+# <florian.froschermeier@tum.de>, fortiss GmbH, HR Agrartechnik GmbH. This
+# program and the accompanying materials are made available under the terms
+# of the Eclipse Public License 2.0 which is available at
 # http://www.eclipse.org/legal/epl-2.0.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors: Florian Froschermeier - initial integration of OPC Unified
-# Architecture into FORTE Stefan Profanter - refactoring and adaption to new
-# concept
+# Architecture into FORTE Stefan Profanter - refactoring and adaptation to new concept;
+# Franz Höpfinger - Add optional OPC UA over WebSocket (insecure and secure
+# transports) server endpoint
 # ******************************************************************************************
 
 # ############################################################################
@@ -25,7 +26,36 @@ if (NOT FORTE_COM_OPC_UA)
     return()
 endif ()
 
-find_package(open62541 1.5.4 REQUIRED)
+if (FORTE_COM_OPC_UA_INCLUDE_DIR)
+    get_filename_component(FORTE_COM_OPC_UA_INCLUDE_DIR_ABS "${FORTE_COM_OPC_UA_INCLUDE_DIR}" ABSOLUTE)
+    if (NOT TARGET open62541::open62541)
+        # FORTE_COM_OPC_UA_INCLUDE_DIR points at an amalgamated open62541 build
+        # (open62541.c/.h, no compiled library yet): on ESP-IDF targets that
+        # source is compiled and linked one level up, as the outer project's
+        # own "open62541" component, so forte only ever needs the headers here
+        # to type-check against - never a real library to link.
+        add_library(open62541 INTERFACE)
+        add_library(open62541::open62541 ALIAS open62541)
+        # Also used as the INSTALL_INTERFACE (not just BUILD_INTERFACE): these are
+        # absolute, build-machine-specific paths, so the exported target is only
+        # usable by a consumer building against this same tree -- but that beats an
+        # exported target with no include paths at all, which is what plain
+        # BUILD_INTERFACE-only paths would leave for install(EXPORT) consumers.
+        target_include_directories(open62541 INTERFACE
+            $<BUILD_INTERFACE:${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}>
+            $<BUILD_INTERFACE:${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/src_generated>
+            $<BUILD_INTERFACE:${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/../open62541/include>
+            $<BUILD_INTERFACE:${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/../open62541/plugins/include>
+            $<INSTALL_INTERFACE:${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}>
+            $<INSTALL_INTERFACE:${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/src_generated>
+            $<INSTALL_INTERFACE:${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/../open62541/include>
+            $<INSTALL_INTERFACE:${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/../open62541/plugins/include>
+        )
+        install(TARGETS open62541 EXPORT forte-export)
+    endif ()
+else ()
+    find_package(open62541 1.5.4 REQUIRED)
+endif ()
 
 set(FORTE_COM_OPC_UA_PORT
         4840
@@ -49,6 +79,136 @@ set(FORTE_COM_OPC_UA_SERVER_MAX_ITERATION_INTERVAL
 option(FORTE_COM_OPC_UA_MULTICAST
         "Enable multicast support for OPC UA and registering with LDS" OFF
 )
+# Enables the insecure and secure WebSocket endpoints alongside the plain opc.tcp
+# endpoint, using the ports immediately above it (insecure WebSocket on port+1 and
+# secure WebSocket on port+2). On platforms built with UA_ENABLE_LWS (libwebsockets,
+# POSIX-only), open62541 provides the "websocket" ConnectionManager itself. On
+# platforms without libwebsockets (RTOS targets such as FreeRTOS/Zephyr), that
+# ConnectionManager has to be registered by the platform's own code instead.
+option(FORTE_COM_OPC_UA_WEBSOCKET
+        "Enable OPC UA over WebSocket server endpoints." OFF
+)
+
+# On platforms without UA_ENABLE_LWS (RTOS targets, see comment above), the
+# "websocket" ConnectionManager has to come from the platform's own code.
+# FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR points at the directory
+# providing that implementation's header (ws_connection_manager.h); on
+# ESP-IDF targets its .c is compiled and linked one level up, as the outer
+# project's own "open62541" component, so forte only needs the header here
+# to type-check against - never a real library to link, same rationale as
+# FORTE_COM_OPC_UA_INCLUDE_DIR above.
+# Declared here, ahead of the WEBSOCKET_INSECURE/_SECURE validation below,
+# so that validation can check it.
+set(FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR
+        CACHE PATH
+        "Directory containing ws_connection_manager.h, providing the \"websocket\" UA_ConnectionManager on platforms without UA_ENABLE_LWS"
+)
+
+if (FORTE_COM_OPC_UA_WEBSOCKET)
+    # Intentional unencrypted-WebSocket support (builder-configurable, off when
+    # INSECURE=OFF); it exists for development/test setups without a TLS
+    # certificate, never on by default -- see the option description below.
+    option(FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+            "Enable unencrypted OPC UA over WebSocket (opc.ws://) endpoint" OFF # nosemgrep: javascript.lang.security.detect-insecure-websocket
+    )
+    option(FORTE_COM_OPC_UA_WEBSOCKET_SECURE
+            "Enable secure OPC UA over WebSocket (opc.wss://) endpoint" ON
+    )
+    if (NOT FORTE_COM_OPC_UA_WEBSOCKET_INSECURE AND NOT FORTE_COM_OPC_UA_WEBSOCKET_SECURE)
+        message(FATAL_ERROR "FORTE_COM_OPC_UA_WEBSOCKET is enabled, but neither FORTE_COM_OPC_UA_WEBSOCKET_INSECURE nor FORTE_COM_OPC_UA_WEBSOCKET_SECURE is selected.")
+    endif ()
+
+    # UA_ServerConfig::webSocketEnabled/webSocketAllowUnencrypted/webSocketCertificate/
+    # webSocketPrivateKey and the UA_ENABLE_LWS macro are a patch on top of upstream
+    # open62541, not present in stock releases such as the "1.5.4" pulled in by the
+    # find_package() fallback below. Checked via plain CMAKE_REQUIRED_INCLUDES rather
+    # than linking open62541::open62541: FORTE_COM_OPC_UA_INCLUDE_DIR mode is
+    # headers-only by design (see comment above) -- the library is compiled and linked
+    # one level up (e.g. as its own ESP-IDF component), so there is nothing to link
+    # against yet here, and a link-based check would always spuriously fail.
+    if (FORTE_COM_OPC_UA_INCLUDE_DIR)
+        # Same paths used to build the open62541::open62541 INTERFACE target above --
+        # read directly from that source variable instead of extracting them back out of
+        # the target's (BUILD_INTERFACE-wrapped) INTERFACE_INCLUDE_DIRECTORIES via generator-
+        # expression string-munging, so there's nothing to keep in sync if that target's
+        # include list ever changes shape.
+        set(FORTE_COM_OPC_UA_WS_CHECK_INCLUDES
+                "${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}"
+                "${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/src_generated"
+                "${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/../open62541/include"
+                "${FORTE_COM_OPC_UA_INCLUDE_DIR_ABS}/../open62541/plugins/include"
+        )
+    else ()
+        # find_package()-imported targets expose plain, already-resolved paths here (no
+        # BUILD_INTERFACE wrapping), so no extra handling is needed for this branch.
+        get_target_property(FORTE_COM_OPC_UA_WS_CHECK_INCLUDES open62541::open62541 INTERFACE_INCLUDE_DIRECTORIES)
+        if (NOT FORTE_COM_OPC_UA_WS_CHECK_INCLUDES)
+            set(FORTE_COM_OPC_UA_WS_CHECK_INCLUDES "")
+        endif ()
+    endif ()
+
+    include(CheckStructHasMember)
+    include(CheckSymbolExists)
+    include(CMakePushCheckState)
+    cmake_push_check_state(RESET)
+    set(CMAKE_REQUIRED_INCLUDES ${FORTE_COM_OPC_UA_WS_CHECK_INCLUDES})
+    check_struct_has_member("UA_ServerConfig" webSocketEnabled "open62541/server.h"
+            FORTE_COM_OPC_UA_HAS_WS_ENABLED LANGUAGE C)
+    check_struct_has_member("UA_ServerConfig" webSocketAllowUnencrypted "open62541/server.h"
+            FORTE_COM_OPC_UA_HAS_WS_ALLOW_UNENCRYPTED LANGUAGE C)
+    check_struct_has_member("UA_ServerConfig" webSocketCertificate "open62541/server.h"
+            FORTE_COM_OPC_UA_HAS_WS_CERTIFICATE LANGUAGE C)
+    check_struct_has_member("UA_ServerConfig" webSocketPrivateKey "open62541/server.h"
+            FORTE_COM_OPC_UA_HAS_WS_PRIVATE_KEY LANGUAGE C)
+    check_symbol_exists(UA_ENABLE_LWS "open62541/config.h" FORTE_COM_OPC_UA_HAS_UA_ENABLE_LWS)
+    cmake_pop_check_state()
+    unset(FORTE_COM_OPC_UA_WS_CHECK_INCLUDES)
+
+    if (NOT (FORTE_COM_OPC_UA_HAS_WS_ENABLED AND FORTE_COM_OPC_UA_HAS_WS_ALLOW_UNENCRYPTED AND
+             FORTE_COM_OPC_UA_HAS_WS_CERTIFICATE AND FORTE_COM_OPC_UA_HAS_WS_PRIVATE_KEY))
+        message(FATAL_ERROR
+                "FORTE_COM_OPC_UA_WEBSOCKET requires an open62541 build with WebSocket support on "
+                "UA_ServerConfig (webSocketEnabled, webSocketAllowUnencrypted, webSocketCertificate, "
+                "webSocketPrivateKey), which stock upstream open62541 does not have. Point "
+                "FORTE_COM_OPC_UA_INCLUDE_DIR at a patched open62541 checkout instead of relying on "
+                "find_package(open62541).")
+    endif ()
+
+    # The secure transport (opc.wss://) is only ever provided by open62541's LWS-based
+    # ConnectionManager (see opcua_local_handler.cpp) -- the platform-ConnectionManager
+    # fallback for platforms without libwebsockets only ever supports the plain,
+    # unencrypted WebSocket transport. So with the default SECURE=ON/INSECURE=OFF, a
+    # UA_ENABLE_LWS-less open62541 build would silently register no WebSocket endpoint
+    # at all despite FORTE_COM_OPC_UA_WEBSOCKET being on.
+    if (FORTE_COM_OPC_UA_WEBSOCKET_SECURE AND NOT FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+            AND NOT FORTE_COM_OPC_UA_HAS_UA_ENABLE_LWS)
+        message(FATAL_ERROR
+                "FORTE_COM_OPC_UA_WEBSOCKET_SECURE (opc.wss://) requires an open62541 build with "
+                "UA_ENABLE_LWS -- it is the only backend that supports the secure transport; the "
+                "platform-ConnectionManager fallback (FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR) "
+                "only ever supports opc.ws://. Either use an open62541 build with UA_ENABLE_LWS, or set " # nosemgrep: javascript.lang.security.detect-insecure-websocket
+                "FORTE_COM_OPC_UA_WEBSOCKET_INSECURE=ON to get opc.ws:// via the platform " # nosemgrep: javascript.lang.security.detect-insecure-websocket
+                "ConnectionManager instead.")
+    endif ()
+
+    # Mirrors the SECURE check above: without UA_ENABLE_LWS, the insecure transport can
+    # only come from a platform ConnectionManager (see the #elif
+    # FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER chain in opcua_local_handler.cpp),
+    # which requires FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR. Without either,
+    # configureUAServer() silently registers no WebSocket endpoint at all.
+    if (FORTE_COM_OPC_UA_WEBSOCKET_INSECURE AND NOT FORTE_COM_OPC_UA_HAS_UA_ENABLE_LWS
+            AND NOT FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR)
+        message(FATAL_ERROR
+                "FORTE_COM_OPC_UA_WEBSOCKET_INSECURE (opc.ws://) requires either an open62541 " # nosemgrep: javascript.lang.security.detect-insecure-websocket
+                "build with UA_ENABLE_LWS or FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR "
+                "pointing at a platform-provided ws_connection_manager.h; otherwise no "
+                "WebSocket endpoint is registered at runtime.")
+    endif ()
+else ()
+    set(FORTE_COM_OPC_UA_WEBSOCKET_INSECURE OFF)
+    set(FORTE_COM_OPC_UA_WEBSOCKET_SECURE OFF)
+endif ()
+
 set(FORTE_COM_OPC_UA_CUSTOM_HOSTNAME
         CACHE STRING
         "Custom hostname which is used for the OPC UA app name and app uri"
@@ -61,6 +221,29 @@ option(FORTE_COM_OPC_UA_AC "Enable OPC UA A&C Support" OFF)
 add_library(forte-com-opc_ua)
 target_link_libraries(forte-com-opc_ua PUBLIC forte-core open62541::open62541)
 target_link_libraries(forte PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,forte-com-opc_ua,$<LINK_LIBRARY:WHOLE_ARCHIVE,forte-com-opc_ua>>)
+
+if (FORTE_COM_OPC_UA_WEBSOCKET AND FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR)
+    if (FORTE_COM_OPC_UA_HAS_UA_ENABLE_LWS)
+        # The open62541 build already has libwebsockets support, which
+        # configureUAServer() always prefers over the platform ConnectionManager
+        # (see the #ifdef UA_ENABLE_LWS / #elif FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER
+        # chain in opcua_local_handler.cpp). Defining the latter here too would be not
+        # just redundant but actively dangerous: it would make
+        # WsConnectionManager_poll() reachable while mWsConnectionManager is really an
+        # LWS-backed UA_ConnectionManager, which is undefined behavior.
+        message(STATUS
+                "FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR is set, but this open62541 "
+                "build already has UA_ENABLE_LWS; ignoring it since the LWS backend takes "
+                "priority.")
+    else ()
+        get_filename_component(FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR_ABS
+                "${FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR}" ABSOLUTE)
+        target_include_directories(forte-com-opc_ua PRIVATE
+                $<BUILD_INTERFACE:${FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR_ABS}>
+        )
+        target_compile_definitions(forte-com-opc_ua PRIVATE FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER)
+    endif ()
+endif ()
 
 add_subdirectory(include)
 add_subdirectory(src)

--- a/com/opc_ua/src/CMakeLists.txt
+++ b/com/opc_ua/src/CMakeLists.txt
@@ -1,16 +1,17 @@
 # *******************************************************************************************
 
-# Copyright (c) 2015-2016 Florian Froschermeier
-# <florian.froschermeier@tum.de>, fortiss GmbH This program and the
-# accompanying materials are made available under the terms of the Eclipse
-# Public License 2.0 which is available at
+# Copyright (c) 2015 Florian Froschermeier
+# <florian.froschermeier@tum.de>, fortiss GmbH, HR Agrartechnik GmbH. This
+# program and the accompanying materials are made available under the terms
+# of the Eclipse Public License 2.0 which is available at
 # http://www.eclipse.org/legal/epl-2.0.
 #
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors: Florian Froschermeier - initial integration of OPC Unified
-# Architecture into FORTE Stefan Profanter - refactoring and adaption to new
-# concept
+# Architecture into FORTE Stefan Profanter - refactoring and adaptation to new concept;
+# Franz Höpfinger - Add optional OPC UA over WebSocket (insecure and secure
+# transports) server endpoint
 # ******************************************************************************************
 
 # ############################################################################
@@ -50,7 +51,7 @@ target_sources(forte-com-opc_ua PRIVATE
         $<$<BOOL:${FORTE_COM_OPC_UA_AC}>:${CMAKE_CURRENT_SOURCE_DIR}/opcua_ac_layer.cpp>
         $<$<BOOL:${FORTE_COM_OPC_UA_AC}>:${CMAKE_CURRENT_SOURCE_DIR}/opcua_ac_layer.h>
 )
-target_include_directories(forte-com-opc_ua PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(forte-com-opc_ua PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 add_subdirectory(types)
 add_subdirectory(detail)

--- a/com/opc_ua/src/opcua_defaults.h.in
+++ b/com/opc_ua/src/opcua_defaults.h.in
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agrartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Franz Höpfinger
+ *      - Add optional OPC UA over WebSocket (insecure and secure transports) server endpoint
+ *******************************************************************************/
 #define FORTE_COM_OPC_UA_PORT ${FORTE_COM_OPC_UA_PORT}
 #define FORTE_COM_OPC_UA_SERVER_MAX_ITERATION_INTERVAL ${FORTE_COM_OPC_UA_SERVER_MAX_ITERATION_INTERVAL}
 #define FORTE_COM_OPC_UA_SERVER_PUB_INTERVAL ${FORTE_COM_OPC_UA_SERVER_PUB_INTERVAL}
 #define FORTE_COM_OPC_UA_CLIENT_PUB_INTERVAL ${FORTE_COM_OPC_UA_CLIENT_PUB_INTERVAL}
     
 #cmakedefine FORTE_COM_OPC_UA_MULTICAST
+#cmakedefine FORTE_COM_OPC_UA_WEBSOCKET
+#cmakedefine FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+#cmakedefine FORTE_COM_OPC_UA_WEBSOCKET_SECURE
 #cmakedefine FORTE_COM_OPC_UA_CUSTOM_HOSTNAME "${FORTE_COM_OPC_UA_CUSTOM_HOSTNAME}"

--- a/com/opc_ua/src/opcua_local_handler.cpp
+++ b/com/opc_ua/src/opcua_local_handler.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Florian Froschermeier <florian.froschermeier@tum.de>,
- *                          fortiss GmbH, Primetals Technologies Austria GmbH
+ * Copyright (c) 2015 Florian Froschermeier <florian.froschermeier@tum.de>,
+ *                    fortiss GmbH, Primetals Technologies Austria GmbH,
+ *                    HR Agrartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,13 +20,20 @@
  *      - Change CIEC_STRING to std::string
  *    Markus Meingast:
  *      - Add support for Object Structs
+ *    Franz Höpfinger
+ *      - Add optional OPC UA over WebSocket (insecure and secure transports) server endpoint
  *******************************************************************************/
 
-#include "opcua_defaults.h"
 #include "opcua_local_handler.h"
 
 #include <open62541/server.h>
 #include <open62541/server_config_default.h>
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET
+#include <open62541/plugin/eventloop.h>
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER
+#include "ws_connection_manager.h"
+#endif // FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER
+#endif // FORTE_COM_OPC_UA_WEBSOCKET
 
 #include "forte/iec61131_functions.h"
 #include "forte/cominfra/basecommfb.h"
@@ -41,6 +49,8 @@
 #include "detail/lds_me_handler.h"
 #endif // FORTE_COM_OPC_UA_MULTICAST
 #include <string>
+#include <cstdint>
+#include <limits>
 
 #ifndef FORTE_COM_OPC_UA_CUSTOM_HOSTNAME
 #include "forte/arch/sockhand.h"
@@ -74,8 +84,7 @@ namespace forte::com_infra::opc_ua {
   const char *const COPC_UA_Local_Handler::mDefaultDescriptionForVariableNodes = "Digital port of Function Block";
 
   COPC_UA_Local_Handler::COPC_UA_Local_Handler(CDeviceExecution &paDeviceExecution) :
-      COPC_UA_HandlerAbstract(paDeviceExecution),
-      mUaServer(nullptr) {
+      COPC_UA_HandlerAbstract(paDeviceExecution) {
   }
 
   COPC_UA_Local_Handler::~COPC_UA_Local_Handler() {
@@ -95,9 +104,20 @@ namespace forte::com_infra::opc_ua {
     stopServer();
   }
 
-  void COPC_UA_Local_Handler::run() {
-    DEVLOG_INFO("[OPC UA LOCAL]: Starting OPC UA Server: opc.tcp://localhost:%d\n", gOpcuaServerPort.mArgument);
+  namespace {
+    constexpr std::uint32_t scmWsPortOffset = 1U;
+    constexpr std::uint32_t scmWssPortOffset = 2U;
 
+    constexpr std::uint32_t getInsecureWsPort(std::uint32_t paTcpPort) {
+      return paTcpPort + scmWsPortOffset;
+    }
+
+    constexpr std::uint32_t getSecureWsPort(std::uint32_t paTcpPort) {
+      return paTcpPort + scmWssPortOffset;
+    }
+  } // namespace
+
+  void COPC_UA_Local_Handler::run() {
     UA_ServerConfig config{
         .logging = &getLogger(),
     };
@@ -113,11 +133,25 @@ namespace forte::com_infra::opc_ua {
     generateServerStrings(gOpcuaServerPort.mArgument, serverStrings);
     configureUAServer(serverStrings, config);
 
+    // Built from the endpoints configureUAServer() actually registered (e.g. it drops the
+    // unencrypted WebSocket endpoint if the WebSocket ConnectionManager failed to register,
+    // and the secure one if no certificate/private key were configured), not from the raw
+    // port and compile-time flags. Only logged below once the server has actually started
+    // listening.
+    std::string startupLogMsg = "[OPC UA LOCAL]: Starting OPC UA Server";
+    for (size_t i = 0; i < config.serverUrlsSize; ++i) {
+      startupLogMsg += (i == 0) ? ": " : ", ";
+      startupLogMsg +=
+          std::string(reinterpret_cast<const char *>(config.serverUrls[i].data), config.serverUrls[i].length);
+    }
+    startupLogMsg += "\n";
+
     mUaServer = UA_Server_newWithConfig(&config);
     if (mUaServer) {
       if (initializeNodesets(*mUaServer)) {
         UA_StatusCode retVal = UA_Server_run_startup(mUaServer);
         if (UA_STATUSCODE_GOOD == retVal) {
+          DEVLOG_INFO("%s", startupLogMsg.c_str());
           {
 #ifdef FORTE_COM_OPC_UA_MULTICAST
             // the extra curly brace on top is to limit the lifetime of this object.
@@ -130,6 +164,23 @@ namespace forte::com_infra::opc_ua {
               UA_UInt16 timeToSleepMs;
               {
                 util::CCriticalRegion criticalRegion(mServerAccessMutex);
+#if defined(FORTE_COM_OPC_UA_WEBSOCKET) && defined(FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER) &&                    \
+    !defined(UA_ENABLE_LWS)
+                // Must run on the same thread as UA_Server_run_iterate(), see
+                // ws_connection_manager.h: open62541 has no locking on this
+                // architecture, so all UA_Server access has to stay on this thread.
+                //
+                // The !defined(UA_ENABLE_LWS) guard matters here even though
+                // FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER is meant for platforms
+                // without it: if both end up defined for the same build, the #ifdef/#elif
+                // in configureUAServer() below still gives UA_ENABLE_LWS priority, so
+                // mWsConnectionManager is an LWS-backed UA_ConnectionManager, not a
+                // WsConnectionManager -- calling WsConnectionManager_poll() on it would be
+                // undefined behavior.
+                if (mWsConnectionManager) {
+                  WsConnectionManager_poll(mWsConnectionManager);
+                }
+#endif // FORTE_COM_OPC_UA_WEBSOCKET && FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER && !UA_ENABLE_LWS
                 timeToSleepMs = UA_Server_run_iterate(mUaServer, false);
               }
 
@@ -156,9 +207,19 @@ namespace forte::com_infra::opc_ua {
       }
       UA_Server_delete(mUaServer);
       mUaServer = nullptr;
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET
+      // mWsConnectionManager was torn down as part of the EventLoop that
+      // UA_Server_delete() just freed; drop the now-dangling pointer.
+      mWsConnectionManager = nullptr;
+#endif // FORTE_COM_OPC_UA_WEBSOCKET
     } else {
       DEVLOG_ERROR("[OPC UA LOCAL]: Couldn't initialize server\n");
       UA_ServerConfig_clear(&config);
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET
+      // Same as above: torn down together with the eventLoop that
+      // UA_ServerConfig_clear() just cleared.
+      mWsConnectionManager = nullptr;
+#endif // FORTE_COM_OPC_UA_WEBSOCKET
     }
     mServerStarted.inc(); // this will avoid locking startServer() for all cases where the starting of server failed
   }
@@ -185,18 +246,123 @@ namespace forte::com_infra::opc_ua {
 #endif // FORTE_COM_OPC_UA_MULTICAST
 
     paServerStrings.mAppURI = "org.eclipse.4diac."s;
-    paServerStrings.mHostname = std::string("opc.tcp://");
+    std::string serverName;
 #ifdef FORTE_COM_OPC_UA_CUSTOM_HOSTNAME
-    paServerStrings.mHostname.append(FORTE_COM_OPC_UA_CUSTOM_HOSTNAME);
-    paServerStrings.mHostname.append("-"s);
-    paServerStrings.mHostname.append(helperBuffer);
-    paServerStrings.mAppURI.append(paServerStrings.mHostname);
+    serverName = std::string(FORTE_COM_OPC_UA_CUSTOM_HOSTNAME) + "-" + helperBuffer;
+    paServerStrings.mAppURI.append("opc.tcp://" + serverName);
 #else
     paServerStrings.mAppURI.append(helperBuffer);
 #endif
+    // serverName stays empty here when FORTE_COM_OPC_UA_CUSTOM_HOSTNAME is not defined --
+    // that's intentional, not a lost host identifier: it matches this function's
+    // pre-WebSocket behavior (mHostname was always "opc.tcp://" + ":" + port in that case,
+    // helperBuffer only ever went into mAppURI), and an empty host makes open62541 listen
+    // on all interfaces, which is the desired default. See the WebSocket hostname comment
+    // below for the same rationale.
+    paServerStrings.mHostname = "opc.tcp://" + serverName;
     paServerStrings.mHostname.append(":");
     paServerStrings.mHostname.append(std::to_string(paUAServerPort));
+
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET
+    const auto makeWebSocketHostname = [&](const char *paScheme, const std::uint32_t paPort) {
+      std::string hostname(paScheme);
+      hostname.append(serverName);
+      hostname.append(":");
+      hostname.append(std::to_string(paPort));
+      return hostname;
+    };
+#if defined(FORTE_COM_OPC_UA_WEBSOCKET_SECURE)
+    constexpr std::uint32_t maxAllowedPort = std::numeric_limits<TForteUInt16>::max() - scmWssPortOffset;
+#else
+    constexpr std::uint32_t maxAllowedPort = std::numeric_limits<TForteUInt16>::max() - scmWsPortOffset;
+#endif
+    if (paUAServerPort <= maxAllowedPort) {
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+      // Mirrors mHostname above: an empty hostname makes open62541 listen on
+      // all interfaces, which is the default here (no FORTE_COM_OPC_UA_CUSTOM_HOSTNAME).
+      // Intentional unencrypted-WebSocket support (builder-configurable, off when
+      // INSECURE=OFF): a dev/test transport, never enabled by default.
+      paServerStrings.mWsHostname = makeWebSocketHostname(
+          "opc.ws://",
+          getInsecureWsPort(paUAServerPort)); // nosemgrep: javascript.lang.security.detect-insecure-websocket
+#endif // FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET_SECURE
+      paServerStrings.mWssHostname = makeWebSocketHostname("opc.wss://", getSecureWsPort(paUAServerPort));
+#endif // FORTE_COM_OPC_UA_WEBSOCKET_SECURE
+    } else {
+      DEVLOG_ERROR("[OPC UA LOCAL]: OPC UA server port %u is too high to derive WebSocket ports (max %u)\n",
+                   paUAServerPort, maxAllowedPort);
+    }
+#endif // FORTE_COM_OPC_UA_WEBSOCKET
   }
+
+#if defined(FORTE_COM_OPC_UA_WEBSOCKET) &&                                                                             \
+    (defined(UA_ENABLE_LWS) ||                                                                                         \
+     (defined(FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER) && defined(FORTE_COM_OPC_UA_WEBSOCKET_INSECURE)))
+  namespace {
+    // Registers paConnectionManager (already created by the caller) with the EventLoop.
+    // On any failure, logs, frees it, and nulls it out; on success, marks webSocketEnabled.
+    // Shared by both the UA_ENABLE_LWS and platform-ConnectionManager paths below, which
+    // otherwise differ only in how the ConnectionManager itself gets created. Guarded to
+    // match exactly the condition under which it's actually called (both call sites live
+    // in configureUAServer(), guarded the same way) so it isn't defined-but-unused when
+    // neither path applies.
+    // Frees paConnectionManager's event source, if the ConnectionManager provides a free
+    // callback at all (defensive -- not all implementations necessarily set one).
+    void freeWsEventSource(UA_ConnectionManager *paConnectionManager) {
+      if (paConnectionManager->eventSource.free) {
+        paConnectionManager->eventSource.free(&paConnectionManager->eventSource);
+      }
+    }
+
+    void registerWsConnectionManager(UA_ConnectionManager *&paConnectionManager, UA_ServerConfig &paUaServerConfig) {
+      if (!paConnectionManager) {
+        DEVLOG_ERROR("[OPC UA LOCAL]: Could not create the WebSocket ConnectionManager\n");
+        return;
+      }
+      if (paUaServerConfig.eventLoop == nullptr) {
+        DEVLOG_ERROR("[OPC UA LOCAL]: Could not register WebSocket ConnectionManager: eventLoop is null\n");
+        // registerEventSource() was never called here, so the event source was never
+        // linked into the EventLoop -- safe to free directly.
+        freeWsEventSource(paConnectionManager);
+        paConnectionManager = nullptr;
+        return;
+      }
+      const UA_StatusCode wsRetVal = paUaServerConfig.eventLoop->registerEventSource(paUaServerConfig.eventLoop,
+                                                                                     &paConnectionManager->eventSource);
+      if (wsRetVal != UA_STATUSCODE_GOOD) {
+        DEVLOG_ERROR("[OPC UA LOCAL]: Could not register the WebSocket ConnectionManager: %s\n",
+                     UA_StatusCode_name(wsRetVal));
+        // registerEventSource() links the event source into the EventLoop's internal list
+        // *before* attempting to start it, so on failure (a failed start()) it is still
+        // linked there even though the overall call reports failure -- confirmed against
+        // both the UA_ENABLE_LWS and platform ConnectionManager start() implementations,
+        // neither of which touch eventSource.state on a failure path, leaving it at the
+        // STOPPED state registerEventSource() set just before calling start(). Deregister
+        // it first so the EventLoop doesn't keep a dangling pointer to the memory freed
+        // below.
+        const UA_StatusCode deregisterStatus = paUaServerConfig.eventLoop->deregisterEventSource(
+            paUaServerConfig.eventLoop, &paConnectionManager->eventSource);
+        if (deregisterStatus != UA_STATUSCODE_GOOD) {
+          // Could not safely unlink it from the EventLoop (e.g. still mid-start) -- freeing
+          // it now would leave the EventLoop holding a dangling pointer, so leak it instead
+          // of risking a use-after-free.
+          DEVLOG_ERROR("[OPC UA LOCAL]: Could not deregister the failed WebSocket ConnectionManager: %s -- "
+                       "leaking it to avoid a dangling EventLoop reference\n",
+                       UA_StatusCode_name(deregisterStatus));
+          paConnectionManager = nullptr;
+          return;
+        }
+        freeWsEventSource(paConnectionManager);
+        paConnectionManager = nullptr;
+        return;
+      }
+      paUaServerConfig.webSocketEnabled = true;
+    }
+  } // namespace
+#endif // FORTE_COM_OPC_UA_WEBSOCKET && (UA_ENABLE_LWS || (FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER &&
+       // FORTE_COM_OPC_UA_WEBSOCKET_INSECURE))
 
   void COPC_UA_Local_Handler::configureUAServer(UA_ServerStrings &paServerStrings,
                                                 UA_ServerConfig &paUaServerConfig) const {
@@ -208,16 +374,79 @@ namespace forte::com_infra::opc_ua {
     paUaServerConfig.serverUrls = nullptr;
     paUaServerConfig.serverUrlsSize = 0;
 
-    UA_String serverUrls[1];
-    size_t serverUrlsSize = 0;
-    serverUrls[serverUrlsSize] = UA_STRING(&paServerStrings.mHostname[0]);
-    serverUrlsSize++;
-    UA_StatusCode retVal =
-        UA_Array_copy(serverUrls, serverUrlsSize, (void **) &paUaServerConfig.serverUrls, &UA_TYPES[UA_TYPES_STRING]);
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET
+    // WebSocket support (both insecure and secure transports): UA_ENABLE_WEBSOCKET_TRANSPORT
+    // (the generic server-side handling for both) looks up a UA_ConnectionManager named
+    // "websocket" in the EventLoop. On platforms built with UA_ENABLE_LWS (libwebsockets,
+    // POSIX-only), open62541 provides that ConnectionManager via
+    // UA_ConnectionManager_new_LWS_WebSocket. Platforms without libwebsockets (RTOS targets
+    // such as FreeRTOS/Zephyr, e.g. ESP-IDF builds) never define UA_ENABLE_LWS; there
+    // webSocketEnabled is set directly and the unencrypted transport has to come from a
+    // ConnectionManager registered by that platform's own code.
+    bool webSocketTransportAvailable = false;
+    paUaServerConfig.webSocketEnabled = false;
+#ifdef UA_ENABLE_LWS
+    mWsConnectionManager = UA_ConnectionManager_new_LWS_WebSocket(UA_STRING_STATIC("websocket"));
+    registerWsConnectionManager(mWsConnectionManager, paUaServerConfig);
+    if (mWsConnectionManager) {
+      webSocketTransportAvailable = true;
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+      paUaServerConfig.webSocketAllowUnencrypted = true;
+#endif
+    }
+#elif defined(FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER) && defined(FORTE_COM_OPC_UA_WEBSOCKET_INSECURE)
+    // No libwebsockets on this platform (e.g. ESP-IDF/FreeRTOS+lwIP): use the
+    // platform-provided "websocket" ConnectionManager instead (unencrypted transport
+    // only, WsCM_openConnection() rejects useSSL, so the secure one stays disabled).
+    mWsConnectionManager = WsConnectionManager_new();
+    registerWsConnectionManager(mWsConnectionManager, paUaServerConfig);
+    if (mWsConnectionManager) {
+      webSocketTransportAvailable = true;
+      paUaServerConfig.webSocketAllowUnencrypted = true;
+    }
+#else
+    // No ConnectionManager is created here when libwebsockets is unavailable.
+#endif // UA_ENABLE_LWS
+#endif // FORTE_COM_OPC_UA_WEBSOCKET
+
+    std::vector<UA_String> serverUrls;
+    serverUrls.push_back(UA_STRING(&paServerStrings.mHostname[0]));
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+    if (webSocketTransportAvailable && !paServerStrings.mWsHostname.empty()) {
+      serverUrls.push_back(UA_STRING(&paServerStrings.mWsHostname[0]));
+    }
+#endif // FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET_SECURE
+    const bool hasWebSocketCredentials =
+        paUaServerConfig.webSocketCertificate.length > 0 && paUaServerConfig.webSocketCertificate.data != nullptr &&
+        paUaServerConfig.webSocketPrivateKey.length > 0 && paUaServerConfig.webSocketPrivateKey.data != nullptr;
+    if (!paServerStrings.mWssHostname.empty()) {
+      if (webSocketTransportAvailable && hasWebSocketCredentials) {
+        serverUrls.push_back(UA_STRING(&paServerStrings.mWssHostname[0]));
+      } else if (!hasWebSocketCredentials) {
+        // Forte itself never populates webSocketCertificate/webSocketPrivateKey -- there is
+        // no built-in configuration path for them yet, so with a stock (unpatched)
+        // UA_ServerConfig_setDefault() this branch is always taken and opc.wss:// can never
+        // actually come up. Logged as an error, not a warning: FORTE_COM_OPC_UA_WEBSOCKET_SECURE
+        // defaulting to ON creates an explicit expectation of an encrypted endpoint that this
+        // build cannot meet, which the operator needs to notice.
+        DEVLOG_ERROR("[OPC UA LOCAL]: opc.wss:// endpoint requires webSocketCertificate and webSocketPrivateKey "
+                     "credentials, which forte does not currently provide a configuration path for; disabling "
+                     "opc.wss://\n");
+      } else {
+        DEVLOG_WARNING("[OPC UA LOCAL]: opc.wss:// endpoint configured with valid webSocketCertificate and "
+                       "webSocketPrivateKey, but WebSocket transport is unavailable; disabling opc.wss://\n");
+      }
+    }
+#endif // FORTE_COM_OPC_UA_WEBSOCKET_SECURE
+
+    UA_StatusCode retVal = UA_Array_copy(serverUrls.data(), serverUrls.size(), (void **) &paUaServerConfig.serverUrls,
+                                         &UA_TYPES[UA_TYPES_STRING]);
     if (retVal != UA_STATUSCODE_GOOD) {
+      DEVLOG_ERROR("[OPC UA LOCAL]: Could not set the server URLs. Error: %s\n", UA_StatusCode_name(retVal));
       return;
     }
-    paUaServerConfig.serverUrlsSize = serverUrlsSize;
+    paUaServerConfig.serverUrlsSize = serverUrls.size();
 
     // delete pre-initialized values
     UA_LocalizedText_clear(&paUaServerConfig.applicationDescription.applicationName);

--- a/com/opc_ua/src/opcua_local_handler.h
+++ b/com/opc_ua/src/opcua_local_handler.h
@@ -1,6 +1,7 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2025 Florian Froschermeier <florian.froschermeier@tum.de>,
- *                          fortiss GmbH, Primetals Technologies Austria GmbH
+ * Copyright (c) 2015 Florian Froschermeier <florian.froschermeier@tum.de>,
+ *                    fortiss GmbH, Primetals Technologies Austria GmbH,
+ *                    HR Agrartechnik GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,6 +20,8 @@
  *      - Change CIEC_STRING to std::string
  *    Markus Meingast:
  *      - Add support for Object Structs
+ *    Franz Höpfinger
+ *      - Add optional OPC UA over WebSocket (insecure and secure transports) server endpoint
  *******************************************************************************/
 
 #pragma once
@@ -31,11 +34,24 @@
 #include "forte/arch/forte_sem.h"
 #include "forte/arch/forte_sync.h"
 
+// Must come before any use of FORTE_COM_OPC_UA_WEBSOCKET below: this header is
+// also reached via stdfblib/system/src/OPCUA_MGR.h, in a different CMake target
+// than forte-com-opc_ua. Without including the generated defaults here, that
+// target would see FORTE_COM_OPC_UA_WEBSOCKET as undefined while opcua_local_handler.cpp
+// sees it defined, giving COPC_UA_Local_Handler two different sizes (ODR violation:
+// mWsConnectionManager present in one TU's layout, absent in the other's) - the
+// constructor (compiled once, with the member present) then writes past the end of
+// an object allocated using the smaller, member-less size.
+#include "opcua_defaults.h"
+
 #include "opcua_handler_abstract.h"
 #include "opcua_helper.h"
 
 struct UA_Server;
 struct UA_ServerConfig;
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET
+struct UA_ConnectionManager;
+#endif // FORTE_COM_OPC_UA_WEBSOCKET
 
 namespace forte::com_infra::opc_ua {
   /**
@@ -197,6 +213,12 @@ namespace forte::com_infra::opc_ua {
        */
       struct UA_ServerStrings {
           std::string mHostname;
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+          std::string mWsHostname;
+#endif // FORTE_COM_OPC_UA_WEBSOCKET_INSECURE
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET_SECURE
+          std::string mWssHostname;
+#endif // FORTE_COM_OPC_UA_WEBSOCKET_SECURE
           std::string mAppURI;
 #ifdef FORTE_COM_OPC_UA_MULTICAST
           std::string mMdnsServerName;
@@ -211,7 +233,11 @@ namespace forte::com_infra::opc_ua {
       void generateServerStrings(TForteUInt16 paUAServerPort, UA_ServerStrings &paServerStrings) const;
 
       /**
-       *  Creates the configuration for the OPC UA Server.
+       *  Creates the configuration for the OPC UA Server. When built with
+       *  FORTE_COM_OPC_UA_WEBSOCKET, also creates and registers the WebSocket
+       *  ConnectionManager backing paServerStrings.mWsHostname (unencrypted) and
+       *  paServerStrings.mWssHostname (secure), storing it in
+       *  mWsConnectionManager.
        * @param paServerStrings Strings needed to configure the server
        * @param paUaServerConfig Place to store all the configurations
        */
@@ -220,7 +246,21 @@ namespace forte::com_infra::opc_ua {
       /**
        * Handler of the OPC UA stack server
        */
-      UA_Server *mUaServer;
+      UA_Server *mUaServer = nullptr;
+
+#ifdef FORTE_COM_OPC_UA_WEBSOCKET
+      /**
+       * WebSocket ConnectionManager backing the server's insecure and secure
+       * endpoints. Only populated on platforms built with UA_ENABLE_LWS
+       * (libwebsockets, POSIX-only), where it is created via
+       * UA_ConnectionManager_new_LWS_WebSocket; stays null on platforms without
+       * libwebsockets (RTOS targets such as FreeRTOS/Zephyr), where the unencrypted
+       * transport has to be backed by a ConnectionManager registered elsewhere.
+       * Owned by the EventLoop of mUaServer once registered -- freed together with
+       * it, torn down in run() by UA_Server_delete().
+       */
+      mutable UA_ConnectionManager *mWsConnectionManager = nullptr;
+#endif // FORTE_COM_OPC_UA_WEBSOCKET
 
       /**
        * Maximal length for the server name


### PR DESCRIPTION
See also:

- https://github.com/franz-hoepfinger-4diac-org/4diac-forte/pull/33
- https://github.com/eclipse-4diac/4diac-forte/discussions/1002




Introduces FORTE_COM_OPC_UA_WEBSOCKET (default OFF), which registers
opc.ws:// and/or opc.wss:// endpoints alongside the plain opc.tcp:// one,
one and two ports above it respectively. On platforms built with
UA_ENABLE_LWS (libwebsockets, POSIX-only), the endpoints are backed by
open62541's LWS-based WebSocket ConnectionManager
(UA_ConnectionManager_new_LWS_WebSocket) and support both opc.ws:// and
opc.wss://. On RTOS targets without libwebsockets (e.g. ESP-IDF), a
platform-provided ConnectionManager can be plugged in via
FORTE_COM_OPC_UA_WEBSOCKET_CONNECTIONMANAGER_DIR instead, supporting
opc.ws:// only. FORTE_COM_OPC_UA_WEBSOCKET_INSECURE/_SECURE gate the two
transports independently; INSECURE defaults to OFF so enabling WebSocket
support doesn't implicitly expose an unencrypted endpoint.

The WebSocket support (UA_ServerConfig::webSocketEnabled and friends,
UA_ENABLE_LWS) is a patch on top of upstream open62541, not present in
stock releases such as the "1.5.4" pulled in by the find_package()
fallback. Guard this with a configure-time capability check instead of
letting it fail with a confusing compiler error deep in
opcua_local_handler.cpp: check the relevant UA_ServerConfig members via
CMAKE_REQUIRED_INCLUDES rather than linking against open62541::open62541,
since FORTE_COM_OPC_UA_INCLUDE_DIR mode is headers-only by design (the
library is compiled and linked one level up, e.g. as its own ESP-IDF
component) and a link-based check would always spuriously fail there.
Also reject the default SECURE=ON/INSECURE=OFF combination when
UA_ENABLE_LWS isn't available, since opc.wss:// has no non-LWS backend and
that combination would otherwise silently register no WebSocket endpoint
at all.

The server startup log now reflects the endpoints configureUAServer()
actually registered (read back from UA_ServerConfig::serverUrls after
configuration, e.g. dropping opc.ws:// if the WebSocket ConnectionManager
failed to register, or opc.wss:// if no certificate/private key were
configured) and is only emitted once the server has actually started
listening, rather than being derived from the configured port and
compile-time flags before any of that runs.

opcua_local_handler.h now includes opcua_defaults.h directly: that header
is also reached via stdfblib/system/src/OPCUA_MGR.h in a different CMake
target than forte-com-opc_ua, and without it that target would see
FORTE_COM_OPC_UA_WEBSOCKET as undefined while opcua_local_handler.cpp sees
it defined -- an ODR violation (COPC_UA_Local_Handler with and without
mWsConnectionManager) that had the constructor writing past the end of an
object allocated using the smaller, member-less layout.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
