### PR TITLE
Add generic function block GEN_E_D_FF

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
+++ b/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(forte-events PUBLIC
         E_TRAIN_fbt.h
         E_TRIG_fbt.h
         GEN_E_DEMUX_fbt.h
+        GEN_E_D_FF_fbt.h
         GEN_E_MUX_fbt.h
         GEN_E_MERGE_fbt.h
         GEN_E_REND_fbt.h

--- a/stdfblib/events/include/forte/iec61499/events/GEN_E_D_FF_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/GEN_E_D_FF_fbt.h
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - implement Generic GEN_E_D_FF_fbt
+ *******************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "forte/genfb.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/stringid.h"
+
+namespace forte::iec61499::events {
+  /**
+   * @brief A generic function block for a data (D) latch over multiple parallel BOOL channels.
+   *
+   * The number of channels is determined by the instance name, e.g., an instance
+   * named "E_D_FF_3" will have 3 data inputs (D1, D2, D3) and 3 data outputs (Q1, Q2, Q3).
+   * On CLK, all Qi are latched to the corresponding Di, and EO is fired only if at
+   * least one Di differed from the previously latched Qi.
+   */
+  class GEN_E_D_FF final : public CGenFunctionBlock<CFunctionBlock> {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_E_D_FF)
+
+    protected:
+      /** EO is the single fixed event output; it is not part of the generic set. */
+      size_t getGenEOOffset() override {
+        return 1;
+      }
+
+      CEventConnection *getEOConUnchecked(TPortId) override;
+
+      void createGenInputData() override;
+      void createGenOutputData() override;
+
+      CIEC_ANY *getDI(size_t paIndex) override;
+      CIEC_ANY *getDO(size_t paIndex) override;
+
+    private:
+      static const TEventID scmEventCLKID = 0;
+      static const TEventID scmEventEOID = 0;
+
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+
+      bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
+
+      /** Dynamically generated port names for D1..Dn / Q1..Qn. */
+      std::vector<StringId> mDINames;
+      std::vector<StringId> mDONames;
+
+      /** Latched data values D1..Dn / Q1..Qn. */
+      std::unique_ptr<CIEC_BOOL[]> mGenDs;
+      std::unique_ptr<CIEC_BOOL[]> mGenQs;
+
+    public:
+      GEN_E_D_FF(StringId paInstanceNameId, CFBContainer &paContainer);
+      ~GEN_E_D_FF() override = default;
+
+      CEventConnection conn_EO;
+  };
+} // namespace forte::iec61499::events

--- a/stdfblib/events/src/CMakeLists.txt
+++ b/stdfblib/events/src/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(forte-events PRIVATE
         E_TRAIN_fbt.cpp
         E_TRIG_fbt.cpp
         GEN_E_DEMUX_fbt.cpp
+        GEN_E_D_FF_fbt.cpp
         GEN_E_MUX_fbt.cpp
         GEN_E_MERGE_fbt.cpp
         GEN_E_REND_fbt.cpp

--- a/stdfblib/events/src/GEN_E_D_FF_fbt.cpp
+++ b/stdfblib/events/src/GEN_E_D_FF_fbt.cpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - implement Generic GEN_E_D_FF_fbt
+ *******************************************************************************/
+
+#include "forte/iec61499/events/GEN_E_D_FF_fbt.h"
+#include "forte/util/string_utils.h"
+
+using namespace forte::literals;
+
+namespace forte::iec61499::events {
+  namespace {
+    const auto cEventInputNames = std::array{"CLK"_STRID};
+    const auto cEventOutputNames = std::array{"EO"_STRID};
+  } // namespace
+
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_E_D_FF, "iec61499::events::GEN_E_D_FF"_STRID)
+
+  GEN_E_D_FF::GEN_E_D_FF(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CGenFunctionBlock<CFunctionBlock>(paContainer, paInstanceNameId),
+      conn_EO(*this, 0) {
+  }
+
+  void GEN_E_D_FF::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    if (scmEventCLKID == paEIID) {
+      const size_t numD = getFBInterfaceSpec().getNumDIs();
+
+      bool changed = false;
+      for (size_t i = 0; i < numD; ++i) {
+        if (static_cast<bool>(mGenDs[i]) != static_cast<bool>(mGenQs[i])) {
+          changed = true;
+          break;
+        }
+      }
+
+      if (changed) {
+        for (size_t i = 0; i < numD; ++i) {
+          mGenQs[i] = mGenDs[i];
+        }
+        sendOutputEvent(scmEventEOID, paECET);
+      }
+    }
+  }
+
+  void GEN_E_D_FF::readInputData(TEventID) {
+    for (TPortId i = 0; i < getFBInterfaceSpec().getNumDIs(); ++i) {
+      readData(i, mGenDs[i], mGenDIConns[i]);
+    }
+  }
+
+  void GEN_E_D_FF::writeOutputData(TEventID) {
+    const TPortId numD = static_cast<TPortId>(getFBInterfaceSpec().getNumDIs());
+    for (TPortId i = 0; i < getFBInterfaceSpec().getNumDOs(); ++i) {
+      writeData(numD + i, mGenQs[i], mGenDOConns[i]);
+    }
+  }
+
+  bool GEN_E_D_FF::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    // Find the last underscore in the name, e.g., "E_D_FF_3".
+    const char *acPos = strrchr(paConfigString, '_');
+
+    if (nullptr != acPos) {
+      ++acPos; // Move pointer to the character after the underscore.
+
+      char *acEnd = nullptr;
+      const size_t numD = static_cast<size_t>(util::strtoul(acPos, &acEnd, 10));
+
+      if (('\0' == *acEnd) && numD >= 1 && numD < cgInvalidPortId) {
+        generateGenericInterfacePointNameArray("D", mDINames, numD);
+        generateGenericInterfacePointNameArray("Q", mDONames, numD);
+
+        paInterfaceSpec.mEINames = cEventInputNames;
+        paInterfaceSpec.mEONames = cEventOutputNames;
+        paInterfaceSpec.mDINames = mDINames;
+        paInterfaceSpec.mDONames = mDONames;
+        return true;
+      }
+
+      DEVLOG_ERROR("Cannot configure FB-Instance E_D_FF_%zu. Number of data channels must be within 1 and %u.\n", numD,
+                   cgInvalidPortId);
+    }
+    return false;
+  }
+
+  CEventConnection *GEN_E_D_FF::getEOConUnchecked(const TPortId paIndex) {
+    return (paIndex == 0) ? &conn_EO : nullptr;
+  }
+
+  void GEN_E_D_FF::createGenInputData() {
+    mGenDs = std::make_unique<CIEC_BOOL[]>(getFBInterfaceSpec().getNumDIs());
+  }
+
+  void GEN_E_D_FF::createGenOutputData() {
+    mGenQs = std::make_unique<CIEC_BOOL[]>(getFBInterfaceSpec().getNumDOs());
+  }
+
+  CIEC_ANY *GEN_E_D_FF::getDI(const size_t paIndex) {
+    return &mGenDs[paIndex];
+  }
+
+  CIEC_ANY *GEN_E_D_FF::getDO(const size_t paIndex) {
+    return &mGenQs[paIndex];
+  }
+} // namespace forte::iec61499::events

--- a/tests/stdfblib/events/CMakeLists.txt
+++ b/tests/stdfblib/events/CMakeLists.txt
@@ -32,5 +32,7 @@ forte_test_add_sourcefile_cpp(E_REND_tester.cpp)
 forte_test_add_sourcefile_cpp(GEN_E_REND_2_tester.cpp)
 forte_test_add_sourcefile_cpp(GEN_E_REND_3_tester.cpp)
 forte_test_add_sourcefile_cpp(GEN_E_REND_4_tester.cpp)
+forte_test_add_sourcefile_cpp(GEN_E_D_FF_1_tester.cpp)
+forte_test_add_sourcefile_cpp(GEN_E_D_FF_3_tester.cpp)
 
 

--- a/tests/stdfblib/events/GEN_E_D_FF_1_tester.cpp
+++ b/tests/stdfblib/events/GEN_E_D_FF_1_tester.cpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include "../../core/fbtests/fbtestfixture.h"
+#include "forte/datatypes/forte_bool.h"
+
+using namespace forte::literals;
+
+namespace forte::iec61499::events::test {
+  struct GEN_E_D_FF_1_TestFixture : public forte::test::CFBTestFixtureBase {
+      CIEC_BOOL mD1{false_BOOL};
+      CIEC_BOOL mQ1{false_BOOL};
+
+      GEN_E_D_FF_1_TestFixture() : CFBTestFixtureBase("iec61499::events::E_D_FF_1"_STRID) {
+        setInputData({&mD1});
+        setOutputData({&mQ1});
+        setup();
+      }
+
+      static constexpr TEventID CLK = 0;
+      static constexpr TEventID EO = 0;
+  };
+
+  BOOST_FIXTURE_TEST_SUITE(GenEDFf1Tests, GEN_E_D_FF_1_TestFixture)
+
+  BOOST_AUTO_TEST_CASE(NoChangeDoesNotFire) {
+    triggerEvent(CLK); // D1 still false, same as latched Q1
+    BOOST_CHECK(eventChainEmpty());
+  }
+
+  BOOST_AUTO_TEST_CASE(InitialClockLatches) {
+    mD1 = true_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    BOOST_CHECK(static_cast<bool>(mQ1));
+  }
+
+  BOOST_AUTO_TEST_CASE(UnchangedClockDoesNotFireAgain) {
+    mD1 = true_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+
+    triggerEvent(CLK); // D1 unchanged
+    BOOST_CHECK(eventChainEmpty());
+  }
+
+  BOOST_AUTO_TEST_CASE(ChangeFiresAgain) {
+    mD1 = true_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+
+    mD1 = false_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    BOOST_CHECK(!static_cast<bool>(mQ1));
+  }
+
+  BOOST_AUTO_TEST_SUITE_END()
+} // namespace forte::iec61499::events::test

--- a/tests/stdfblib/events/GEN_E_D_FF_3_tester.cpp
+++ b/tests/stdfblib/events/GEN_E_D_FF_3_tester.cpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include "../../core/fbtests/fbtestfixture.h"
+#include "forte/datatypes/forte_bool.h"
+
+using namespace forte::literals;
+
+namespace forte::iec61499::events::test {
+  struct GEN_E_D_FF_3_TestFixture : public forte::test::CFBTestFixtureBase {
+      CIEC_BOOL mD1{false_BOOL};
+      CIEC_BOOL mD2{false_BOOL};
+      CIEC_BOOL mD3{false_BOOL};
+      CIEC_BOOL mQ1{false_BOOL};
+      CIEC_BOOL mQ2{false_BOOL};
+      CIEC_BOOL mQ3{false_BOOL};
+
+      GEN_E_D_FF_3_TestFixture() : CFBTestFixtureBase("iec61499::events::E_D_FF_3"_STRID) {
+        setInputData({&mD1, &mD2, &mD3});
+        setOutputData({&mQ1, &mQ2, &mQ3});
+        setup();
+      }
+
+      static constexpr TEventID CLK = 0;
+      static constexpr TEventID EO = 0;
+  };
+
+  BOOST_FIXTURE_TEST_SUITE(GenEDFf3Tests, GEN_E_D_FF_3_TestFixture)
+
+  BOOST_AUTO_TEST_CASE(AllEqualDoesNotFire) {
+    triggerEvent(CLK); // all Di still false, same as latched Qi
+    BOOST_CHECK(eventChainEmpty());
+  }
+
+  BOOST_AUTO_TEST_CASE(PartialChangeFiresAndLatchesAll) {
+    mD1 = true_BOOL;
+    mD2 = false_BOOL;
+    mD3 = false_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    BOOST_CHECK(static_cast<bool>(mQ1));
+    BOOST_CHECK(!static_cast<bool>(mQ2));
+    BOOST_CHECK(!static_cast<bool>(mQ3));
+
+    triggerEvent(CLK); // no change
+    BOOST_CHECK(eventChainEmpty());
+
+    mD2 = true_BOOL; // only D2 changes now
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    BOOST_CHECK(static_cast<bool>(mQ1));
+    BOOST_CHECK(static_cast<bool>(mQ2));
+    BOOST_CHECK(!static_cast<bool>(mQ3));
+  }
+
+  BOOST_AUTO_TEST_SUITE_END()
+} // namespace forte::iec61499::events::test


### PR DESCRIPTION
Introduces a generic data latch function block (GEN_E_D_FF) for IEC 61499, allowing customizable boolean channel configurations. The function block can handle varying numbers of data inputs and outputs, determined by the instance naming convention, such as E_D_FF_3 for three channels. 

Enhancements include:
- Implementation of the GEN_E_D_FF function block to manage data latching across multiple boolean channels.
- Tests for 1-channel and 3-channel configurations to verify correct functionality, ensuring output events are fired only when input data differs from latched values.
- Safeguards against malformed instance suffixes.

This addition serves to enhance flexibility and configurability in event-based systems.

- https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-forte/pull/39
- https://github.com/eclipse-4diac/4diac-ide/pull/2780
