### PR TITLE
Fix CommandParser::appendIdentifierName() emitting a duplicated final segment

### DIFF
--- a/stdfblib/system/src/CommandParser.cpp
+++ b/stdfblib/system/src/CommandParser.cpp
@@ -10,6 +10,8 @@
  *   Jose Cabral
  *    - initial API and implementation and/or initial documentation
  *   Franz Höpfinger
+ *    - fix appendIdentifierName() emitting a duplicated/extra final segment
+ *   Franz Höpfinger
  *    - fix parseIdentifier() dropping a trailing empty name segment
  *******************************************************************************/
 
@@ -628,12 +630,15 @@ namespace forte::iec61499::system {
   }
 
   void CommandParser::appendIdentifierName(CIEC_STRING &paDest, TNameIdentifier &paIdentifier) {
-    if (!paIdentifier.empty()) {
-      for (const auto &runner : paIdentifier) {
-        paDest.append(runner.data());
-        paDest.append(".");
-      }
-      paDest.append(paIdentifier.back().data());
+    auto it = paIdentifier.begin();
+    if (it == paIdentifier.end()) {
+      return;
+    }
+
+    paDest.append(it->data());
+    for (++it; it != paIdentifier.end(); ++it) {
+      paDest.append(".");
+      paDest.append(it->data());
     }
   }
 

--- a/tests/stdfblib/system/commandparser_test.cpp
+++ b/tests/stdfblib/system/commandparser_test.cpp
@@ -811,6 +811,25 @@ namespace forte::iec61499::system::test {
     BOOST_TEST(response == EMGMResponse::BadParams);
   }
 
+  // Regression test: appendIdentifierName() appended a separator after every segment (including
+  // the last) and then appended the last segment a second time, duplicating it in READ responses
+  // (e.g. "SubApp1.Trigger.DT" became "SubApp1.Trigger.DT.DT").
+  BOOST_AUTO_TEST_CASE(readConnectionResponseDoesNotDuplicateLastSourceSegment) {
+    SManagementCMD cmd;
+    CommandParser parser(cmd);
+
+    auto response = parser.parseMGMCommand(
+        "", R"(<Request ID="1" Action="READ"><Connection Source="SubApp1.Trigger.DT" Destination="*" /></Request>)");
+
+    // Simulate the device manager having filled in the read value before the response is generated.
+    cmd.mAdditionalParams = "TRUE";
+    CIEC_STRING responseText;
+    parser.generateResponse(responseText, response);
+
+    BOOST_TEST(static_cast<std::string>(responseText) ==
+               "<Response ID=\"1\">\n  <Connection Source=\"SubApp1.Trigger.DT\" Destination=\"TRUE\" />\n</Response>");
+  }
+
   BOOST_AUTO_TEST_CASE(readWatches) {
     SManagementCMD cmd;
     CommandParser parser(cmd);


### PR DESCRIPTION
Split off from #1026 per review feedback (the fix isn't needed for the
BAD_PARAMS bug that PR addresses).

appendIdentifierName() appended a separator after every segment,
including the last, then appended the last segment a second time. For
an ordinary hierarchical name this duplicated the final segment in
generated READ responses, e.g. Source="SubApp1.Trigger.DT" was echoed
back as "SubApp1.Trigger.DT.DT".

Join segments with a separator only between them instead.

Verified: full forte_test suite passes (posix_ws build,
FORTE_COM_OPC_UA=OFF).

Reference: 

- https://github.com/Meisterschulen-am-Ostbahnhof-Munchen/4diac-forte/pull/48
