### PR TITLE
Add generic GEN_E_D_FF_ANY function block and tests

### DIFF
--- a/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
+++ b/stdfblib/events/include/forte/iec61499/events/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(forte-events PUBLIC
         E_TRAIN_fbt.h
         E_TRIG_fbt.h
         GEN_E_DEMUX_fbt.h
+        GEN_E_D_FF_ANY_fbt.h
         GEN_E_MUX_fbt.h
         GEN_E_MERGE_fbt.h
         GEN_E_REND_fbt.h

--- a/stdfblib/events/include/forte/iec61499/events/GEN_E_D_FF_ANY_fbt.h
+++ b/stdfblib/events/include/forte/iec61499/events/GEN_E_D_FF_ANY_fbt.h
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - implement Generic GEN_E_D_FF_ANY_fbt
+ *******************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "forte/genfb.h"
+#include "forte/datatypes/forte_any_variant.h"
+#include "forte/stringid.h"
+
+namespace forte::iec61499::events {
+  /**
+   * @brief A generic function block for a data (D) latch over multiple parallel ANY channels.
+   *
+   * The number of channels is determined by the instance name, e.g., an instance
+   * named "E_D_FF_ANY_3" will have 3 data inputs (D1, D2, D3) and 3 data outputs (Q1, Q2, Q3).
+   * On CLK, all Qi are latched to the corresponding Di, and EO is fired only if at
+   * least one Di differed from the previously latched Qi.
+   */
+  class GEN_E_D_FF_ANY final : public CGenFunctionBlock<CFunctionBlock> {
+      DECLARE_GENERIC_FIRMWARE_FB(GEN_E_D_FF_ANY)
+
+    protected:
+      /** EO is the single fixed event output; it is not part of the generic set. */
+      size_t getGenEOOffset() override {
+        return 1;
+      }
+
+      CEventConnection *getEOConUnchecked(TPortId) override;
+
+      void createGenInputData() override;
+      void createGenOutputData() override;
+
+      CIEC_ANY *getDI(size_t paIndex) override;
+      CIEC_ANY *getDO(size_t paIndex) override;
+
+    private:
+      static const TEventID scmEventCLKID = 0;
+      static const TEventID scmEventEOID = 0;
+
+      void executeEvent(TEventID paEIID, CEventChainExecutionThread *const paECET) override;
+
+      void readInputData(TEventID paEIID) override;
+      void writeOutputData(TEventID paEIID) override;
+
+      bool createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) override;
+
+      /** Dynamically generated port names for D1..Dn / Q1..Qn. */
+      std::vector<StringId> mDINames;
+      std::vector<StringId> mDONames;
+
+      /** Latched data values D1..Dn / Q1..Qn. */
+      std::unique_ptr<CIEC_ANY_VARIANT[]> mGenDs;
+      std::unique_ptr<CIEC_ANY_VARIANT[]> mGenQs;
+
+    public:
+      GEN_E_D_FF_ANY(StringId paInstanceNameId, CFBContainer &paContainer);
+      ~GEN_E_D_FF_ANY() override = default;
+
+      CEventConnection conn_EO;
+  };
+} // namespace forte::iec61499::events

--- a/stdfblib/events/src/CMakeLists.txt
+++ b/stdfblib/events/src/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(forte-events PRIVATE
         E_TRAIN_fbt.cpp
         E_TRIG_fbt.cpp
         GEN_E_DEMUX_fbt.cpp
+        GEN_E_D_FF_ANY_fbt.cpp
         GEN_E_MUX_fbt.cpp
         GEN_E_MERGE_fbt.cpp
         GEN_E_REND_fbt.cpp

--- a/stdfblib/events/src/GEN_E_D_FF_ANY_fbt.cpp
+++ b/stdfblib/events/src/GEN_E_D_FF_ANY_fbt.cpp
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - implement Generic GEN_E_D_FF_ANY_fbt
+ *******************************************************************************/
+
+#include "forte/iec61499/events/GEN_E_D_FF_ANY_fbt.h"
+#include "forte/util/string_utils.h"
+
+using namespace forte::literals;
+
+namespace forte::iec61499::events {
+  namespace {
+    const auto cEventInputNames = std::array{"CLK"_STRID};
+    const auto cEventOutputNames = std::array{"EO"_STRID};
+  } // namespace
+
+  DEFINE_GENERIC_FIRMWARE_FB(GEN_E_D_FF_ANY, "iec61499::events::GEN_E_D_FF_ANY"_STRID)
+
+  GEN_E_D_FF_ANY::GEN_E_D_FF_ANY(const StringId paInstanceNameId, CFBContainer &paContainer) :
+      CGenFunctionBlock<CFunctionBlock>(paContainer, paInstanceNameId),
+      conn_EO(*this, 0) {
+  }
+
+  void GEN_E_D_FF_ANY::executeEvent(const TEventID paEIID, CEventChainExecutionThread *const paECET) {
+    if (scmEventCLKID == paEIID) {
+      const size_t numD = getFBInterfaceSpec().getNumDIs();
+
+      bool changed = false;
+      for (size_t i = 0; i < numD; ++i) {
+        if (!mGenQs[i].equals(mGenDs[i])) {
+          changed = true;
+          break;
+        }
+      }
+
+      if (changed) {
+        for (size_t i = 0; i < numD; ++i) {
+          mGenQs[i].setValue(mGenDs[i].unwrap());
+        }
+        sendOutputEvent(scmEventEOID, paECET);
+      }
+    }
+  }
+
+  void GEN_E_D_FF_ANY::readInputData(TEventID) {
+    for (TPortId i = 0; i < getFBInterfaceSpec().getNumDIs(); ++i) {
+      readData(i, mGenDs[i], mGenDIConns[i]);
+    }
+  }
+
+  void GEN_E_D_FF_ANY::writeOutputData(TEventID) {
+    const TPortId numD = static_cast<TPortId>(getFBInterfaceSpec().getNumDIs());
+    for (TPortId i = 0; i < getFBInterfaceSpec().getNumDOs(); ++i) {
+      writeData(numD + i, mGenQs[i], mGenDOConns[i]);
+    }
+  }
+
+  bool GEN_E_D_FF_ANY::createInterfaceSpec(const char *paConfigString, SFBInterfaceSpec &paInterfaceSpec) {
+    // Find the last underscore in the name, e.g., "E_D_FF_ANY_3".
+    const char *acPos = strrchr(paConfigString, '_');
+
+    if (nullptr != acPos) {
+      ++acPos; // Move pointer to the character after the underscore.
+
+      char *acEnd = nullptr;
+      const size_t numD = static_cast<size_t>(util::strtoul(acPos, &acEnd, 10));
+
+      if (('\0' == *acEnd) && numD >= 1 && numD < cgInvalidPortId) {
+        generateGenericInterfacePointNameArray("D", mDINames, numD);
+        generateGenericInterfacePointNameArray("Q", mDONames, numD);
+
+        paInterfaceSpec.mEINames = cEventInputNames;
+        paInterfaceSpec.mEONames = cEventOutputNames;
+        paInterfaceSpec.mDINames = mDINames;
+        paInterfaceSpec.mDONames = mDONames;
+        return true;
+      }
+
+      DEVLOG_ERROR("Cannot configure FB-Instance E_D_FF_ANY_%zu. Number of data channels must be within 1 and %u.\n",
+                   numD, cgInvalidPortId);
+    }
+    return false;
+  }
+
+  CEventConnection *GEN_E_D_FF_ANY::getEOConUnchecked(const TPortId paIndex) {
+    return (paIndex == 0) ? &conn_EO : nullptr;
+  }
+
+  void GEN_E_D_FF_ANY::createGenInputData() {
+    mGenDs = std::make_unique<CIEC_ANY_VARIANT[]>(getFBInterfaceSpec().getNumDIs());
+  }
+
+  void GEN_E_D_FF_ANY::createGenOutputData() {
+    mGenQs = std::make_unique<CIEC_ANY_VARIANT[]>(getFBInterfaceSpec().getNumDOs());
+  }
+
+  CIEC_ANY *GEN_E_D_FF_ANY::getDI(const size_t paIndex) {
+    return &mGenDs[paIndex];
+  }
+
+  CIEC_ANY *GEN_E_D_FF_ANY::getDO(const size_t paIndex) {
+    return &mGenQs[paIndex];
+  }
+} // namespace forte::iec61499::events

--- a/tests/stdfblib/events/CMakeLists.txt
+++ b/tests/stdfblib/events/CMakeLists.txt
@@ -32,5 +32,7 @@ forte_test_add_sourcefile_cpp(E_REND_tester.cpp)
 forte_test_add_sourcefile_cpp(GEN_E_REND_2_tester.cpp)
 forte_test_add_sourcefile_cpp(GEN_E_REND_3_tester.cpp)
 forte_test_add_sourcefile_cpp(GEN_E_REND_4_tester.cpp)
+forte_test_add_sourcefile_cpp(GEN_E_D_FF_ANY_1_tester.cpp)
+forte_test_add_sourcefile_cpp(GEN_E_D_FF_ANY_3_tester.cpp)
 
 

--- a/tests/stdfblib/events/GEN_E_D_FF_ANY_1_tester.cpp
+++ b/tests/stdfblib/events/GEN_E_D_FF_ANY_1_tester.cpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include "../../core/fbtests/fbtestfixture.h"
+#include "forte/datatypes/forte_any_variant.h"
+#include "forte/datatypes/forte_bool.h"
+
+using namespace forte::literals;
+
+namespace forte::iec61499::events::test {
+  struct GEN_E_D_FF_ANY_1_TestFixture : public forte::test::CFBTestFixtureBase {
+      CIEC_ANY_VARIANT mD1;
+      CIEC_ANY_VARIANT mQ1;
+
+      GEN_E_D_FF_ANY_1_TestFixture() : CFBTestFixtureBase("iec61499::events::E_D_FF_ANY_1"_STRID) {
+        setInputData({&mD1});
+        setOutputData({&mQ1});
+        setup();
+      }
+
+      static constexpr TEventID CLK = 0;
+      static constexpr TEventID EO = 0;
+  };
+
+  BOOST_FIXTURE_TEST_SUITE(GenEDFfAny1Tests, GEN_E_D_FF_ANY_1_TestFixture)
+
+  BOOST_AUTO_TEST_CASE(NoChangeDoesNotFire) {
+    triggerEvent(CLK); // D1 still at its reset default, same as latched Q1
+    BOOST_CHECK(eventChainEmpty());
+  }
+
+  BOOST_AUTO_TEST_CASE(InitialClockLatches) {
+    mD1 = true_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    BOOST_CHECK(mQ1.equals(true_BOOL));
+  }
+
+  BOOST_AUTO_TEST_CASE(UnchangedClockDoesNotFireAgain) {
+    mD1 = true_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+
+    triggerEvent(CLK); // D1 unchanged
+    BOOST_CHECK(eventChainEmpty());
+  }
+
+  BOOST_AUTO_TEST_CASE(ChangeFiresAgain) {
+    mD1 = true_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+
+    mD1 = false_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    BOOST_CHECK(mQ1.equals(false_BOOL));
+  }
+
+  BOOST_AUTO_TEST_SUITE_END()
+} // namespace forte::iec61499::events::test

--- a/tests/stdfblib/events/GEN_E_D_FF_ANY_3_tester.cpp
+++ b/tests/stdfblib/events/GEN_E_D_FF_ANY_3_tester.cpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2026 HR Agartechnik GmbH
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Franz Höpfinger
+ *     - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+#include "../../core/fbtests/fbtestfixture.h"
+#include "forte/datatypes/forte_any_variant.h"
+#include "forte/datatypes/forte_bool.h"
+#include "forte/datatypes/forte_uint.h"
+
+using namespace forte::literals;
+
+namespace forte::iec61499::events::test {
+  struct GEN_E_D_FF_ANY_3_TestFixture : public forte::test::CFBTestFixtureBase {
+      CIEC_ANY_VARIANT mD1;
+      CIEC_ANY_VARIANT mD2;
+      CIEC_ANY_VARIANT mD3;
+      CIEC_ANY_VARIANT mQ1;
+      CIEC_ANY_VARIANT mQ2;
+      CIEC_ANY_VARIANT mQ3;
+
+      GEN_E_D_FF_ANY_3_TestFixture() : CFBTestFixtureBase("iec61499::events::E_D_FF_ANY_3"_STRID) {
+        setInputData({&mD1, &mD2, &mD3});
+        setOutputData({&mQ1, &mQ2, &mQ3});
+        setup();
+      }
+
+      static constexpr TEventID CLK = 0;
+      static constexpr TEventID EO = 0;
+  };
+
+  BOOST_FIXTURE_TEST_SUITE(GenEDFfAny3Tests, GEN_E_D_FF_ANY_3_TestFixture)
+
+  BOOST_AUTO_TEST_CASE(NoChangeDoesNotFire) {
+    triggerEvent(CLK); // all Di still at their reset default, same as latched Qi
+    BOOST_CHECK(eventChainEmpty());
+  }
+
+  BOOST_AUTO_TEST_CASE(HeterogeneousChannelsLatchIndependently) {
+    // channels may carry different ANY-compatible types simultaneously
+    mD1 = true_BOOL;
+    mD2 = 0_UINT;
+    mD3 = false_BOOL;
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    BOOST_CHECK(mQ1.equals(true_BOOL));
+    BOOST_CHECK(mQ2.equals(0_UINT));
+    BOOST_CHECK(mQ3.equals(false_BOOL));
+
+    triggerEvent(CLK); // no change
+    BOOST_CHECK(eventChainEmpty());
+
+    mD2 = 42_UINT; // only D2 changes now
+    triggerEvent(CLK);
+    BOOST_CHECK(checkForSingleOutputEventOccurence(EO));
+    BOOST_CHECK(mQ1.equals(true_BOOL));
+    BOOST_CHECK(mQ2.equals(42_UINT));
+    BOOST_CHECK(mQ3.equals(false_BOOL));
+  }
+
+  BOOST_AUTO_TEST_SUITE_END()
+} // namespace forte::iec61499::events::test


### PR DESCRIPTION
Implements the generic function block GEN_E_D_FF_ANY for handling data latches over multiple parallel ANY channels, as part of the IEC 61499 standard. This enhancement supports dynamic instances based on specified channel counts, allowing flexibility in input and output configuration.

Includes unit tests to validate behavior under different configurations, ensuring functionality across a range of scenarios.

Addresses commit objectives focusing on generic function block addition and input validation improvements.

- https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-forte/pull/40
- https://github.com/eclipse-4diac/4diac-ide/pull/2781