### PR TITLE
fix(opc_ua): fix UA_ServerConfig aggregate-init clobbering context

### DIFF
--- a/com/opc_ua/src/opcua_local_handler.cpp
+++ b/com/opc_ua/src/opcua_local_handler.cpp
@@ -99,7 +99,7 @@ namespace forte::com_infra::opc_ua {
     DEVLOG_INFO("[OPC UA LOCAL]: Starting OPC UA Server: opc.tcp://localhost:%d\n", gOpcuaServerPort.mArgument);
 
     UA_ServerConfig config{
-        config.logging = &getLogger(),
+        .logging = &getLogger(),
     };
 
     // set default config


### PR DESCRIPTION
UA_ServerConfig config{ config.logging = &getLogger() } is not a
designated initializer (missing the leading dot): it evaluates the
assignment expression config.logging = &getLogger() and uses its
result as the positional initializer for UA_ServerConfig's first
member, which is context, not logging. The assignment itself does set
config.logging correctly as a side effect, but config.context -- which
should stay null -- ends up aliased to the logger pointer instead.

Use a proper designated initializer for .logging so context is left at
its zero-initialized default, as intended.
