### PR TITLE
Fix CommandParser::parseIdentifier() dropping a Connection Source's trailing empty port name

### DIFF
--- a/core/include/forte/mgmcmd.h
+++ b/core/include/forte/mgmcmd.h
@@ -58,7 +58,9 @@ namespace forte {
      *
      * When creating a connection the parameters of the SManagementCMD are defined as:
      *    - mDestination = "" for creating within the device or "resname" for creating within a resource
-     *    - mFistParam = source of the connection given by: "fbname.output"
+     *    - mFistParam = source of the connection given by: "fbname.output". The output may be
+     *      empty ("fbname."), which addresses an IEC 61131-3 Function's unnamed return-value
+     *      output port.
      *    - mSecondParam = destination of the connection given by: "fbname.intput"
      *    - mAdditionalParams not used
      */
@@ -82,7 +84,9 @@ namespace forte {
      *
      * When deleting a connection the parameters of the SManagementCMD are defined as:
      *    - mDestination = "" for deleting within the device or "resname" for deleting within a resource
-     *    - mFistParam = source of the connection given by: "fbname.output"
+     *    - mFistParam = source of the connection given by: "fbname.output". The output may be
+     *      empty ("fbname."), which addresses an IEC 61131-3 Function's unnamed return-value
+     *      output port.
      *    - mSecondParam = destination of the connection given by: "fbname.intput"
      *    - mAdditionalParams not used
      */

--- a/stdfblib/system/src/CommandParser.cpp
+++ b/stdfblib/system/src/CommandParser.cpp
@@ -9,6 +9,8 @@
  * Contributors:
  *   Jose Cabral
  *    - initial API and implementation and/or initial documentation
+ *   Franz Höpfinger
+ *    - fix parseIdentifier() dropping a trailing empty name segment
  *******************************************************************************/
 
 #include "CommandParser.h"
@@ -272,7 +274,9 @@ namespace forte::iec61499::system {
     return EMGMResponse::Ready;
   }
 
-  EMGMResponse CommandParser::parseIdentifier(std::string_view paIdentifierString, TNameIdentifier &paIdentifier) {
+  EMGMResponse CommandParser::parseIdentifier(std::string_view paIdentifierString,
+                                              TNameIdentifier &paIdentifier,
+                                              bool paAllowEmptyLastSegment) {
     while (!paIdentifierString.empty()) {
       auto pos = paIdentifierString.find('.');
       if (pos == std::string_view::npos) {
@@ -288,6 +292,18 @@ namespace forte::iec61499::system {
         return EMGMResponse::Overflow;
       }
       paIdentifierString = paIdentifierString.substr(pos + 1);
+      if (paIdentifierString.empty()) {
+        // Trailing '.': the final segment is the empty string. Only valid where explicitly
+        // allowed (a Connection's Source -- see the parameter doc in the header); an FB
+        // instance name or a Connection's Destination must always have a real final segment.
+        if (!paAllowEmptyLastSegment) {
+          return EMGMResponse::BadParams;
+        }
+        if (!paIdentifier.try_push_back(StringId::insert(std::string_view{}))) {
+          return EMGMResponse::Overflow;
+        }
+        return EMGMResponse::Ready;
+      }
     }
     return EMGMResponse::BadParams;
   }
@@ -322,7 +338,7 @@ namespace forte::iec61499::system {
       return EMGMResponse::BadParams;
     }
     if (source != "*") {
-      EMGMResponse resp = parseIdentifier(source, mCommand.mFirstParam);
+      EMGMResponse resp = parseIdentifier(source, mCommand.mFirstParam, true);
       if (resp != EMGMResponse::Ready) {
         return resp;
       }

--- a/stdfblib/system/src/CommandParser.h
+++ b/stdfblib/system/src/CommandParser.h
@@ -103,9 +103,16 @@ namespace forte::iec61499::system {
        *
        * @param paIdentifierString string value of the identifier
        * @param paIdentifier identifier vector where to write the parsed identifiers to
+       * @param paAllowEmptyLastSegment allow the final segment (after the last '.') to be empty,
+       *        for identifiers whose last segment names a port rather than an FB instance -- IEC
+       *        61131-3 Functions use the empty string as the name of their return-value output
+       *        port, so a Connection's Source can legitimately end in '.'. Not allowed by default,
+       *        since e.g. an FB instance name or a Connection's Destination must never be empty.
        * @return EMGMResponse::Ready if all segments could be parsed and added to the name identifier
        */
-      EMGMResponse parseIdentifier(std::string_view paIdentifierString, TNameIdentifier &paIdentifier);
+      EMGMResponse parseIdentifier(std::string_view paIdentifierString,
+                                   TNameIdentifier &paIdentifier,
+                                   bool paAllowEmptyLastSegment = false);
 
       /*! \brief Parse the name of the type
        *

--- a/tests/stdfblib/system/commandparser_test.cpp
+++ b/tests/stdfblib/system/commandparser_test.cpp
@@ -198,14 +198,19 @@ namespace forte::iec61499::system::test {
     BOOST_TEST(response == EMGMResponse::BadParams);
   }
 
-  BOOST_AUTO_TEST_CASE(createConnectionDotAtEndOfSource) {
+  // A Connection's Source ending in '.' means the final segment (the port name) is itself the
+  // empty string. That's valid: IEC 61131-3 Functions use the empty string as the name of their
+  // return-value output port, so a Connection sourced from e.g. an ASSEMBLE_BYTE_FROM_BOOLS
+  // instance's return value looks exactly like this on the wire.
+  BOOST_AUTO_TEST_CASE(createConnectionSourceEndsWithEmptyPortName) {
     SManagementCMD cmd;
     CommandParser parser(cmd);
 
     auto response = parser.parseMGMCommand(
-        "", R"(<Request ID="1" Action="CREATE"><Connection Source="Test." Destination="Trigger.DT" />)");
+        "", R"(<Request ID="1" Action="CREATE"><Connection Source="Test." Destination="Trigger.DT" /></Request>)");
 
-    BOOST_TEST(response == EMGMResponse::BadParams);
+    BOOST_TEST(response == EMGMResponse::Ready);
+    BOOST_TEST(nameIdentifierEquals(cmd.mFirstParam, {"Test", ""}));
   }
 
   BOOST_AUTO_TEST_CASE(createConnectionDoubleDotInDestination) {
@@ -259,6 +264,17 @@ namespace forte::iec61499::system::test {
 
     auto response =
         parser.parseMGMCommand("", R"(<Request ID="9" Action="CREATE"><Watch Source="" Destination="*" /></Request>)");
+
+    BOOST_TEST(response == EMGMResponse::BadParams);
+  }
+
+  // Unlike a Connection's Source, a Watch's Destination must always have a real final segment.
+  BOOST_AUTO_TEST_CASE(createWatchDotAtEndOfDestination) {
+    SManagementCMD cmd;
+    CommandParser parser(cmd);
+
+    auto response = parser.parseMGMCommand(
+        "", R"(<Request ID="9" Action="CREATE"><Watch Source="FF.Q" Destination="Switch.G." /></Request>)");
 
     BOOST_TEST(response == EMGMResponse::BadParams);
   }
@@ -375,6 +391,17 @@ namespace forte::iec61499::system::test {
     BOOST_TEST(response == EMGMResponse::BadParams);
   }
 
+  // Symmetric with createFBDotAtEnd: an FB instance name must always have a real final segment.
+  BOOST_AUTO_TEST_CASE(deleteFBDotAtEnd) {
+    SManagementCMD cmd;
+    CommandParser parser(cmd);
+
+    auto response =
+        parser.parseMGMCommand("", R"(<Request ID="1" Action="DELETE"><FB Name="Trigger." Type="" /></Request>)");
+
+    BOOST_TEST(response == EMGMResponse::BadParams);
+  }
+
   BOOST_AUTO_TEST_CASE(deleteConnection) {
     SManagementCMD cmd;
     CommandParser parser(cmd);
@@ -404,6 +431,31 @@ namespace forte::iec61499::system::test {
 
     auto response = parser.parseMGMCommand(
         "", R"(<Request ID="1" Action="DELETE"><Connection Source="T#500ms" Destination="" /></Request>)");
+
+    BOOST_TEST(response == EMGMResponse::BadParams);
+  }
+
+  // Symmetric with createConnectionSourceEndsWithEmptyPortName: deleting a Connection sourced
+  // from an IEC 61131-3 Function's (unnamed) return-value output must work the same way.
+  BOOST_AUTO_TEST_CASE(deleteConnectionSourceEndsWithEmptyPortName) {
+    SManagementCMD cmd;
+    CommandParser parser(cmd);
+
+    auto response = parser.parseMGMCommand(
+        "", R"(<Request ID="1" Action="DELETE"><Connection Source="Test." Destination="Trigger.DT" /></Request>)");
+
+    BOOST_TEST(response == EMGMResponse::Ready);
+    BOOST_TEST(nameIdentifierEquals(cmd.mFirstParam, {"Test", ""}));
+  }
+
+  // Symmetric with createConnectionDotAtEndOfDestination: a Connection's Destination must always
+  // have a real final segment, for DELETE as well as CREATE.
+  BOOST_AUTO_TEST_CASE(deleteConnectionDotAtEndOfDestination) {
+    SManagementCMD cmd;
+    CommandParser parser(cmd);
+
+    auto response = parser.parseMGMCommand(
+        "", R"(<Request ID="1" Action="DELETE"><Connection Source="Test.EO" Destination="Trigger.DT." />)");
 
     BOOST_TEST(response == EMGMResponse::BadParams);
   }
@@ -438,6 +490,17 @@ namespace forte::iec61499::system::test {
 
     auto response =
         parser.parseMGMCommand("", R"(<Request ID="1" Action="DELETE"><Watch Source="" Destination="*" /></Request>)");
+
+    BOOST_TEST(response == EMGMResponse::BadParams);
+  }
+
+  // Symmetric with createWatchDotAtEndOfDestination.
+  BOOST_AUTO_TEST_CASE(deleteWatchDotAtEndOfDestination) {
+    SManagementCMD cmd;
+    CommandParser parser(cmd);
+
+    auto response = parser.parseMGMCommand(
+        "", R"(<Request ID="1" Action="DELETE"><Watch Source="FF.Q" Destination="Switch.G." /></Request>)");
 
     BOOST_TEST(response == EMGMResponse::BadParams);
   }
@@ -620,6 +683,18 @@ namespace forte::iec61499::system::test {
 
     auto response = parser.parseMGMCommand(
         "", R"(<Request ID="1" Action="WRITE"><Connection Source="42" Destination="" /></Request>)");
+
+    BOOST_TEST(response == EMGMResponse::BadParams);
+  }
+
+  // Unlike a Connection's Source in CREATE/DELETE, a WRITE's Destination must always have a real
+  // final segment -- it identifies the port being written to, not a Function's return value.
+  BOOST_AUTO_TEST_CASE(writeDestinationDotAtEndIsBadParams) {
+    SManagementCMD cmd;
+    CommandParser parser(cmd);
+
+    auto response = parser.parseMGMCommand(
+        "", R"(<Request ID="1" Action="WRITE"><Connection Source="42" Destination="Trigger.DT." /></Request>)");
 
     BOOST_TEST(response == EMGMResponse::BadParams);
   }


### PR DESCRIPTION
A Connection's Source ending in '.' means its final segment (the port
name) is itself the empty string. That's valid: IEC 61131-3 Functions
use the empty string as the name of their return-value output port
(e.g. ASSEMBLE_BYTE_FROM_BOOLS), so a Connection sourced from such an
instance's return value legitimately looks like
"App.functions.RotaCut.ASSEMBLE_BYTE_FROM_BOOLS." on the wire.

parseIdentifier()'s loop tested "while (!paIdentifierString.empty())"
*before* checking for a final dot-less segment, so consuming the
trailing '.' left an empty string that exited the loop before that
last (empty) segment was ever pushed, falling through to a bare
"return BadParams". Observed on real hardware as "Boot file error.
DEV_MGR says error is BAD_PARAMS" for a CREATE Connection whose source
ends at such a pin.

Adds an opt-in paAllowEmptyLastSegment parameter (default false, so
FB instance names and Connection Destinations -- which must always
have a real final segment -- keep their existing behavior unchanged)
and passes true only for a Connection's Source in
parseConnectionContent, which is shared by both CREATE and DELETE.

Updates the existing createConnectionDotAtEndOfSource unit test
(renamed createConnectionSourceEndsWithEmptyPortName) to reflect the
corrected behavior, and adds a symmetric
deleteConnectionSourceEndsWithEmptyPortName test. createFBDotAtEnd and
createConnectionDotAtEndOfDestination are intentionally unchanged.

Also adds negative tests covering every other place parseIdentifier()
is used with a trailing '.', confirming it is still rejected as
BadParams there: DELETE's FB Name and Connection Destination, Watch
Destination (CREATE and DELETE, which share parseConnectionContent),
and WRITE's Destination.

Verified: full forte_test suite passes (posix_ws build,
FORTE_COM_OPC_UA=OFF).

Reference:

- https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-forte/pull/44