### PR TITLE
fix(opc_ua): report the actual SecureChannel state in the client callback

### DIFF
--- a/com/opc_ua/src/opcua_client_information.cpp
+++ b/com/opc_ua/src/opcua_client_information.cpp
@@ -790,12 +790,17 @@ namespace forte::com_infra::opc_ua {
     // there
     if (channelState == UA_SECURECHANNELSTATE_CLOSED) {
       DEVLOG_INFO("[OPC UA CLIENT]: The client is disconnected\n");
-    } else if (channelState != UA_SECURECHANNELSTATE_OPEN) {
-      DEVLOG_INFO("[OPC UA CLIENT]: A TCP connection to the server is open\n");
-    } else if (sessionState != UA_SESSIONSTATE_ACTIVATED) {
-      DEVLOG_INFO("[OPC UA CLIENT]: A SecureChannel to the server is open\n");
-    } else if (sessionState == UA_SESSIONSTATE_ACTIVATED) {
-      DEVLOG_INFO("[OPC UA CLIENT]: A session with the server is open\n");
+    } else if (channelState == UA_SECURECHANNELSTATE_OPEN) {
+      if (sessionState == UA_SESSIONSTATE_ACTIVATED) {
+        DEVLOG_INFO("[OPC UA CLIENT]: A session with the server is open\n");
+      } else {
+        DEVLOG_INFO("[OPC UA CLIENT]: A SecureChannel to the server is open\n");
+      }
+    } else {
+      // Everything between CLOSED and OPEN (CONNECTING, RHE/HEL/ACK/OPN
+      // handshake steps, ...) -- report the actual state so a stuck/failed
+      // handshake can be pinpointed instead of being reported as "open".
+      DEVLOG_INFO("[OPC UA CLIENT]: Connecting to the server (channel state %d)\n", channelState);
     }
     if (connectStatus != UA_STATUSCODE_GOOD) {
       DEVLOG_WARNING("[OPC UA CLIENT]: client error: channel %d, session %d, status 0x%08x\n", channelState,


### PR DESCRIPTION
clientStateChangeCallback logged "A TCP connection to the server is open"
for every channelState other than CLOSED and OPEN -- including CONNECTING,
RHE_SENT, HEL_SENT, ACK_SENT, ACK_RECEIVED and OPN_SENT. This made an
in-progress or stuck handshake indistinguishable from a genuinely open TCP
connection in the log, which made diagnosing connection failures (e.g. a
client that connects at the TCP level but never completes the SecureChannel
handshake) much harder than it needed to be.

Now the SecureChannel-open case is only reported when the channel is
actually UA_SECURECHANNELSTATE_OPEN, and every other non-closed state logs
the concrete channelState value instead of a misleading "open" message.

- https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-forte/pull/41
